### PR TITLE
chore: bump aws-actions/amazon-ecr-login from 1 to 2

### DIFF
--- a/actions/cicd-build-publish-artifacts-go/action.yml
+++ b/actions/cicd-build-publish-artifacts-go/action.yml
@@ -184,7 +184,7 @@ runs:
 
     - name: Login to aws ecr
       if: inputs.publish == 'true' && inputs.docker-registry == 'aws'
-      uses: aws-actions/amazon-ecr-login@5a88a04c91d5c6f97aae0d9be790e64d9b1d47b7 # v1.7.1
+      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
       with:
         registries: ${{ steps.process-params.outputs.aws-account-number }}
 

--- a/actions/setup-gap/action.yml
+++ b/actions/setup-gap/action.yml
@@ -78,7 +78,7 @@ runs:
 
     - name: Login to aws ecr
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@5a88a04c91d5c6f97aae0d9be790e64d9b1d47b7 # v1.7.1
+      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
       env:
         AWS_REGION: us-east-1
       with:


### PR DESCRIPTION
Updating `aws-actions/amazon-ecr-login` references in this repository's workflows. Updating to v2 updates the default runner to `node20`.
- `v1.7.1` -> `v2.0.1`

---

[RE-1955](https://smartcontract-it.atlassian.net/browse/RE-1955)