### PR TITLE
Add ability to manually invoke renovate bot

### DIFF
--- a/.github/workflows/schedule-renovate.yml
+++ b/.github/workflows/schedule-renovate.yml
@@ -1,6 +1,7 @@
 name: schedule-renovate
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
 


### PR DESCRIPTION
Renovate bot is currently setup to run once per day. If we want to maintain a process of using renovate bot for most updates, we should be able to manually trigger it when we are hoping to:
1. Update a large number of dependencies within a day
		* Don't have to wait multiple days to update all dependencies, as the max appears to be 4 per invoc. 
2. Manually trigger an update for a recently updated transitive dependency.
		* Don't have to wait for renovate bot schedule to have it update a dependency.

