### PR TITLE
feat: ci-publish-npm action

### DIFF
--- a/.changeset/friendly-pans-pretend.md
+++ b/.changeset/friendly-pans-pretend.md
@@ -1,0 +1,5 @@
+---
+"ci-publish-npm": minor
+---
+
+Create ci-publish-npm action

--- a/actions/ci-publish-npm/README.md
+++ b/actions/ci-publish-npm/README.md
@@ -1,0 +1,23 @@
+# ci-publish-npm
+
+This action publishes things to NPM.
+
+## Usage
+
+### Setup
+
+1. Declare a publish script inside your `package.json` ([example](https://github.com/smartcontractkit/chainlink/blob/b8199c52e22c0c1a875713e0d01df21466a91567/contracts/package.json#L19-L20))
+2. Ensure the `NPM_TOKEN` exists and is accessible by the calling workflow
+
+### Running
+
+Ensure all testing is complete, and `pnpm` is setup prior to calling this action.
+
+#### Inputs
+
+1. `publish-command` - The actual publish script to run, as defined in your `package.json`. The action will run `pnpm <publish command>`.
+2. `package-json-directory` - The sub directory of the `package.json` if not at the root of the repository.
+3. `npm-token` - The NPM access token with permissions to publish to the repository.
+4. `create-github-release` - Whether to create a Github release.
+5. `github-release-tag-name` - The release's tag name
+6. `github-token` - The `GITHUB_TOKEN` issued for the workflow. Used when creating Github releases.

--- a/actions/ci-publish-npm/README.md
+++ b/actions/ci-publish-npm/README.md
@@ -20,4 +20,4 @@ Ensure all testing is complete, and `pnpm` is setup prior to calling this action
 3. `npm-token` - The NPM access token with permissions to publish to the repository.
 4. `create-github-release` - Whether to create a Github release.
 5. `github-release-tag-name` - The release's tag name
-6. `github-token` - The `GITHUB_TOKEN` issued for the workflow. Used when creating Github releases.
+6. `github-token` - The `GITHUB_TOKEN` issued for the workflow. Only required when creating Github releases. Requires `contents: write` permissions.

--- a/actions/ci-publish-npm/README.md
+++ b/actions/ci-publish-npm/README.md
@@ -1,6 +1,6 @@
 # ci-publish-npm
 
-This action publishes things to NPM.
+This action sets up the `.npmrc` file, and runs a command to publish something to NPM.
 
 ## Usage
 
@@ -15,9 +15,9 @@ Ensure all testing is complete, and `pnpm` is setup prior to calling this action
 
 #### Inputs
 
-1. `publish-command` - The actual publish script to run, as defined in your `package.json`. The action will run `pnpm <publish command>`.
-2. `package-json-directory` - The sub directory of the `package.json` if not at the root of the repository.
+1. `publish-command` - The command which will be run to publish.
+2. `package-json-directory` - The sub directory of the `package.json`. Supply if the publish command executes a script declared within the `package.json`, is not located at the root of the repository.
 3. `npm-token` - The NPM access token with permissions to publish to the repository.
 4. `create-github-release` - Whether to create a Github release.
 5. `github-release-tag-name` - The release's tag name
-6. `github-token` - The `GITHUB_TOKEN` issued for the workflow. Only required when creating Github releases. Requires `contents: write` permissions.
+6. `github-token` - The `GITHUB_TOKEN` issued for the workflow. Supply when creating Github releases. Requires `contents: write` permissions"

--- a/actions/ci-publish-npm/README.md
+++ b/actions/ci-publish-npm/README.md
@@ -1,13 +1,12 @@
 # ci-publish-npm
 
-This action sets up the `.npmrc` file, and runs a command to publish something to NPM.
+This action optionally creates a Github release, sets up the `.npmrc` file, and then runs a command to publish something to NPM.
 
 ## Usage
 
 ### Setup
 
-1. Declare a publish script inside your `package.json` ([example](https://github.com/smartcontractkit/chainlink/blob/b8199c52e22c0c1a875713e0d01df21466a91567/contracts/package.json#L19-L20))
-2. Ensure the `NPM_TOKEN` exists and is accessible by the calling workflow
+Obtain an NPM token scoped to your npm package with the necessary permissions.
 
 ### Running
 
@@ -16,7 +15,7 @@ Ensure all testing is complete, and `pnpm` is setup prior to calling this action
 #### Inputs
 
 1. `publish-command` - The command which will be run to publish.
-2. `package-json-directory` - The sub directory of the `package.json`. Supply if the publish command executes a script declared within the `package.json`, is not located at the root of the repository.
+2. `package-json-directory` - The sub directory of the `package.json`. Supply if the publish command executes a script declared within the `package.json` and is not located at the root of the repository.
 3. `npm-token` - The NPM access token with permissions to publish to the repository.
 4. `create-github-release` - Whether to create a Github release.
 5. `github-release-tag-name` - The release's tag name

--- a/actions/ci-publish-npm/action.yml
+++ b/actions/ci-publish-npm/action.yml
@@ -2,18 +2,18 @@ name: ci-publish-npm
 description: Publishes to NPM
 
 inputs:
+  publish-command:
+    description: "The command which will be run to publish."
+    required: true
   package-json-directory:
-    description: "The sub directory of the package.json if not at the root of the repository."
+    description: "The sub directory of the `package.json`. Supply if the publish command executes a script declared within the `package.json`, is not located at the root of the repository."
     required: false
     default: '.'
-  publish-command:
-    description: "The package.json defined script used to publish. Will run as `pnpm <publish-command>`"
-    required: true
   npm-token:
     description: The NPM token with publish access
     required: true
   github-token:
-    description: "The `GITHUB_TOKEN` issued for the workflow. Only required when creating Github releases. Requires `contents: write` permissions"
+    description: "The `GITHUB_TOKEN` issued for the workflow. Supply when creating Github releases. Requires `contents: write` permissions"
     required: false
     default: ${{ github.token }}
   create-github-release:
@@ -47,4 +47,4 @@ runs:
     - name: Publish to NPM
       shell: bash
       working-directory: ${{ inputs.package-json-directory }}
-      run: pnpm ${{ inputs.publish-command }}
+      run: ${{ inputs.publish-command }}

--- a/actions/ci-publish-npm/action.yml
+++ b/actions/ci-publish-npm/action.yml
@@ -1,0 +1,50 @@
+name: ci-publish-npm
+description: Publishes to NPM
+
+inputs:
+  package-json-directory:
+    description: "The sub directory of the package.json if not at the root of the repository."
+    required: false
+    default: '.'
+  publish-command:
+    description: "The package.json defined script used to publish. Will run as `pnpm <publish-command>`"
+    required: true
+  npm-token:
+    description: The NPM token with publish access
+    required: true
+  github-token:
+    description: The GITHUB_TOKEN for the workflow
+    required: false
+    default: ${{ github.token }}
+  create-github-release:
+    description: "Whether or not to create a GitHub release"
+    required: false
+    default: false
+  github-release-tag-name:
+    description: "The name of the GitHub release. Defaults to the current branch name"
+    required: false
+    default: ${{ github.ref_name }}
+
+runs:
+  using: composite
+  steps:
+    - name: Create GitHub Release
+      if: inputs.create-github-release == 'true'
+      # TODO: Use something that can sign the release
+      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
+      with:
+        tag_name: ${{ inputs.github-release-tag-name }}
+        token: ${{ inputs.github-token }}
+
+    - name: Configure npmrc
+      shell: bash
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.npm-token }}
+      run: |
+        echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> ~/.npmrc
+        echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
+
+    - name: Publish to NPM
+      shell: bash
+      working-directory: ${{ inputs.package-json-directory }}
+      run: pnpm ${{ inputs.publish-command }}

--- a/actions/ci-publish-npm/action.yml
+++ b/actions/ci-publish-npm/action.yml
@@ -13,11 +13,11 @@ inputs:
     description: The NPM token with publish access
     required: true
   github-token:
-    description: The GITHUB_TOKEN for the workflow
+    description: "The `GITHUB_TOKEN` issued for the workflow. Only required when creating Github releases. Requires `contents: write` permissions"
     required: false
     default: ${{ github.token }}
   create-github-release:
-    description: "Whether or not to create a GitHub release"
+    description: "Whether or not to create a GitHub release."
     required: false
     default: false
   github-release-tag-name:

--- a/actions/ci-publish-npm/package.json
+++ b/actions/ci-publish-npm/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ci-publish-npm",
+  "version": "0.1.0",
+  "description": "",
+  "private": true,
+  "scripts": {},
+  "author": "@erikburt",
+  "license": "MIT",
+  "dependencies": {},
+  "repository": "https://github.com/smartcontractkit/.github"
+}

--- a/actions/ci-publish-npm/project.json
+++ b/actions/ci-publish-npm/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "ci-publish-npm",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "actions/ci-publish-npm",
+  "targets": {}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,8 @@ importers:
 
   actions/ci-lint-ts: {}
 
+  actions/ci-publish-npm: {}
+
   actions/ci-sonarqube: {}
 
   actions/ci-test-go: {}


### PR DESCRIPTION
As part of [RE-2033](https://smartcontract-it.atlassian.net/browse/RE-2033) - create a reusable npm publishing action based off [smartcontractkit/ccip/.github/workflows/solidity](https://github.com/smartcontractkit/ccip/blob/7d332c917a190a5ef89e279213f72968efc4fe32/.github/workflows/solidity.yml#L162-L221).

Will be used initially in https://github.com/smartcontractkit/chainlink-contracts-deprecated/pull/2

Testing:
- https://github.com/smartcontractkit/chainlink-contracts-deprecated/actions/runs/7147133338/job/19466124711

<details>
  <summary><i>Test run output</i></summary>

```
Run smartcontractkit/.github/actions/ci-publish-npm@feat/ci-publish-npm
Run echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> ~/.npmrc
Run pnpm publish-test --publish-branch 'feat/publishing-follow-up' --no-git-checks
> @chainlink/contracts-deprecated@0.1.0 publish-test /home/runner/work/chainlink-contracts-deprecated/chainlink-contracts-deprecated/contracts
> ./scripts/echo-test.sh "--publish-branch" "feat/publishing-follow-up" "--no-git-checks"
--publish-branch
feat/publishing-follow-up
--no-git-checks

Run smartcontractkit/.github/actions/ci-publish-npm@feat/ci-publish-npm
Run echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> ~/.npmrc
Run ./contracts/scripts/echo-test.sh --publish-branch 'feat/publishing-follow-up' --no-git-checks
--publish-branch
feat/publishing-follow-up
--no-git-checks

Run cat  ~/.npmrc
//registry.npmjs.org/:_authToken=fake-test-token
registry=https://registry.npmjs.org/
//registry.npmjs.org/:_authToken=fake-test-token
registry=https://registry.npmjs.org/
```
</details>

