### PR TITLE
feat: sub-directory input for setup-nodejs action

### DIFF
--- a/.changeset/sour-needles-occur.md
+++ b/.changeset/sour-needles-occur.md
@@ -1,0 +1,5 @@
+---
+"setup-nodejs": minor
+---
+
+Add sub-directory input for package.json files located outside of root directory

--- a/actions/setup-nodejs/action.yml
+++ b/actions/setup-nodejs/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: Run npm/yarn/pnpm install
     required: true
     default: 'true'
+  package-json-directory:
+    description: The sub-directory of the package.json, if not at the root of the repository
+    required: false
+    default: '.'
 
 runs:
   using: composite
@@ -52,4 +56,5 @@ runs:
     - name: Run package manager install
       if: inputs.run-install == 'true'
       shell: bash
+      working-directory: ${{ inputs.package-json-directory }}
       run: pnpm install


### PR DESCRIPTION
Needed for [RE-2033](https://smartcontract-it.atlassian.net/browse/RE-2033), https://github.com/smartcontractkit/.github/pull/60, https://github.com/smartcontractkit/chainlink-contracts-deprecated/pull/2.

Even with a `cd` before calling this action, the `package.json` cannot be found if it's not in the package root.

Tested with:
- PR: https://github.com/smartcontractkit/chainlink-contracts-deprecated/pull/2/files
- Action: https://github.com/smartcontractkit/chainlink-contracts-deprecated/actions/runs/7093362113/job/19306593998#step:3:3
