### PR TITLE
partial rollout - cicd-changesets using signed-commits

### DIFF
--- a/.changeset/soft-radios-breathe.md
+++ b/.changeset/soft-radios-breathe.md
@@ -1,0 +1,5 @@
+---
+"cicd-changesets": minor
+---
+
+Use signed-commits action, drop-in replacement for changesets/action

--- a/actions/cicd-changesets/action.yml
+++ b/actions/cicd-changesets/action.yml
@@ -79,7 +79,7 @@ outputs:
     value: ${{ steps.changesets.outputs.hasChangesets }}
   pullRequestNumber:
     description: The pull request number that was created or updated
-    value: ${{ steps.changesets.outputs.pullRequestNumber }}  
+    value: ${{ steps.changesets.outputs.pullRequestNumber }}
 
 runs:
   using: composite
@@ -119,7 +119,7 @@ runs:
 
     - name: Run changesets
       id: changesets
-      uses: changesets/action@f13b1baaa620fde937751f5d2c3572b9da32af23 # v1.4.5
+      uses: smartcontractkit/.github/actions/signed-commits@main
       env:
         GITHUB_TOKEN: ${{ steps.get-gh-token.outputs.access-token }}
       with:


### PR DESCRIPTION
## This PR branch should not be deleted until repos that reference this branch are updated to reference main

Switching from https://github.com/changesets/action/ to `signed-commits` introduced in #64.

This PR branch will be used as a partial roll-out, applying this change to repositories.

Partial roll-outs so far:
- https://github.com/smartcontractkit/github-app-token-issuer/commit/e5d9e5ef0001147dbbdf4edeada98dfa123f0b49
    - Undo: https://github.com/smartcontractkit/github-app-token-issuer/pull/66
- [smartcontractkit/.github@`16d8dab`](https://github.com/smartcontractkit/.github/commit/16d8dab56873e35e50eeb33ed988df09c7cbbb6c)
    - Undo: #122
- https://github.com/smartcontractkit/mercury-pipeline/commit/e4a38d4b7794598f80ba17d6d5ba737029c14d09
    - Undo: https://github.com/smartcontractkit/mercury-pipeline/pull/683
- https://github.com/smartcontractkit/gauntlet-evm/commit/b3c651a1f7d8b12c13e0686c245cbb955da6a9a0
    - Undo: https://github.com/smartcontractkit/gauntlet-evm/pull/572
