### PR TITLE
feat: partial roll-out for cicd-changesets w/ signed commits

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -70,13 +70,16 @@ jobs:
       contents: read
       actions: read
     steps:
-      - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          fetch-depth: 0
+      # Partial roll-out of cicd-changesets-signed-commits
+
+      # - name: Checkout repo (needed to reference local action)
+      #   uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      #   with:
+      #     fetch-depth: 0
 
       - name: cd-release
-        uses: ./actions/cicd-changesets
+        # uses: ./actions/cicd-changesets
+        uses: smartcontractkit/.github/actions/cicd-changesets@feat/cicd-changesets-signed-commits
         with:
           # general inputs
           git-user: app-token-issuer-releng-renovate[bot]


### PR DESCRIPTION
Partial roll out for the `signed-commits` action which acts as a drop-in replacement of `changesets/action`. 

This points the `cd-release` job to the branch in #80 instead of referencing the local action which is still using `changesets/action` under-the-hood.

See https://github.com/smartcontractkit/.github/pull/80 for more context.