### PR TITLE
fix: flag signed-commits as private

### DIFF
--- a/actions/signed-commits/package.json
+++ b/actions/signed-commits/package.json
@@ -2,6 +2,7 @@
   "name": "@smartcontractkit/changesets-action-signed-commits",
   "version": "1.0.0",
   "main": "dist/index.js",
+  "private": true,
   "license": "MIT",
   "devDependencies": {
     "@changesets/cli": "^2.27.1",


### PR DESCRIPTION
Mark `signed-commits` as private because workflow failed.

https://github.com/smartcontractkit/.github/actions/runs/7226453502/job/19692053908