### PR TITLE
feat: cicd-changesets using signed-commits

### DIFF
--- a/.changeset/soft-radios-breathe.md
+++ b/.changeset/soft-radios-breathe.md
@@ -1,0 +1,5 @@
+---
+"cicd-changesets": minor
+---
+
+Use signed-commits action, drop-in replacement for changesets/action

--- a/actions/cicd-changesets/action.yml
+++ b/actions/cicd-changesets/action.yml
@@ -79,7 +79,7 @@ outputs:
     value: ${{ steps.changesets.outputs.hasChangesets }}
   pullRequestNumber:
     description: The pull request number that was created or updated
-    value: ${{ steps.changesets.outputs.pullRequestNumber }}  
+    value: ${{ steps.changesets.outputs.pullRequestNumber }}
 
 runs:
   using: composite
@@ -119,7 +119,7 @@ runs:
 
     - name: Run changesets
       id: changesets
-      uses: changesets/action@f13b1baaa620fde937751f5d2c3572b9da32af23 # v1.4.5
+      uses: smartcontractkit/.github/actions/signed-commits@95b6030f4d23d5d87f53eb0f018f51806afa4da3 # changesets-signed-commits@1.0.1
       env:
         GITHUB_TOKEN: ${{ steps.get-gh-token.outputs.access-token }}
       with:


### PR DESCRIPTION
Full roll-out for `cicd-changesets` with `signed-commits`. This PR uses the new `signed-commits` action which is a drop-in replacement for the `changesets/action`, but offers signed commits and therefore "signed" tags.

#80 is another PR which has been referenced in other repos during the partial roll-out. This partial roll-out confirmed compatibility of the update. As a follow-up, those partially rolled-out repos will need to be updated to reference the official release. The tracking of updating those references will be done in that PR. 

---

https://smartcontract-it.atlassian.net/browse/RE-1901

Related to #80.