### PR TITLE
chore: full roll out for signed-commits (undo partial rollout)

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -70,16 +70,13 @@ jobs:
       contents: read
       actions: read
     steps:
-      # Partial roll-out of cicd-changesets-signed-commits
-
-      # - name: Checkout repo (needed to reference local action)
-      #   uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      #   with:
-      #     fetch-depth: 0
+      - name: Checkout repo (needed to reference local action)
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
 
       - name: cd-release
-        # uses: ./actions/cicd-changesets
-        uses: smartcontractkit/.github/actions/cicd-changesets@feat/cicd-changesets-signed-commits
+        uses: ./actions/cicd-changesets
         with:
           # general inputs
           git-user: app-token-issuer-releng-renovate[bot]


### PR DESCRIPTION
Removing reference to the partial rollout branch - #80.

By checking out the repo and not directly referencing the `cicd-changesets` release/tag - this guarantees it will use the version at current ref.

I think this is the right way to do this as the action belongs to this repository, and if the action is updated, the workflow should use the version at the current ref rather than the last releases. Thoughts?

