### PR TITLE
fix: signed-commits crash when no local tags exist

### DIFF
--- a/.changeset/healthy-fans-behave.md
+++ b/.changeset/healthy-fans-behave.md
@@ -1,0 +1,5 @@
+---
+"changesets-signed-commits": patch
+---
+
+fix: crash when no local tags exist

--- a/actions/signed-commits/dist/index.js
+++ b/actions/signed-commits/dist/index.js
@@ -61575,8 +61575,7 @@ async function getLocalRemoteTagDiff(cwd) {
 }
 async function getLocalTags(cwd) {
   const stdout = await execWithOutput("git", ["tag", "--list"], { cwd });
-  const tagNames = stdout.split("\n");
-  const tags = tagNames.map(async (name) => {
+  const tags = stdout.split("\n").filter((line) => !!line).map(async (name) => {
     const ref = await execWithOutput("git", ["rev-list", "-1", name], { cwd });
     return { name, ref };
   });

--- a/actions/signed-commits/src/git/github-git/repo-tags.test.ts
+++ b/actions/signed-commits/src/git/github-git/repo-tags.test.ts
@@ -7,6 +7,7 @@ import {
   GitTag,
   pushTags,
   getRemoteTagNames,
+  getLocalTags,
 } from "./repo-tags";
 import { createRepo } from "./utilts.testutils";
 
@@ -85,7 +86,19 @@ describe("repo-tags", () => {
     });
   });
 
-  describe("getRemoteTagNames", () => {
+  describe(getLocalTags.name, () => {
+    it("should return empty array if no local tags exist", async () => {
+      const testRepoConfig = await createTestRepoWithRemote("repo-tags");
+
+      expect(testRepoConfig.localOnlyTags).toEqual([]);
+      expect(testRepoConfig.sharedTags).toEqual([]);
+
+      const remoteTags = await getLocalTags(testRepoConfig.localRepoPath);
+      expect(remoteTags).toEqual([]);
+    });
+  });
+
+  describe(getRemoteTagNames.name, () => {
     it("should return empty array if no remote tags exist", async () => {
       const testRepoConfig = await createTestRepoWithRemote("repo-tags");
 

--- a/actions/signed-commits/src/git/github-git/repo-tags.ts
+++ b/actions/signed-commits/src/git/github-git/repo-tags.ts
@@ -38,11 +38,12 @@ export async function getLocalRemoteTagDiff(cwd?: string): Promise<GitTag[]> {
 export async function getLocalTags(cwd?: string): Promise<GitTag[]> {
   const stdout = await execWithOutput("git", ["tag", "--list"], { cwd });
 
-  const tagNames = stdout.split("\n");
-  const tags: Promise<GitTag>[] = tagNames.map(async (name) => {
-    const ref = await execWithOutput("git", ["rev-list", "-1", name], { cwd });
-    return { name, ref: ref };
-  });
+  const tags: Promise<GitTag>[] = stdout.split("\n")
+    .filter((line) => !!line)
+    .map(async (name) => {
+      const ref = await execWithOutput("git", ["rev-list", "-1", name], { cwd });
+      return { name, ref: ref };
+    });
 
   return await Promise.all(tags);
 }


### PR DESCRIPTION
Found this bug with https://github.com/smartcontractkit/functions-toolkit/pull/52 ([example run](https://github.com/smartcontractkit/functions-toolkit/actions/runs/7545689293/job/20548039097)).

Cause of the error is similar to that for the remote tags issue which was solved before merging the PR in: 9a45935fe6184f2f010f2c8871b6593beb4d66d6

```
setting git user
/usr/bin/git config user.name "github-actions[bot]"
/usr/bin/git config user.email "github-actions[bot]@users.noreply.github.com"
setting GitHub credentials
No changesets found, attempting to publish any unpublished packages to npm
No user .npmrc file found, creating one
/opt/hostedtoolcache/node/18.19.0/x64/bin/npx changeset publish
🦋  info npm info @chainlink/functions-toolkit
🦋  warn @chainlink/functions-toolkit is not being published because version 0.2.8 is already published on npm
🦋  warn No unpublished projects to publish
/usr/bin/git tag --list
/usr/bin/git rev-list -1 
fatal: ambiguous argument '': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
Error: Error: The process '/usr/bin/git' failed with exit code 128
Error: The process '/usr/bin/git' failed with exit code 128
```

### Testing

1. Tested locally with a command like:
    ```
    GITHUB_TOKEN=fake \
    INPUT_CWD=<path to repo cloned with --depth 1> \
    INPUT_SETUPGITUSER=false \
    INPUT_CREATEGITHUBRELEASES=true \
    INPUT_PUBLISH="pnpm changeset publish"  \
    node ./dist/index.js
    ```
2. Created unit test which failed without fix, passing with fix
