### PR TITLE
config: renovate - skip dev dependency patch updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,5 +19,11 @@
       "(^|/)action\\.ya?ml$"
     ]
   },
-  "packageRules": []
+  "packageRules": [
+    {
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
To avoid a lot of spam from renovate, we should skip patch updates for dev dependencies.

