### PR TITLE
feat: support grafana org/tenant id input for push-gha-metrics-action v2.1.0

### DIFF
--- a/.changeset/large-walls-hear.md
+++ b/.changeset/large-walls-hear.md
@@ -1,0 +1,21 @@
+---
+"cicd-build-publish-artifacts-go": patch
+"cicd-build-publish-artifacts-ts": patch
+"guard-from-missing-changesets": patch
+"helm-version-bump-receiver": patch
+"cicd-build-publish-charts": patch
+"cicd-changesets": patch
+"ci-lint-charts": patch
+"manifest-build": patch
+"update-actions": patch
+"ci-lint-misc": patch
+"ci-sonarqube": patch
+"ci-test-sol": patch
+"ci-lint-go": patch
+"ci-lint-ts": patch
+"ci-test-go": patch
+"ci-test-ts": patch
+"setup-gap": patch
+---
+
+Support grafana org/tenant id input for push-gha-metrics-action v2.1.0

--- a/actions/ci-lint-charts/action.yml
+++ b/actions/ci-lint-charts/action.yml
@@ -20,16 +20,19 @@ inputs:
     description: "chart-testing extra args"
     required: false
     default: ""
-  # grafana cloud inputs
+  # grafana inputs
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
     default: ci-lint-charts
   gc-host:
-    description: "grafana cloud hostname"
+    description: "grafana hostname"
     required: false
   gc-basic-auth:
-    description: "grafana cloud basic auth"
+    description: "grafana basic auth"
+    required: false
+  gc-org-id:
+    description: "grafana org/tenant id"
     required: false
 
 runs:
@@ -59,5 +62,6 @@ runs:
       with:
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
+        org-id: ${{ inputs.gc-org-id}}
         this-job-name: ${{ inputs.metrics-job-name }}
       continue-on-error: true

--- a/actions/ci-lint-go/action.yml
+++ b/actions/ci-lint-go/action.yml
@@ -11,16 +11,19 @@ inputs:
     description: "number of commits to fetch"
     required: false
     default: "0"
-  # grafana cloud inputs
+  # grafana inputs
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
     default: ci-lint
   gc-host:
-    description: "grafana cloud hostname"
+    description: "grafana hostname"
     required: false
   gc-basic-auth:
-    description: "grafana cloud basic auth"
+    description: "grafana basic auth"
+    required: false
+  gc-org-id:
+    description: "grafana org/tenant id"
     required: false
   # aws inputs
   aws-role-duration-seconds:
@@ -149,5 +152,6 @@ runs:
       with:
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
+        org-id: ${{ inputs.gc-org-id}}
         this-job-name: ${{ inputs.metrics-job-name }}
       continue-on-error: true

--- a/actions/ci-lint-misc/action.yml
+++ b/actions/ci-lint-misc/action.yml
@@ -11,16 +11,19 @@ inputs:
     description: "number of commits to fetch"
     required: false
     default: "0"
-  # grafana cloud inputs
+  # grafana inputs
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
     default: ci-lint-misc
   gc-host:
-    description: "grafana cloud hostname"
+    description: "grafana hostname"
     required: false
   gc-basic-auth:
-    description: "grafana cloud basic auth"
+    description: "grafana basic auth"
+    required: false
+  gc-org-id:
+    description: "grafana org/tenant id"
     required: false
 
 runs:
@@ -47,5 +50,6 @@ runs:
       with:
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
+        org-id: ${{ inputs.gc-org-id}}
         this-job-name: ${{ inputs.metrics-job-name }}
       continue-on-error: true

--- a/actions/ci-lint-ts/action.yml
+++ b/actions/ci-lint-ts/action.yml
@@ -19,17 +19,21 @@ inputs:
     description: ""
     required: false
     default: main
-  # grafana cloud inputs
+  # grafana inputs
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
     default: ci-lint
   gc-host:
-    description: "grafana cloud hostname"
+    description: "grafana hostname"
     required: false
   gc-basic-auth:
-    description: "grafana cloud basic auth"
+    description: "grafana basic auth"
     required: false
+  gc-org-id:
+    description: "grafana org/tenant id"
+    required: false
+
   # nodejs inputs
   node-version-file:
     description: ""
@@ -75,5 +79,6 @@ runs:
       with:
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
+        org-id: ${{ inputs.gc-org-id}}
         this-job-name: ${{ inputs.metrics-job-name }}
       continue-on-error: true

--- a/actions/ci-sonarqube/action.yml
+++ b/actions/ci-sonarqube/action.yml
@@ -11,16 +11,19 @@ inputs:
     description: "number of commits to fetch"
     required: false
     default: "0"
-  # grafana cloud inputs
+  # grafana inputs
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
     default: ci-sonarqube
   gc-host:
-    description: "grafana cloud hostname"
+    description: "grafana hostname"
     required: false
   gc-basic-auth:
-    description: "grafana cloud basic auth"
+    description: "grafana basic auth"
+    required: false
+  gc-org-id:
+    description: "grafana org/tenant id"
     required: false
   # sonarqube inputs
   sonar-token:
@@ -89,5 +92,6 @@ runs:
       with:
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
+        org-id: ${{ inputs.gc-org-id}}
         this-job-name: ${{ inputs.metrics-job-name }}
       continue-on-error: true

--- a/actions/ci-test-go/action.yml
+++ b/actions/ci-test-go/action.yml
@@ -11,16 +11,19 @@ inputs:
     description: "number of commits to fetch"
     required: false
     default: "0"
-  # grafana cloud inputs
+  # grafana inputs
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
     default: ci-test
   gc-host:
-    description: "grafana cloud hostname"
+    description: "grafana hostname"
     required: false
   gc-basic-auth:
-    description: "grafana cloud basic auth"
+    description: "grafana basic auth"
+    required: false
+  gc-org-id:
+    description: "grafana org/tenant id"
     required: false
   # aws inputs
   aws-role-duration-seconds:
@@ -148,5 +151,6 @@ runs:
       with:
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
+        org-id: ${{ inputs.gc-org-id}}
         this-job-name: ${{ inputs.metrics-job-name }}
       continue-on-error: true

--- a/actions/ci-test-sol/action.yml
+++ b/actions/ci-test-sol/action.yml
@@ -40,16 +40,19 @@ inputs:
     description: ""
     required: false
     default: "--report lcov"
-  # grafana cloud inputs
+  # grafana inputs
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
     default: ci-test-sol
   gc-host:
-    description: "grafana cloud hostname"
+    description: "grafana hostname"
     required: false
   gc-basic-auth:
-    description: "grafana cloud basic auth"
+    description: "grafana basic auth"
+    required: false
+  gc-org-id:
+    description: "grafana org/tenant id"
     required: false
   # nodejs inputs
   node-version-file:
@@ -142,5 +145,6 @@ runs:
       with:
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
+        org-id: ${{ inputs.gc-org-id}}
         this-job-name: ${{ inputs.metrics-job-name }}
       continue-on-error: true

--- a/actions/ci-test-ts/action.yml
+++ b/actions/ci-test-ts/action.yml
@@ -19,16 +19,19 @@ inputs:
     description: ""
     required: false
     default: main
-  # grafana cloud inputs
+  # grafana inputs
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
     default: ci-test
   gc-host:
-    description: "grafana cloud hostname"
+    description: "grafana hostname"
     required: false
   gc-basic-auth:
-    description: "grafana cloud basic auth"
+    description: "grafana basic auth"
+    required: false
+  gc-org-id:
+    description: "grafana org/tenant id"
     required: false
   # nodejs inputs
   node-version-file:
@@ -75,5 +78,6 @@ runs:
       with:
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
+        org-id: ${{ inputs.gc-org-id}}
         this-job-name: ${{ inputs.metrics-job-name }}
       continue-on-error: true

--- a/actions/cicd-build-publish-artifacts-go/action.yml
+++ b/actions/cicd-build-publish-artifacts-go/action.yml
@@ -26,16 +26,19 @@ inputs:
     description: ""
     required: false
     default: "false"
-  # grafana cloud inputs
+  # grafana inputs
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
     default: cicd-build-publish-artifacts
   gc-host:
-    description: "grafana cloud hostname"
+    description: "grafana hostname"
     required: false
   gc-basic-auth:
-    description: "grafana cloud basic auth"
+    description: "grafana basic auth"
+    required: false
+  gc-org-id:
+    description: "grafana org/tenant id"
     required: false
   # aws inputs
   aws-role-duration-seconds:
@@ -224,5 +227,6 @@ runs:
       with:
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
+        org-id: ${{ inputs.gc-org-id}}
         this-job-name: ${{ inputs.metrics-job-name }}
       continue-on-error: true

--- a/actions/cicd-build-publish-artifacts-ts/action.yml
+++ b/actions/cicd-build-publish-artifacts-ts/action.yml
@@ -46,16 +46,19 @@ inputs:
   monorepo-release-version:
     description: ""
     required: false
-  # grafana cloud inputs
+  # grafana inputs
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
     default: cicd-build-publish-artifacts
   gc-host:
-    description: "grafana cloud hostname"
+    description: "grafana hostname"
     required: false
   gc-basic-auth:
-    description: "grafana cloud basic auth"
+    description: "grafana basic auth"
+    required: false
+  gc-org-id:
+    description: "grafana org/tenant id"
     required: false
   # nodejs inputs
   node-version-file:
@@ -148,5 +151,6 @@ runs:
       with:
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
+        org-id: ${{ inputs.gc-org-id}}
         this-job-name: ${{ inputs.metrics-job-name }}
       continue-on-error: true

--- a/actions/cicd-build-publish-charts/action.yml
+++ b/actions/cicd-build-publish-charts/action.yml
@@ -11,16 +11,19 @@ inputs:
     description: "number of commits to fetch"
     required: false
     default: "0"
-  # grafana cloud inputs
+  # grafana inputs
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
     default: cicd-build-publish-charts
   gc-host:
-    description: "grafana cloud hostname"
+    description: "grafana hostname"
     required: false
   gc-basic-auth:
-    description: "grafana cloud basic auth"
+    description: "grafana basic auth"
+    required: false
+  gc-org-id:
+    description: "grafana org/tenant id"
     required: false
   # general inputs
   package-dir:
@@ -114,5 +117,6 @@ runs:
       with:
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
+        org-id: ${{ inputs.gc-org-id}}
         this-job-name: ${{ inputs.metrics-job-name }}
       continue-on-error: true

--- a/actions/cicd-changesets/action.yml
+++ b/actions/cicd-changesets/action.yml
@@ -42,16 +42,19 @@ inputs:
     description: "Use cache for pnpm"
     required: false
     default: "true"
-  # grafana cloud inputs
+  # grafana inputs
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
     default: cicd-changesets
   gc-host:
-    description: "grafana cloud hostname"
+    description: "grafana hostname"
     required: false
   gc-basic-auth:
-    description: "grafana cloud basic auth"
+    description: "grafana basic auth"
+    required: false
+  gc-org-id:
+    description: "grafana org/tenant id"
     required: false
   # changesets inputs
   changesets-publish-cmd:
@@ -141,5 +144,6 @@ runs:
       with:
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
+        org-id: ${{ inputs.gc-org-id}}
         this-job-name: ${{ inputs.metrics-job-name }}
       continue-on-error: true

--- a/actions/guard-from-missing-changesets/action.yml
+++ b/actions/guard-from-missing-changesets/action.yml
@@ -10,12 +10,15 @@ inputs:
       step with `fetch-depth: 0`.
     required: false
     default: "false"
-  # grafana cloud inputs
+  # grafana inputs
   gc-basic-auth:
-    description: "grafana cloud basic auth"
+    description: "grafana basic auth"
+    required: false
+  gc-org-id:
+    description: "grafana org/tenant id"
     required: false
   gc-host:
-    description: "grafana cloud hostname"
+    description: "grafana hostname"
     required: false
   metrics-job-name:
     description: "grafana metrics job name"
@@ -47,5 +50,6 @@ runs:
       with:
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
+        org-id: ${{ inputs.gc-org-id}}
         this-job-name: ${{ inputs.metrics-job-name }}
       continue-on-error: true

--- a/actions/helm-version-bump-receiver/action.yml
+++ b/actions/helm-version-bump-receiver/action.yml
@@ -28,7 +28,7 @@ inputs:
     default: ${{ github.token }}
   helm-chart-repo:
     description: |
-      Helm chart repo URL to use, either `sdlc` or `prod`. 
+      Helm chart repo URL to use, either `sdlc` or `prod`.
       Only used if `inputs.helm-chart-repo-update` is true.
       Only use `sdlc` for pre-releases.
 
@@ -68,6 +68,20 @@ inputs:
     description: "Used to append to the branch name and the PR title."
     required: true
     default: "sandbox"
+  # grafana inputs
+  metrics-job-name:
+    description: "grafana metrics job name"
+    required: false
+    default: ci-lint
+  gc-host:
+    description: "grafana hostname"
+    required: false
+  gc-basic-auth:
+    description: "grafana basic auth"
+    required: false
+  gc-org-id:
+    description: "grafana org/tenant id"
+    required: false
 
 outputs:
   pr-number:
@@ -103,9 +117,7 @@ runs:
         AWS_SESSION_TOKEN: ""
       with:
         cmd:
-          yq eval -i '.releases[] |= select(.name == "${{
-          inputs.app-release-name }}").version = "${{ inputs.helm-chart-version
-          }}"' ${{ inputs.app-file-path-pattern }}
+          yq eval -i '.releases[] |= select(.name == "${{ inputs.app-release-name }}").version = "${{ inputs.helm-chart-version }}"' ${{ inputs.app-file-path-pattern }}
 
     - name: Update helm chart repo
       if: inputs.helm-chart-repo-update == 'true'
@@ -117,8 +129,7 @@ runs:
         AWS_SESSION_TOKEN: ""
       with:
         cmd:
-          yq eval -i '.repositories[] |= select(.name == "infra-charts").url =
-          "${{ inputs.helm-chart-repo }}"' ${{ inputs.app-file-path-pattern }}
+          yq eval -i '.repositories[] |= select(.name == "infra-charts").url = "${{ inputs.helm-chart-repo }}"' ${{ inputs.app-file-path-pattern }}
 
     - name: Create PR to deploy
       id: create-pr
@@ -126,8 +137,7 @@ runs:
       with:
         base: ${{ inputs.pr-base-branch }}
         branch:
-          auto/${{ inputs.app-release-name}}/helm-${{ inputs.helm-chart-version
-          }}-${{ inputs.release-type }}
+          auto/${{ inputs.app-release-name}}/helm-${{ inputs.helm-chart-version }}-${{ inputs.release-type }}
         draft: ${{ inputs.pr-draft }}
         labels: ${{ inputs.pr-labels }}
         title:
@@ -142,5 +152,6 @@ runs:
       with:
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
+        org-id: ${{ inputs.gc-org-id}}
         this-job-name: ${{ inputs.metrics-job-name }}
       continue-on-error: true

--- a/actions/manifest-build/action.yml
+++ b/actions/manifest-build/action.yml
@@ -15,16 +15,19 @@ inputs:
       description: "Cachix auth token for private cache"
       required: false
       default: ""
-  # grafana cloud inputs
+  # grafana inputs
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
     default: manifest-build
   gc-host:
-    description: "grafana cloud hostname"
+    description: "grafana hostname"
     required: false
   gc-basic-auth:
-    description: "grafana cloud basic auth"
+    description: "grafana basic auth"
+    required: false
+  gc-org-id:
+    description: "grafana org/tenant id"
     required: false
 
 runs:
@@ -61,5 +64,6 @@ runs:
       with:
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
+        org-id: ${{ inputs.gc-org-id}}
         this-job-name: ${{ inputs.metrics-job-name }}
       continue-on-error: true

--- a/actions/manifest-build/action.yml
+++ b/actions/manifest-build/action.yml
@@ -57,7 +57,7 @@ runs:
     - name: Collect metrics
       if: always()
       id: collect-gha-metrics
-      uses: smartcontractkit/push-gha-metrics-action@031fd89b33b3e7722b0c4d2593ece1861d9f503f
+      uses: smartcontractkit/push-gha-metrics-action@0281b09807758be1dcc41651e44e62b353808c47 # v2.1.0
       with:
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}

--- a/actions/setup-gap/action.yml
+++ b/actions/setup-gap/action.yml
@@ -48,16 +48,19 @@ inputs:
   argocd-pass:
     description: ""
     required: false
-  # grafana cloud inputs
+  # grafana inputs
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
     default: setup-gap
   gc-host:
-    description: "grafana cloud hostname"
+    description: "grafana hostname"
     required: false
   gc-basic-auth:
-    description: "grafana cloud basic auth"
+    description: "grafana basic auth"
+    required: false
+  gc-org-id:
+    description: "grafana org/tenant id"
     required: false
 
 runs:
@@ -124,5 +127,6 @@ runs:
       with:
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
+        org-id: ${{ inputs.gc-org-id}}
         this-job-name: ${{ inputs.metrics-job-name }}
       continue-on-error: true

--- a/actions/update-actions/action.yml
+++ b/actions/update-actions/action.yml
@@ -31,16 +31,19 @@ inputs:
   aws-lambda-url-updater:
     description: ""
     required: true
-  # grafana cloud inputs
+  # grafana inputs
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
     default: update-actions
   gc-host:
-    description: "grafana cloud hostname"
+    description: "grafana hostname"
     required: false
   gc-basic-auth:
-    description: "grafana cloud basic auth"
+    description: "grafana basic auth"
+    required: false
+  gc-org-id:
+    description: "grafana org/tenant id"
     required: false
 
 runs:
@@ -101,5 +104,6 @@ runs:
       with:
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
+        org-id: ${{ inputs.gc-org-id}}
         this-job-name: ${{ inputs.metrics-job-name }}
       continue-on-error: true

--- a/libs/nx-chainlink/src/generators/create-gh-action/files/composite/action.yml.template
+++ b/libs/nx-chainlink/src/generators/create-gh-action/files/composite/action.yml.template
@@ -11,16 +11,19 @@ inputs:
     description: "number of commits to fetch"
     required: false
     default: "0"
-  # grafana cloud inputs
+  # grafana inputs
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
     default: <%= name %>
   gc-host:
-    description: "grafana cloud hostname"
+    description: "grafana hostname"
     required: false
   gc-basic-auth:
-    description: "grafana cloud basic auth"
+    description: "grafana basic auth"
+    required: false
+  gc-org-id:
+    description: "grafana org/tenant id"
     required: false
 
 runs:
@@ -43,5 +46,6 @@ runs:
       with:
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
+        org-id: ${{ inputs.gc-org-id}}
         this-job-name: ${{ inputs.metrics-job-name }}
       continue-on-error: true

--- a/libs/nx-chainlink/src/generators/create-gh-action/files/composite/action.yml.template
+++ b/libs/nx-chainlink/src/generators/create-gh-action/files/composite/action.yml.template
@@ -39,7 +39,7 @@ runs:
     - name: Collect metrics
       if: always()
       id: collect-gha-metrics
-      uses: smartcontractkit/push-gha-metrics-action@031fd89b33b3e7722b0c4d2593ece1861d9f503f
+      uses: smartcontractkit/push-gha-metrics-action@0281b09807758be1dcc41651e44e62b353808c47 # v2.1.0
       with:
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}


### PR DESCRIPTION
Updated all actions which reference `push-gha-metrics-action` to accept a new *optional* `gc-org-id` input, and pass that to the action which has been updated for support with grafana self-hosted.

Also tried to generify references to grafana *cloud* to just grafana
- Kept inputs prefixed with `gc-` for backwards compatibility as there are many references to these shared actions with `@main`.