### PR TITLE
chore: add changesets for renovate changes

### DIFF
--- a/.changeset/seven-balloons-repeat.md
+++ b/.changeset/seven-balloons-repeat.md
@@ -1,0 +1,22 @@
+---
+"ci-benchmarking": patch
+"ci-lint-go": patch
+"ci-sonarqube": patch
+"ci-test-go": patch
+"ci-test-sol": patch
+"cicd-build-publish-artifacts-go": patch
+"cicd-build-publish-artifacts-ts": patch
+"cicd-build-publish-charts": patch
+"cicd-changesets": patch
+"guard-tag-from-branch": patch
+"helm-version-bump-receiver": patch
+"nops-upgrade-checker": patch
+"setup-github-token": patch
+"setup-golang": patch
+"setup-nodejs": patch
+"setup-renovate": patch
+"update-actions": patch
+"wait-for-workflows": patch
+---
+
+Update dependencies


### PR DESCRIPTION
These are all the packages which have been updated by renovate but haven't been versioned.

As a follow-up we should figure out a way to automatically add changesets to renovate bot PRs. 