### PR TITLE
chore: mask aws account id

### DIFF
--- a/.changeset/weak-walls-walk.md
+++ b/.changeset/weak-walls-walk.md
@@ -1,0 +1,13 @@
+---
+"cicd-build-publish-artifacts-go": patch
+"cicd-build-publish-charts": patch
+"setup-github-token": patch
+"cicd-changesets": patch
+"update-actions": patch
+"ci-lint-go": patch
+"ci-test-go": patch
+"setup-gap": patch
+"setup-nix": patch
+---
+
+chore: mask aws account id when calling aws-actions/configure-aws-credentials

--- a/actions/ci-lint-go/action.yml
+++ b/actions/ci-lint-go/action.yml
@@ -94,6 +94,7 @@ runs:
         role-to-assume: ${{ inputs.aws-role-arn-gati }}
         role-duration-seconds: ${{ inputs.aws-role-duration-seconds }}
         aws-region: ${{ inputs.aws-region }}
+        mask-aws-account-id: true
 
     - name: Get github token from gati
       if: inputs.use-gati == 'true'

--- a/actions/ci-test-go/action.yml
+++ b/actions/ci-test-go/action.yml
@@ -96,6 +96,7 @@ runs:
         role-to-assume: ${{ inputs.aws-role-arn-gati }}
         role-duration-seconds: ${{ inputs.aws-role-duration-seconds }}
         aws-region: ${{ inputs.aws-region }}
+        mask-aws-account-id: true
 
     - name: Get github token from gati
       if: inputs.use-gati == 'true'

--- a/actions/cicd-build-publish-artifacts-go/action.yml
+++ b/actions/cicd-build-publish-artifacts-go/action.yml
@@ -132,6 +132,7 @@ runs:
         role-to-assume: ${{ inputs.aws-role-arn-gati }}
         role-duration-seconds: ${{ inputs.aws-role-duration-seconds }}
         aws-region: ${{ inputs.aws-region }}
+        mask-aws-account-id: true
 
     - name: Get github token from gati
       if: inputs.use-gati == 'true'
@@ -192,6 +193,7 @@ runs:
         role-to-assume: ${{ inputs.aws-role-arn }}
         role-duration-seconds: ${{ inputs.aws-role-duration-seconds }}
         aws-region: ${{ inputs.aws-region }}
+        mask-aws-account-id: true
 
     - name: Login to aws ecr
       if: inputs.publish == 'true' && inputs.docker-registry == 'aws'

--- a/actions/cicd-build-publish-charts/action.yml
+++ b/actions/cicd-build-publish-charts/action.yml
@@ -88,6 +88,7 @@ runs:
         role-to-assume: ${{ inputs.aws-role-arn }}
         role-duration-seconds: ${{ inputs.aws-role-duration-seconds }}
         aws-region: ${{ inputs.aws-region }}
+        mask-aws-account-id: true
 
     - name: Login to aws ecr registry
       if: inputs.publish == 'true'

--- a/actions/cicd-changesets/action.yml
+++ b/actions/cicd-changesets/action.yml
@@ -93,6 +93,7 @@ runs:
         role-to-assume: ${{ inputs.aws-role-arn }}
         role-duration-seconds: ${{ inputs.aws-role-duration-seconds }}
         aws-region: ${{ inputs.aws-region }}
+        mask-aws-account-id: true
 
     - name: Get github token from gati
       id: get-gh-token

--- a/actions/setup-gap/action.yml
+++ b/actions/setup-gap/action.yml
@@ -105,6 +105,7 @@ runs:
         role-to-assume: ${{ inputs.aws-role-arn }}
         role-duration-seconds: ${{ inputs.aws-role-duration-seconds }}
         aws-region: ${{ inputs.aws-region }}
+        mask-aws-account-id: true
 
     - name: Setup Certificate Authority (K8s only)
       # Generate a local ephemeral CA key and cert to sign the local proxy's certificate.

--- a/actions/setup-github-token/action.yml
+++ b/actions/setup-github-token/action.yml
@@ -33,6 +33,7 @@ runs:
         role-to-assume: ${{ inputs.aws-role-arn }}
         role-duration-seconds: ${{ inputs.aws-role-duration-seconds }}
         aws-region: ${{ inputs.aws-region }}
+        mask-aws-account-id: true
 
     - name: Get github token from gati
       id: get-gh-token

--- a/actions/setup-nix/action.yml
+++ b/actions/setup-nix/action.yml
@@ -21,7 +21,7 @@ inputs:
     description: ""
     required: false
     default: "us-west-1"
-  role-to-assume: 
+  role-to-assume:
     description: ""
     required: false
     default: ""
@@ -29,7 +29,7 @@ inputs:
     description: ""
     required: false
     default: 3600
-    
+
   # cachix inputs --------------------------------
   enable-cachix:
     description: "Run cachix for nix caching"
@@ -75,6 +75,8 @@ runs:
         role-to-assume: ${{ inputs.role-to-assume }}
         role-duration-seconds: ${{ inputs.role-duration-seconds }}
         aws-region: ${{ inputs.aws-region }}
+        mask-aws-account-id: true
+
     - name: setup AWS credentials for nix
       if: inputs.enable-aws == 'true'
       shell: bash

--- a/actions/update-actions/action.yml
+++ b/actions/update-actions/action.yml
@@ -61,6 +61,7 @@ runs:
         role-to-assume: ${{ inputs.aws-role-arn }}
         role-duration-seconds: ${{ inputs.aws-role-duration-seconds }}
         aws-region: ${{ inputs.aws-region }}
+        mask-aws-account-id: true
 
     - name: Get github token from gati
       id: get-gh-token
@@ -74,6 +75,7 @@ runs:
         role-to-assume: ${{ inputs.aws-role-arn-updater }}
         role-duration-seconds: ${{ inputs.aws-role-duration-seconds }}
         aws-region: ${{ inputs.aws-region }}
+        mask-aws-account-id: true
 
     - name: Get github token from gati for updater
       id: get-gh-token-updater


### PR DESCRIPTION

For all references of `aws-actions/configure-aws-credentials` set `mask-aws-account-id: true`.

This will avoid leaking account IDs accidentally.

---
RE-2443