### PR TITLE
add prDraft input to changeset signed-commits action

### DIFF
--- a/.changeset/hungry-dryers-mate.md
+++ b/.changeset/hungry-dryers-mate.md
@@ -2,4 +2,4 @@
 "changesets-signed-commits": minor
 ---
 
-Add prDraft and labels inputs
+Add optional prDraft input

--- a/.changeset/hungry-dryers-mate.md
+++ b/.changeset/hungry-dryers-mate.md
@@ -1,0 +1,5 @@
+---
+"changesets-signed-commits": minor
+---
+
+Add prDraft and labels inputs

--- a/actions/signed-commits/action.yml
+++ b/actions/signed-commits/action.yml
@@ -8,7 +8,9 @@ inputs:
     description: "The command to use to build and publish packages"
     required: false
   version:
-    description: "The command to update version, edit CHANGELOG, read and delete changesets. Default to `changeset version` if not provided"
+    description:
+      "The command to update version, edit CHANGELOG, read and delete
+      changesets. Default to `changeset version` if not provided"
     required: false
   cwd:
     description: Sets the cwd for the node process. Default to `process.cwd()`
@@ -20,22 +22,39 @@ inputs:
   title:
     description: The pull request title. Default to `Version Packages`
     required: false
+  prDraft:
+    description:
+      A boolean value to indicate whether the pull request should be a draft or
+      not. Default to `false`
+    required: false
+    default: "false"
+  labels:
+    description: A comma separated list of labels to add to the pull request
+    required: false
   setupGitUser:
-    description: Sets up the git user for commits as `"github-actions[bot]"`. Default to `true`
+    description:
+      Sets up the git user for commits as `"github-actions[bot]"`. Default to
+      `true`
     required: false
-    default: true
+    default: "true"
   createGithubReleases:
-    description: "A boolean value to indicate whether to create Github releases after `publish` or not"
+    description:
+      "A boolean value to indicate whether to create Github releases after
+      `publish` or not"
     required: false
-    default: true
+    default: "true"
 outputs:
   published:
-    description: A boolean value to indicate whether a publishing is happened or not
+    description:
+      A boolean value to indicate whether a publishing is happened or not
   publishedPackages:
     description: >
-      A JSON array to present the published packages. The format is `[{"name": "@xx/xx", "version": "1.2.0"}, {"name": "@xx/xy", "version": "0.8.9"}]`
+      A JSON array to present the published packages. The format is `[{"name":
+      "@xx/xx", "version": "1.2.0"}, {"name": "@xx/xy", "version": "0.8.9"}]`
   hasChangesets:
-    description: A boolean about whether there were changesets. Useful if you want to create your own publishing functionality.
+    description:
+      A boolean about whether there were changesets. Useful if you want to
+      create your own publishing functionality.
   pullRequestNumber:
     description: The pull request number that was created or updated
 branding:

--- a/actions/signed-commits/action.yml
+++ b/actions/signed-commits/action.yml
@@ -28,7 +28,7 @@ inputs:
       not. Default to `false`
     required: false
     default: "false"
-  labels:
+  prLabels:
     description: A comma separated list of labels to add to the pull request
     required: false
   setupGitUser:

--- a/actions/signed-commits/action.yml
+++ b/actions/signed-commits/action.yml
@@ -28,9 +28,6 @@ inputs:
       not. Default to `false`
     required: false
     default: "false"
-  prLabels:
-    description: A comma separated list of labels to add to the pull request
-    required: false
   setupGitUser:
     description:
       Sets up the git user for commits as `"github-actions[bot]"`. Default to

--- a/actions/signed-commits/src/__snapshots__/run.test.ts.snap
+++ b/actions/signed-commits/src/__snapshots__/run.test.ts.snap
@@ -34,7 +34,7 @@ exports[`version creates simple PR 1`] = `
 ]
 `;
 
-exports[`version creates simple PR in draft mode with do-not-merge label 1`] = `
+exports[`version creates simple PR in draft mode 1`] = `
 [
   {
     "base": "some-branch",

--- a/actions/signed-commits/src/__snapshots__/run.test.ts.snap
+++ b/actions/signed-commits/src/__snapshots__/run.test.ts.snap
@@ -25,6 +25,7 @@ exports[`version creates simple PR 1`] = `
 
 -   Awesome feature
 ",
+    "draft": false,
     "head": "changeset-release/some-branch",
     "owner": "changesets",
     "repo": "action",
@@ -43,6 +44,7 @@ exports[`version does not include any release information if a message with simp
 # Releases
 
 > All release information have been omitted from this message, as the content exceeds the size limit.",
+    "draft": false,
     "head": "changeset-release/some-branch",
     "owner": "changesets",
     "repo": "action",
@@ -65,6 +67,7 @@ exports[`version does not include changelog entries if full message exceeds size
 ## simple-project-pkg-a@1.1.0
 
 ",
+    "draft": false,
     "head": "changeset-release/some-branch",
     "owner": "changesets",
     "repo": "action",
@@ -87,6 +90,7 @@ exports[`version doesn't include ignored package that got a dependency update in
 
 -   Awesome feature
 ",
+    "draft": false,
     "head": "changeset-release/some-branch",
     "owner": "changesets",
     "repo": "action",
@@ -109,6 +113,7 @@ exports[`version only includes bumped packages in the PR body 1`] = `
 
 -   Awesome feature
 ",
+    "draft": false,
     "head": "changeset-release/some-branch",
     "owner": "changesets",
     "repo": "action",

--- a/actions/signed-commits/src/__snapshots__/run.test.ts.snap
+++ b/actions/signed-commits/src/__snapshots__/run.test.ts.snap
@@ -34,6 +34,40 @@ exports[`version creates simple PR 1`] = `
 ]
 `;
 
+exports[`version creates simple PR in draft mode with do-not-merge label 1`] = `
+[
+  {
+    "base": "some-branch",
+    "body": "This PR was opened by the [Changesets release](https://github.com/changesets/action) GitHub action. When you're ready to do a release, you can merge this and publish to npm yourself or [setup this action to publish automatically](https://github.com/changesets/action#with-publishing). If you're not ready to do a release yet, that's fine, whenever you add more changesets to some-branch, this PR will be updated.
+
+
+# Releases
+## simple-project-pkg-a@1.1.0
+
+### Minor Changes
+
+-   Awesome feature
+
+### Patch Changes
+
+-   Updated dependencies
+    -   simple-project-pkg-b@1.1.0
+
+## simple-project-pkg-b@1.1.0
+
+### Minor Changes
+
+-   Awesome feature
+",
+    "draft": true,
+    "head": "changeset-release/some-branch",
+    "owner": "changesets",
+    "repo": "action",
+    "title": "Version Packages",
+  },
+]
+`;
+
 exports[`version does not include any release information if a message with simplified release info exceeds size limit 1`] = `
 [
   {

--- a/actions/signed-commits/src/index.ts
+++ b/actions/signed-commits/src/index.ts
@@ -30,7 +30,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
   core.info("setting GitHub credentials");
   await fs.writeFile(
     `${process.env.HOME}/.netrc`,
-    `machine github.com\nlogin github-actions[bot]\npassword ${githubToken}`
+    `machine github.com\nlogin github-actions[bot]\npassword ${githubToken}`,
   );
 
   let { changesets } = await readChangesetState();
@@ -38,7 +38,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
   let publishScript = core.getInput("publish");
   let hasChangesets = changesets.length !== 0;
   const hasNonEmptyChangesets = changesets.some(
-    (changeset) => changeset.releases.length > 0
+    (changeset) => changeset.releases.length > 0,
   );
   let hasPublishScript = !!publishScript;
 
@@ -52,7 +52,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
       return;
     case !hasChangesets && hasPublishScript: {
       core.info(
-        "No changesets found, attempting to publish any unpublished packages to npm"
+        "No changesets found, attempting to publish any unpublished packages to npm",
       );
 
       let userNpmrcPath = `${process.env.HOME}/.npmrc`;
@@ -65,22 +65,22 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
         });
         if (authLine) {
           core.info(
-            "Found existing auth token for the npm registry in the user .npmrc file"
+            "Found existing auth token for the npm registry in the user .npmrc file",
           );
         } else {
           core.info(
-            "Didn't find existing auth token for the npm registry in the user .npmrc file, creating one"
+            "Didn't find existing auth token for the npm registry in the user .npmrc file, creating one",
           );
           fs.appendFileSync(
             userNpmrcPath,
-            `\n//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}\n`
+            `\n//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}\n`,
           );
         }
       } else {
         core.info("No user .npmrc file found, creating one");
         fs.writeFileSync(
           userNpmrcPath,
-          `//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}\n`
+          `//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}\n`,
         );
       }
 
@@ -94,7 +94,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
         core.setOutput("published", "true");
         core.setOutput(
           "publishedPackages",
-          JSON.stringify(result.publishedPackages)
+          JSON.stringify(result.publishedPackages),
         );
       }
       return;
@@ -108,6 +108,8 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
         githubToken,
         prTitle: getOptionalInput("title"),
         commitMessage: getOptionalInput("commit"),
+        prDraft: core.getBooleanInput("prDraft"),
+        labels: getOptionalInput("labels"),
         hasPublishScript,
       });
 

--- a/actions/signed-commits/src/index.ts
+++ b/actions/signed-commits/src/index.ts
@@ -109,7 +109,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
         prTitle: getOptionalInput("title"),
         commitMessage: getOptionalInput("commit"),
         prDraft: core.getBooleanInput("prDraft"),
-        labels: getOptionalInput("labels"),
+        prLabels: getOptionalInput("prLabels"),
         hasPublishScript,
       });
 

--- a/actions/signed-commits/src/index.ts
+++ b/actions/signed-commits/src/index.ts
@@ -109,7 +109,6 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
         prTitle: getOptionalInput("title"),
         commitMessage: getOptionalInput("commit"),
         prDraft: core.getBooleanInput("prDraft"),
-        prLabels: getOptionalInput("prLabels"),
         hasPublishScript,
       });
 

--- a/actions/signed-commits/src/run.test.ts
+++ b/actions/signed-commits/src/run.test.ts
@@ -40,9 +40,6 @@ let mockedGithubMethods = {
   pulls: {
     create: jest.fn(),
   },
-  issues: {
-    addLabels: jest.fn(),
-  },
   repos: {
     createRelease: jest.fn(),
     getBranch: jest.fn().mockReturnValue({ data: { commit: { sha: "abc" } } }),
@@ -159,7 +156,6 @@ describe("version", () => {
       githubToken: "@@GITHUB_TOKEN",
       cwd,
       prDraft: true,
-      prLabels: "do-not-merge",
     });
 
     expect(mockedGithubMethods.pulls.create.mock.calls[0]).toMatchSnapshot();

--- a/actions/signed-commits/src/run.test.ts
+++ b/actions/signed-commits/src/run.test.ts
@@ -121,7 +121,7 @@ describe("version", () => {
     expect(mockedGithubMethods.pulls.create.mock.calls[0]).toMatchSnapshot();
   });
 
-  it("creates simple PR in draft mode with do-not-merge label", async () => {
+  it("creates simple PR in draft mode", async () => {
     const cwd = f.copy("simple-project");
     setupRepo(cwd);
 

--- a/actions/signed-commits/src/run.test.ts
+++ b/actions/signed-commits/src/run.test.ts
@@ -159,7 +159,7 @@ describe("version", () => {
       githubToken: "@@GITHUB_TOKEN",
       cwd,
       prDraft: true,
-      labels: "do-not-merge",
+      prLabels: "do-not-merge",
     });
 
     expect(mockedGithubMethods.pulls.create.mock.calls[0]).toMatchSnapshot();

--- a/actions/signed-commits/src/run.ts
+++ b/actions/signed-commits/src/run.ts
@@ -317,7 +317,7 @@ export async function runVersion({
   cwd = process.cwd(),
   prTitle = "Version Packages",
   commitMessage = "Version Packages",
-  prDraft,
+  prDraft = false,
   labels = "",
   hasPublishScript = false,
   prBodyMaxCharacters = MAX_CHARACTERS_PER_MESSAGE,

--- a/actions/signed-commits/src/run.ts
+++ b/actions/signed-commits/src/run.ts
@@ -302,7 +302,6 @@ type VersionOptions = {
   prTitle?: string;
   commitMessage?: string;
   prDraft?: boolean;
-  prLabels?: string;
   hasPublishScript?: boolean;
   prBodyMaxCharacters?: number;
 };
@@ -318,7 +317,6 @@ export async function runVersion({
   prTitle = "Version Packages",
   commitMessage = "Version Packages",
   prDraft = false,
-  prLabels = "",
   hasPublishScript = false,
   prBodyMaxCharacters = MAX_CHARACTERS_PER_MESSAGE,
 }: VersionOptions): Promise<RunVersionResult> {
@@ -448,15 +446,6 @@ export async function runVersion({
       body: prBody,
       ...github.context.repo,
     });
-
-    if (prLabels) {
-      const labelsArray = prLabels.split(",");
-      await octokit.rest.issues.addLabels({
-        issue_number: newPullRequest.number,
-        labels: labelsArray,
-        ...github.context.repo,
-      });
-    }
 
     return {
       pullRequestNumber: newPullRequest.number,

--- a/actions/signed-commits/src/run.ts
+++ b/actions/signed-commits/src/run.ts
@@ -301,6 +301,8 @@ type VersionOptions = {
   cwd?: string;
   prTitle?: string;
   commitMessage?: string;
+  prDraft?: boolean;
+  labels?: string;
   hasPublishScript?: boolean;
   prBodyMaxCharacters?: number;
 };
@@ -315,6 +317,8 @@ export async function runVersion({
   cwd = process.cwd(),
   prTitle = "Version Packages",
   commitMessage = "Version Packages",
+  prDraft,
+  labels = "",
   hasPublishScript = false,
   prBodyMaxCharacters = MAX_CHARACTERS_PER_MESSAGE,
 }: VersionOptions): Promise<RunVersionResult> {
@@ -440,9 +444,19 @@ export async function runVersion({
       base: branch,
       head: versionBranch,
       title: finalPrTitle,
+      draft: prDraft,
       body: prBody,
       ...github.context.repo,
     });
+
+    if (labels) {
+      const labelsArray = labels.split(",");
+      await octokit.rest.issues.addLabels({
+        issue_number: newPullRequest.number,
+        labels: labelsArray,
+        ...github.context.repo,
+      });
+    }
 
     return {
       pullRequestNumber: newPullRequest.number,

--- a/actions/signed-commits/src/run.ts
+++ b/actions/signed-commits/src/run.ts
@@ -302,7 +302,7 @@ type VersionOptions = {
   prTitle?: string;
   commitMessage?: string;
   prDraft?: boolean;
-  labels?: string;
+  prLabels?: string;
   hasPublishScript?: boolean;
   prBodyMaxCharacters?: number;
 };
@@ -318,7 +318,7 @@ export async function runVersion({
   prTitle = "Version Packages",
   commitMessage = "Version Packages",
   prDraft = false,
-  labels = "",
+  prLabels = "",
   hasPublishScript = false,
   prBodyMaxCharacters = MAX_CHARACTERS_PER_MESSAGE,
 }: VersionOptions): Promise<RunVersionResult> {
@@ -449,8 +449,8 @@ export async function runVersion({
       ...github.context.repo,
     });
 
-    if (labels) {
-      const labelsArray = labels.split(",");
+    if (prLabels) {
+      const labelsArray = prLabels.split(",");
       await octokit.rest.issues.addLabels({
         issue_number: newPullRequest.number,
         labels: labelsArray,


### PR DESCRIPTION
This adds a new input to `signed-commits` action:
```
  prDraft:
    description:
      A boolean value to indicate whether the pull request should be a draft or
      not. Default to `false`
    required: false
    default: "false"
```
