### PR TITLE
add pr-draft and pr-labels to cicd-changeset action

### DIFF
--- a/.changeset/heavy-rivers-check.md
+++ b/.changeset/heavy-rivers-check.md
@@ -1,0 +1,5 @@
+---
+"cicd-changesets": minor
+---
+
+Add pr-draft and pr-labels inputs

--- a/.changeset/heavy-rivers-check.md
+++ b/.changeset/heavy-rivers-check.md
@@ -2,4 +2,4 @@
 "cicd-changesets": minor
 ---
 
-Add pr-draft and pr-labels inputs
+Add optional pr-draft and pr-title inputs

--- a/actions/cicd-changesets/action.yml
+++ b/actions/cicd-changesets/action.yml
@@ -69,16 +69,27 @@ inputs:
     description: ""
     required: false
     default: "false"
+  pr-draft:
+    description: "whether to put the PR in draft mode or not"
+    required: false
+    default: "false"
+  pr-labels:
+    description: "comma-separated labels to add to the PR"
+    required: false
 outputs:
   published:
-    description: A boolean value to indicate whether a publishing is happened or not
+    description:
+      A boolean value to indicate whether a publishing is happened or not
     value: ${{ steps.changesets.outputs.published }}
   publishedPackages:
     description: >
-      A JSON array to present the published packages. The format is `[{"name": "@xx/xx", "version": "1.2.0"}, {"name": "@xx/xy", "version": "0.8.9"}]`
+      A JSON array to present the published packages. The format is `[{"name":
+      "@xx/xx", "version": "1.2.0"}, {"name": "@xx/xy", "version": "0.8.9"}]`
     value: ${{ steps.changesets.outputs.publishedPackages }}
   hasChangesets:
-    description: A boolean about whether there were changesets. Useful if you want to create your own publishing functionality.
+    description:
+      A boolean about whether there were changesets. Useful if you want to
+      create your own publishing functionality.
     value: ${{ steps.changesets.outputs.hasChangesets }}
   pullRequestNumber:
     description: The pull request number that was created or updated
@@ -123,7 +134,7 @@ runs:
 
     - name: Run changesets
       id: changesets
-      uses: smartcontractkit/.github/actions/signed-commits@95b6030f4d23d5d87f53eb0f018f51806afa4da3 # changesets-signed-commits@1.0.1
+      uses: smartcontractkit/.github/actions/signed-commits@re-2428/changeset-signed-commits-action
       env:
         GITHUB_TOKEN: ${{ steps.get-gh-token.outputs.access-token }}
       with:
@@ -131,6 +142,8 @@ runs:
         version: ${{ inputs.changesets-version-cmd }}
         createGithubReleases: ${{ inputs.changesets-create-gh-release }}
         setupGitUser: false
+        prDraft: ${{ inputs.pr-draft }}
+        prLabels: ${{ inputs.pr-labels }}
 
     - name: Check changesets output
       shell: bash

--- a/actions/cicd-changesets/action.yml
+++ b/actions/cicd-changesets/action.yml
@@ -69,6 +69,9 @@ inputs:
     description: ""
     required: false
     default: "false"
+  pr-title:
+    description: "title of the PR"
+    required: false
   pr-draft:
     description: "whether to put the PR in draft mode or not"
     required: false
@@ -134,7 +137,7 @@ runs:
 
     - name: Run changesets
       id: changesets
-      uses: smartcontractkit/.github/actions/signed-commits@re-2428/changeset-signed-commits-action
+      uses: smartcontractkit/.github/actions/signed-commits@re-2428/changeset-signed-commits-action # TODO update sha commit once new signed-commits package has been published
       env:
         GITHUB_TOKEN: ${{ steps.get-gh-token.outputs.access-token }}
       with:
@@ -142,6 +145,7 @@ runs:
         version: ${{ inputs.changesets-version-cmd }}
         createGithubReleases: ${{ inputs.changesets-create-gh-release }}
         setupGitUser: false
+        title: ${{ inputs.pr-title }}
         prDraft: ${{ inputs.pr-draft }}
         prLabels: ${{ inputs.pr-labels }}
 

--- a/actions/cicd-changesets/action.yml
+++ b/actions/cicd-changesets/action.yml
@@ -134,7 +134,7 @@ runs:
 
     - name: Run changesets
       id: changesets
-      uses: smartcontractkit/.github/actions/signed-commits@re-2428/changeset-signed-commits-action # TODO update sha commit once new signed-commits package has been published
+      uses: smartcontractkit/.github/actions/signed-commits@0cd5c6fa8a1af642a74a11d0ba26eb92f17b5865 # changesets-signed-commits@1.1.0
       env:
         GITHUB_TOKEN: ${{ steps.get-gh-token.outputs.access-token }}
       with:

--- a/actions/cicd-changesets/action.yml
+++ b/actions/cicd-changesets/action.yml
@@ -76,9 +76,6 @@ inputs:
     description: "whether to put the PR in draft mode or not"
     required: false
     default: "false"
-  pr-labels:
-    description: "comma-separated labels to add to the PR"
-    required: false
 outputs:
   published:
     description:
@@ -147,7 +144,6 @@ runs:
         setupGitUser: false
         title: ${{ inputs.pr-title }}
         prDraft: ${{ inputs.pr-draft }}
-        prLabels: ${{ inputs.pr-labels }}
 
     - name: Check changesets output
       shell: bash


### PR DESCRIPTION
This adds two new optional inputs to `cicd-changeset` action:

```
  pr-title:
    description: "title of the PR"
    required: false
  pr-draft:
    description: "whether to put the PR in draft mode or not"
    required: false
    default: "false"

```
