### PR TITLE
fix: cicd-changesets upsert pr draft mode

### DIFF
--- a/.changeset/slow-brooms-grow.md
+++ b/.changeset/slow-brooms-grow.md
@@ -1,0 +1,5 @@
+---
+"cicd-changesets": patch
+---
+
+Fixes draft mode for updating a PR during upsert

--- a/actions/cicd-changesets/action.yml
+++ b/actions/cicd-changesets/action.yml
@@ -150,6 +150,16 @@ runs:
       run: |
         echo "published: ${{ steps.changesets.outputs.published }}"
         echo "publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}"
+        echo "hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}"
+        echo "pullRequestNumber: ${{ steps.changesets.outputs.pullRequestNumber }}"
+
+    - name: Set PR to draft
+      shell: bash
+      if:
+        ${{ inputs.pr-draft == 'true' &&
+        steps.changesets.outputs.pullRequestNumber != '' }}
+      run: |
+        gh pr ready ${{ steps.changesets.outputs.pullRequestNumber }} --undo
 
     - name: Collect metrics
       if: always()

--- a/actions/cicd-changesets/action.yml
+++ b/actions/cicd-changesets/action.yml
@@ -158,6 +158,8 @@ runs:
       if:
         ${{ inputs.pr-draft == 'true' &&
         steps.changesets.outputs.pullRequestNumber != '' }}
+      env:
+        GH_TOKEN: ${{ steps.get-gh-token.outputs.access-token }}
       run: |
         gh pr ready ${{ steps.changesets.outputs.pullRequestNumber }} --undo
 


### PR DESCRIPTION
This fixes the issue where updating an existing PR does not include the draft mode option.
