### PR TITLE
fix: upsert pr with draft mode for signed-commits

### DIFF
--- a/.changeset/five-eels-listen.md
+++ b/.changeset/five-eels-listen.md
@@ -1,0 +1,5 @@
+---
+"changesets-signed-commits": patch
+---
+
+Fixes upsert existing PR with draft mode option

--- a/actions/signed-commits/src/run.ts
+++ b/actions/signed-commits/src/run.ts
@@ -457,7 +457,7 @@ export async function runVersion({
       pull_number: pullRequest.number,
       title: finalPrTitle,
       body: prBody,
-      state: "open",
+      ...(prDraft ? {} : { state: "open" }),
       ...github.context.repo,
     });
 


### PR DESCRIPTION
Fix based on this:
https://github.com/smartcontractkit/.github/pull/278#discussion_r1556434525