### PR TITLE
feat: support duplicating authorization header

### DIFF
--- a/.changeset/twelve-pants-reply.md
+++ b/.changeset/twelve-pants-reply.md
@@ -1,0 +1,5 @@
+---
+"setup-gap": patch
+---
+
+Update default proxy-version to v1.8 to support duplicate-headers parameter

--- a/actions/setup-gap/action.yml
+++ b/actions/setup-gap/action.yml
@@ -8,15 +8,19 @@ inputs:
     required: false
     default: "true"
   checkout-repo-fetch-depth:
-    description: "The number of commits to fetch. Defaults to 0 (all commits/history)."
+    description:
+      "The number of commits to fetch. Defaults to 0 (all commits/history)."
     required: false
     default: "0"
   # aws sig4 proxy inputs
   api-gateway-host:
-    description: "The AWS API Gateway host for the target service. Usually of the form <gateway id>.execute-api.<region>.amazonaws.com."
+    description: |
+      The AWS API Gateway host for the target service.
+      Usually of the form <gateway id>.execute-api.<region>.amazonaws.com.
     required: true
   proxy-version:
-    description: "The aws-sigv4-proxy image version / tag, if using the public ecr."
+    description:
+      "The aws-sigv4-proxy image version / tag, if using the public ecr."
     required: false
     default: "1.8"
   proxy-port:
@@ -32,33 +36,49 @@ inputs:
     default: "false"
   # ecr inputs
   use-private-ecr-registry:
-    description: "Whether to use a private ECR registry to pull the aws-sigv4-proxy image. Defaults to false."
+    description:
+      "Whether to use a private ECR registry to pull the aws-sigv4-proxy image.
+      Defaults to false."
     required: false
     default: "false"
   ecr-private-registry:
-    description: "The ECR registry (account id) for the aws-sigv4-proxy. Required if use-private-ecr-registry is true."
+    description:
+      "The ECR registry (account id) for the aws-sigv4-proxy. Required if
+      use-private-ecr-registry is true."
     required: false
   ecr-private-image-tag:
-    description: "The aws-sigv4-proxy image tag for the private ECR registry. Defaults to a known tag."
+    description:
+      "The aws-sigv4-proxy image tag for the private ECR registry. Defaults to a
+      known tag."
     required: false
     default: "6cc1e6d2bce23c04aace47d26511ad65205975b8"
   ecr-private-aws-region:
-    description: "The region for the private ECR registry, if different from aws-region input."
+    description:
+      "The region for the private ECR registry, if different from aws-region
+      input."
     required: false
   # aws role inputs
   aws-role-duration-seconds:
-    description: "The duration in seconds for the assumed role. Defaults to 900 (15 minutes)."
+    description:
+      "The duration in seconds for the assumed role. Defaults to 900 (15
+      minutes)."
     required: false
     default: "900"
   aws-region:
-    description: "The AWS region for the api gateway and other resources unless specified in other inputs"
+    description:
+      "The AWS region for the api gateway and other resources unless specified
+      in other inputs"
     required: false
   aws-role-arn:
-    description: "The AWS role with API Gateway invoke permissions, ECR pull permissions for aws-sigv4-proxy, and if for k8s then EKS describe permissions"
+    description:
+      "The AWS role with API Gateway invoke permissions, ECR pull permissions
+      for aws-sigv4-proxy, and if for k8s then EKS describe permissions"
     required: false
   # argocd inputs
   use-argocd:
-    description: "Whether to setup GAP for communicating with argocd. Cannot be used with use-k8s. Defaults to false."
+    description:
+      "Whether to setup GAP for communicating with argocd. Cannot be used with
+      use-k8s. Defaults to false."
     required: false
     default: "false"
   argocd-version:
@@ -66,21 +86,26 @@ inputs:
     required: false
     default: "2.8.2"
   argocd-user:
-    description: "The username for argocd login. Required if use-argocd is true."
+    description:
+      "The username for argocd login. Required if use-argocd is true."
     required: false
   argocd-pass:
-    description: "The password for argocd login. Required if use-argocd is true."
+    description:
+      "The password for argocd login. Required if use-argocd is true."
     required: false
   # k8s inputs
   use-k8s:
-    description: "Whether to setup GAP for communicating with K8s. Cannot be used with use-argocd. Defaults to false."
+    description:
+      "Whether to setup GAP for communicating with K8s. Cannot be used with
+      use-argocd. Defaults to false."
     required: false
     default: "false"
   k8s-cluster-name:
     description: "The EKS cluster name to target. Required if use-k8s is true."
     required: false
   k8s-cluster-aws-region:
-    description: "The region for the EKS cluster, if different from aws-region input."
+    description:
+      "The region for the EKS cluster, if different from aws-region input."
     required: false
   # grafana inputs
   metrics-job-name:
@@ -130,7 +155,6 @@ runs:
         echo "::debug::Generating new CA key+cert. Writing them to /tmp/setup-gap/ca.key and /tmp/setup-gap/ca.crt"
         openssl ecparam -genkey -name prime256v1 -out /tmp/setup-gap/ca.key
         openssl req -x509 -new -nodes -key /tmp/setup-gap/ca.key -sha256 -days 1 -out /tmp/setup-gap/ca.crt -subj "/CN=My CA"
-
 
     - name: Generate and Sign Server Certificate (K8s only)
       if: inputs.use-k8s == 'true'

--- a/actions/setup-gap/action.yml
+++ b/actions/setup-gap/action.yml
@@ -18,11 +18,18 @@ inputs:
   proxy-version:
     description: "The aws-sigv4-proxy image version / tag, if using the public ecr."
     required: false
-    default: "1.7"
+    default: "1.8"
   proxy-port:
     description: "The port the proxy will listen on. Defaults to 8080."
     required: false
     default: "8080"
+  duplicate-authorization-header:
+    description:
+      "Whether to duplicate the Authorization header to
+      X-Original-Authorization. Note this is only used by the public image, it
+      is on by default for the private image. Defaults to false."
+    required: false
+    default: "false"
   # ecr inputs
   use-private-ecr-registry:
     description: "Whether to use a private ECR registry to pull the aws-sigv4-proxy image. Defaults to false."
@@ -182,6 +189,11 @@ runs:
         AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
         AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
       run: |
+        DUPLICATE_AUTH_HEADER_FLAG=""
+        if [ "${{ inputs.duplicate-authorization-header }}" == "true" ]; then
+          DUPLICATE_AUTH_HEADER_FLAG="--duplicate-headers Authorization"
+        fi
+
         docker run --rm -d \
           -e AWS_ACCESS_KEY_ID \
           -e AWS_SECRET_ACCESS_KEY \
@@ -190,7 +202,7 @@ runs:
           public.ecr.aws/aws-observability/aws-sigv4-proxy:${{ inputs.proxy-version }} \
           --name execute-api --region ${{ inputs.aws-region }} \
           --host "${{ inputs.api-gateway-host }}" \
-          --log-failed-requests
+          --log-failed-requests $DUPLICATE_AUTH_HEADER_FLAG
 
     - name: Login to AWS ECR (private ecr only)
       if: inputs.use-private-ecr-registry == 'true'


### PR DESCRIPTION
### Summary

We need `v1.8` of the `aws-sigv4-proxy` which supports the `--duplicate-headers <Header>` flag ([commit](https://github.com/awslabs/aws-sigv4-proxy/commit/5770ebf7f95b58bad15546a2d1827040d61ec611)).

