### PR TITLE
add check for version diff for helm-version-bump-receiver action

### DIFF
--- a/.changeset/tiny-lions-complain.md
+++ b/.changeset/tiny-lions-complain.md
@@ -1,0 +1,5 @@
+---
+"helm-version-bump-receiver": patch
+---
+
+Add check for chart version change with action fail and not create PR

--- a/actions/helm-version-bump-receiver/action.yml
+++ b/actions/helm-version-bump-receiver/action.yml
@@ -117,7 +117,9 @@ runs:
         AWS_SESSION_TOKEN: ""
       with:
         cmd:
-          yq eval -i '.releases[] |= select(.name == "${{ inputs.app-release-name }}").version = "${{ inputs.helm-chart-version }}"' ${{ inputs.app-file-path-pattern }}
+          yq eval -i '.releases[] |= select(.name == "${{
+          inputs.app-release-name }}").version = "${{ inputs.helm-chart-version
+          }}"' ${{ inputs.app-file-path-pattern }}
 
     - name: Update helm chart repo
       if: inputs.helm-chart-repo-update == 'true'
@@ -129,15 +131,29 @@ runs:
         AWS_SESSION_TOKEN: ""
       with:
         cmd:
-          yq eval -i '.repositories[] |= select(.name == "infra-charts").url = "${{ inputs.helm-chart-repo }}"' ${{ inputs.app-file-path-pattern }}
+          yq eval -i '.repositories[] |= select(.name == "infra-charts").url =
+          "${{ inputs.helm-chart-repo }}"' ${{ inputs.app-file-path-pattern }}
+
+    - name: Check for changes
+      id: check-changes
+      shell: bash
+      run: |
+        if ! git diff --quiet; then
+          echo "Changes detected, proceeding with PR creation."
+        else
+          echo "No changes detected after updates. Failing the action."
+          exit 1
+        fi
 
     - name: Create PR to deploy
       id: create-pr
+      if: success()
       uses: peter-evans/create-pull-request@70a41aba780001da0a30141984ae2a0c95d8704e # v6.0.2
       with:
         base: ${{ inputs.pr-base-branch }}
         branch:
-          auto/${{ inputs.app-release-name}}/helm-${{ inputs.helm-chart-version }}-${{ inputs.release-type }}
+          auto/${{ inputs.app-release-name}}/helm-${{ inputs.helm-chart-version
+          }}-${{ inputs.release-type }}
         draft: ${{ inputs.pr-draft }}
         labels: ${{ inputs.pr-labels }}
         title:

--- a/actions/helm-version-bump-receiver/action.yml
+++ b/actions/helm-version-bump-receiver/action.yml
@@ -72,7 +72,7 @@ inputs:
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
-    default: ci-lint
+    default: helm-version-bump-pr
   gc-host:
     description: "grafana hostname"
     required: false


### PR DESCRIPTION
This updates the `helm-version-bump-receiver` action to have a check to see whether there is a diff between the two helm chart versions and fail if there is no diff.

Tested here:
https://github.com/smartcontractkit/infra-k8s/actions/runs/8709381344/job/23888911387