### PR TITLE
fix: ci-publish-npm add title to github release

### DIFF
--- a/.changeset/brown-brooms-beg.md
+++ b/.changeset/brown-brooms-beg.md
@@ -1,0 +1,5 @@
+---
+"ci-publish-npm": minor
+---
+
+Populate Github release with title instead of only relying on tag name.

--- a/actions/ci-publish-npm/action.yml
+++ b/actions/ci-publish-npm/action.yml
@@ -51,4 +51,4 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
-        gh release create ${{ inputs.github-release-tag-name }} --notes "View the changelog at [${{ inputs.github-release-changelog-path }}](${{ inputs.github-release-changelog-path }})"
+        gh release create ${{ inputs.github-release-tag-name }} --title ${{ inputs.github-release-tag-name }} --notes "View the changelog at [${{ inputs.github-release-changelog-path }}](${{ inputs.github-release-changelog-path }})"


### PR DESCRIPTION
### Summary

During  the `gh release create` for `ci-publish-npm` action, pass `--title` parameter as well. 

This creates basically no visible difference to the release. The difference can be seen when querying the API. 

When listing releases ([api](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#list-releases)) there's two fields
```
    "tag_name": "<tag>",
    "name": "<title>",
```

`name` here is `null` if `--title <tag>` is not passed. This created issues with the github slack announcement integration where it uses the `name` field with no fallback mechanism.

> New release published by [github-actions[bot]](https://github.com/apps/github-actions)
> [Release - undefined](https://github.com/smartcontractkit/chainlink/releases/tag/contracts-v1.1.0)

