### PR TITLE
fix: tag-branch-check script

### DIFF
--- a/actions/guard-tag-from-branch/scripts/tag-branch-check.sh
+++ b/actions/guard-tag-from-branch/scripts/tag-branch-check.sh
@@ -15,7 +15,7 @@ if [[ -z "${BRANCH_REGEX:-}" ]]; then
 fi
 
 # Get the sha of the tag's ancestor commit
-TAG_SHA=$(git rev-parse "${TAG}^{commit}")
+TAG_SHA=$(git rev-parse "origin/${TAG}^{commit}")
 echo "::debug::TAG_SHA: ${TAG_SHA}"
 SOURCE_BRANCHES=$(git branch -a --contains "${TAG_SHA}" | grep -v '(detached from' | sed 's/^\* //' | awk '{print $1}')
 echo "::debug::SOURCE_BRANCHES: ${SOURCE_BRANCHES}"


### PR DESCRIPTION
This should fix this error about `fatal: ambiguous argument 'main^{commit}': unknown revision or path not in the working tree.`
https://github.com/smartcontractkit/mercury-pipeline/actions/runs/8635900445/job/23680380899#step:3:15

Tested here:
https://github.com/smartcontractkit/mercury-pipeline/actions/runs/8822235380/job/24219938510#step:3:15
