### PR TITLE
chore: bump azure/setup-helm to v4.2.0

### DIFF
--- a/.changeset/sharp-sloths-sing.md
+++ b/.changeset/sharp-sloths-sing.md
@@ -1,0 +1,5 @@
+---
+"cicd-build-publish-charts": patch
+---
+
+bump azure/setup-helm to v4.2.0

--- a/actions/cicd-build-publish-charts/action.yml
+++ b/actions/cicd-build-publish-charts/action.yml
@@ -67,7 +67,7 @@ runs:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 
     - name: Setup helm
-      uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
+      uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
       with:
         version: v3.12.0
 


### PR DESCRIPTION
Found this `node16` reference in the wild. Need to update this action.