### PR TITLE
fix: edge case for replacing with quoted yaml

### DIFF
--- a/.changeset/clever-pots-rush.md
+++ b/.changeset/clever-pots-rush.md
@@ -1,0 +1,5 @@
+---
+"actions-dependencies-updater": patch
+---
+
+fix: when replacing text on line with single or double quotes

--- a/apps/actions-dependencies-updater/src/updater.mts
+++ b/apps/actions-dependencies-updater/src/updater.mts
@@ -179,7 +179,7 @@ export async function performUpdates(ctx: RunContext) {
       );
 
       const fileStr = await readFile(file, "utf-8");
-      const regex = new RegExp(`${action}@${ref}( #.*)?`, "g");
+      const regex = new RegExp(`["']?${action}@${ref}["']?( #.*)?`, "g");
       const newFileStr = fileStr.replaceAll(
         regex,
         `${action}@${update.newVersion.sha} # ${update.newVersion.version}`,


### PR DESCRIPTION
Found an issue where a repository had `uses: "actions/checkout@v3"`, this broke the text replacement which was not expecting any quotations.