### PR TITLE
feat: actions-updater workflow_call, and caching improvements

### DIFF
--- a/.changeset/angry-panthers-leave.md
+++ b/.changeset/angry-panthers-leave.md
@@ -1,0 +1,5 @@
+---
+"actions-dependencies-updater": minor
+---
+
+feat: actions dependencies caching

--- a/.changeset/modern-worms-hide.md
+++ b/.changeset/modern-worms-hide.md
@@ -1,0 +1,5 @@
+---
+"actions-dependencies-updater": minor
+---
+
+feat: support for parsing workflow_call jobs

--- a/.changeset/shiny-lies-invite.md
+++ b/.changeset/shiny-lies-invite.md
@@ -1,0 +1,6 @@
+---
+"actions-dependencies-updater": minor
+---
+
+feat: --skip-checks flag to only perform updates and help circumvent rate
+limiting

--- a/apps/actions-dependencies-updater/README.md
+++ b/apps/actions-dependencies-updater/README.md
@@ -47,6 +47,7 @@ pnpm start --repo-dir=<path to repository>
 - If you're _not_ using `direnv` then you will need to export or inline the
   `GH_ACCESS_TOKEN` environment variable.
   - For example: `GH_ACCESS_TOKEN="<pat>" pnpm start ...`
+- If you start experiencing Github API rate-limits, try the `--skip-checks` flag
 
 ### Examples
 
@@ -62,3 +63,8 @@ pnpm start --repo-dir=<path to repository>
 
 - Only check for deprecated action dependencies, perform no updates
   - `pnpm start --repo-dir=/Users/user/repos/chainlink --skip-updates`
+
+- Only perform updates, don't check for deprecated dependencies
+  - `pnpm start --repo-dir=/Users/user/repos/chainlink --skip-checks`
+
+

--- a/apps/actions-dependencies-updater/src/caches.mts
+++ b/apps/actions-dependencies-updater/src/caches.mts
@@ -1,6 +1,7 @@
 import * as log from "./logger.mjs";
 import { GithubShaToVersionCache } from "./github.mjs";
 import { UpdateTransaction } from "./updater.mjs";
+import { ActionsByIdentifier } from "./workflows.mjs";
 
 import { join } from "node:path";
 
@@ -9,6 +10,11 @@ export function initialize(forceRefresh: boolean) {
     shaToVersion: new Cache<GithubShaToVersionCache>(
       true,
       "sha-to-version.json",
+      forceRefresh,
+    ),
+    actionsByIdentifier: new Cache<ActionsByIdentifier>(
+      true,
+      "actions-by-identifier.json",
       forceRefresh,
     ),
     updateTransactions: new Cache<UpdateTransaction>(

--- a/apps/actions-dependencies-updater/src/caches.mts
+++ b/apps/actions-dependencies-updater/src/caches.mts
@@ -17,6 +17,12 @@ export function initialize(forceRefresh: boolean) {
       "actions-by-identifier.json",
       forceRefresh,
     ),
+    directActionsDependencies: new Cache<Record<string, boolean>>(
+      false,
+      "direct-actions-dependencies.json",
+      true,
+      {},
+    ),
     updateTransactions: new Cache<UpdateTransaction>(
       false,
       `updates-transactions.json`,

--- a/apps/actions-dependencies-updater/src/github.mts
+++ b/apps/actions-dependencies-updater/src/github.mts
@@ -163,6 +163,7 @@ async function getAllTags(
   repo: string,
 ): Promise<GitVersionTag[]> {
   try {
+    ctx.debug.tagRequests++;
     const response = (await ctx.octokit.request(
       "GET /repos/{owner}/{repo}/git/matching-refs/tags",
       { owner, repo },
@@ -207,6 +208,7 @@ async function getCommitForAnnotatedTag(
   apiPath: string,
 ): Promise<string | undefined> {
   try {
+    ctx.debug.tagRequests++;
     const response = (await ctx.octokit.request(
       "GET " + apiPath,
     )) as GetTagResponse;
@@ -243,7 +245,7 @@ export async function getActionFile(
   const yamlPath = join(repoPath, "action.yaml");
 
   let actionFile = await getFile(
-    ctx.octokit,
+    ctx,
     owner,
     repo,
     ymlPath,
@@ -251,7 +253,7 @@ export async function getActionFile(
   );
   if (!actionFile) {
     actionFile = await getFile(
-      ctx.octokit,
+      ctx,
       owner,
       repo,
       yamlPath,
@@ -262,7 +264,7 @@ export async function getActionFile(
 }
 
 export async function getFile(
-  octokit: Octokit,
+  ctx: RunContext,
   owner: string,
   repo: string,
   path: string,
@@ -281,7 +283,8 @@ export async function getFile(
       `Getting file through Github - ${owner}/${repo}@${ref}, file: ${path}`,
     );
 
-    const response = await octokit.rest.repos.getContent({
+    ctx.debug.contentRequests++;
+    const response = await ctx.octokit.rest.repos.getContent({
       owner,
       repo,
       path,

--- a/apps/actions-dependencies-updater/src/github.mts
+++ b/apps/actions-dependencies-updater/src/github.mts
@@ -42,11 +42,8 @@ export async function getVersionFromSHA(
   const GH_SHA_TO_VER_CACHE = ctx.caches.shaToVersion.get();
 
   if (!GH_SHA_TO_VER_CACHE[ownerRepo] || !GH_SHA_TO_VER_CACHE[ownerRepo][ref]) {
-    log.debug(`Cache miss for ${owner}/${repo}@${ref}`);
-    return await getVersion(ctx, owner, repo, ref);
+    addToCache(ctx, ownerRepo, ref, await getVersion(ctx, owner, repo, ref));
   }
-
-  log.debug(`Cache hit for ${owner}/${repo}@${ref}`);
 
   if (repo === ".github" && repoPath) {
     const actionName = repoPath.split("/").pop();
@@ -54,9 +51,7 @@ export async function getVersionFromSHA(
       const monorepoVersions = GH_SHA_TO_VER_CACHE[ownerRepo][ref].filter((v) =>
         v.startsWith(actionName),
       );
-      if (monorepoVersions.length > 0) {
-        return guessLatestVersion(monorepoVersions).tag;
-      }
+      return monorepoVersions[0];
     }
   }
 

--- a/apps/actions-dependencies-updater/src/github.mts
+++ b/apps/actions-dependencies-updater/src/github.mts
@@ -275,7 +275,7 @@ export async function getFile(
     if (path.startsWith("./")) path = path.substring(2);
 
     if (path === "") {
-      log.warn("Empty path provided to github.getFile. Returning empty.");
+      log.error("Empty path provided to github.getFile. Returning empty.");
       return;
     }
 

--- a/apps/actions-dependencies-updater/src/index.mts
+++ b/apps/actions-dependencies-updater/src/index.mts
@@ -11,7 +11,6 @@ import 'dotenv/config';
 
 export interface RunContext {
   repoDir: string;
-  debug: boolean;
   skipChecks: boolean;
   skipUpdates: boolean;
   git: {
@@ -20,10 +19,16 @@ export interface RunContext {
     reset: boolean;
   };
   octokit: Octokit;
+  debug: {
+    workflows: number;
+    actions: number;
+    contentRequests: number;
+    tagRequests: number;
+  },
   caches: ReturnType<typeof caches.initialize>;
 }
 
-function handleArgs() {
+function handleArgs(): RunContext {
   const defaults = {
     debug: false,
     changes: true,
@@ -74,7 +79,12 @@ function handleArgs() {
     repoDir,
     skipUpdates: args["skip-updates"] as boolean,
     skipChecks: args["skip-checks"] as boolean,
-    debug: args["debug"] as boolean,
+    debug: {
+      workflows: 0,
+      actions: 0,
+      contentRequests: 0,
+      tagRequests: 0,
+    },
     git: {
       branch: args["branch"] as boolean,
       commit: args["commit"] as boolean,
@@ -123,6 +133,7 @@ async function main() {
     outputDeprecatedPaths(ctx, true, postUpdateDeprecatedPaths);
   }
 
+  log.debug(ctx.debug);
   persistCache(ctx);
 }
 
@@ -137,6 +148,7 @@ function outputDeprecatedPaths(ctx: RunContext, shouldExit: boolean, deprecatedP
   }
 
   if (shouldExit) {
+    log.debug(ctx.debug);
     process.exit(deprecatedPaths.length > 0 ? 1 : 0);
   }
 }

--- a/apps/actions-dependencies-updater/src/index.mts
+++ b/apps/actions-dependencies-updater/src/index.mts
@@ -157,10 +157,12 @@ function persistCache(ctx: RunContext) {
   // Clear part of the actionsByIdentifier cache before persisting
   // 1. Delete local actions as they could clash across repos with the same filenames (not unique)
   // 2. Delete any actions that are not sha references as the contents could change (ref not immutable)
-  // 3. Clear reference paths as they could clash between checks in same or other repos
+  // 3. Delete actions with type unknown as they were not fully processed, and should no be cached.
+  // 4. Clear reference paths as they could clash between checks in same or other repos
   const actionsByIdentifier = ctx.caches.actionsByIdentifier.get();
   Object.keys(actionsByIdentifier).forEach((key) => {
-    if (key.startsWith("./") || !isShaRefIdentifier(key)) {
+    const action = actionsByIdentifier[key];
+    if (action.isLocal || action.type === "unknown" || !isShaRefIdentifier(action.identifier)) {
       log.debug(`Clearing ${key} from cache`);
       return delete actionsByIdentifier[key];
     }

--- a/apps/actions-dependencies-updater/src/index.mts
+++ b/apps/actions-dependencies-updater/src/index.mts
@@ -161,6 +161,7 @@ function persistCache(ctx: RunContext) {
   const actionsByIdentifier = ctx.caches.actionsByIdentifier.get();
   Object.keys(actionsByIdentifier).forEach((key) => {
     if (key.startsWith("./") || !isShaRefIdentifier(key)) {
+      log.debug(`Clearing ${key} from cache`);
       return delete actionsByIdentifier[key];
     }
     actionsByIdentifier[key].referencePaths = [];

--- a/apps/actions-dependencies-updater/src/updater.mts
+++ b/apps/actions-dependencies-updater/src/updater.mts
@@ -82,6 +82,11 @@ async function processActionDependency(
     return Promise.all(dependenciesPromises).then(() => {});
   }
 
+  if (!ctx.caches.directActionsDependencies.getValue(action.identifier)) {
+    log.debug(`Skipping indirect dependency: ${action.identifier}`);
+    return;
+  }
+
   const details = extractDetailsFromActionIdentifier(action.identifier);
   if (!details) {
     log.warn(`Unexpected action identifier: ${action.identifier} - skipping.`);

--- a/apps/actions-dependencies-updater/src/updater.mts
+++ b/apps/actions-dependencies-updater/src/updater.mts
@@ -74,7 +74,7 @@ async function processActionDependency(
       join(ctx.repoDir, currentAction.identifier),
     );
 
-    if (!actionPath) {
+    if (!actionPath || !currentAction.dependencies) {
       return;
     }
 

--- a/apps/actions-dependencies-updater/src/updater.mts
+++ b/apps/actions-dependencies-updater/src/updater.mts
@@ -40,7 +40,7 @@ export async function compileUpdates(
     for (const job of workflow.jobs) {
       log.debug(`Job: ${job.name}`);
 
-      for (const dependency of job.directDependencies) {
+      for (const dependency of job.dependencies) {
         allPromises.push(
           processActionDependency(ctx, dependency, workflow.path),
         );
@@ -142,19 +142,19 @@ function saveUpdateTransaction(
   innerRepoPath?: string,
 ) {
   const entry =   ctx.caches.updateTransactions
-    .getValueOrDefault(`${owner}/${repo}${innerRepoPath || ""}`, {
+  .getValueOrDefault(`${owner}/${repo}${innerRepoPath || ""}`, {
     identifiers: [],
-      references: [],
-      newVersion: {
-        sha: newRef,
-        version: newVersion,
-      },
+    references: [],
+    newVersion: {
+      sha: newRef,
+      version: newVersion,
+    },
   });
 
   entry.references.push({
-      file: filePath,
-      ref: existingRef,
-    });
+    file: filePath,
+    ref: existingRef,
+  });
 
   entry.identifiers.push(identifier);
 }

--- a/apps/actions-dependencies-updater/src/utils.mts
+++ b/apps/actions-dependencies-updater/src/utils.mts
@@ -58,7 +58,7 @@ export function guessLatestVersion(
 ) {
   let versions: VersionIdentifier[] = tags
     .map((tag) => parseTagToVersion(tag))
-    .filter((v) => v) as VersionIdentifier[];
+    .filter((v) => !!v) as VersionIdentifier[];
 
   // support for the .github monorepo
   if (repo === ".github" && repoPath) {
@@ -98,7 +98,7 @@ function parseTagToVersion(tag: string) {
   const coerced = semver.coerce(tag);
 
   if (!coerced) {
-    log.error(`Failed to parse version from tag: ${tag}`);
+    log.debug(`Failed to parse version from tag: ${tag}`);
     return;
   }
 

--- a/apps/actions-dependencies-updater/src/utils.mts
+++ b/apps/actions-dependencies-updater/src/utils.mts
@@ -86,9 +86,13 @@ type VersionIdentifier = NonNullable<ReturnType<typeof parseTagToVersion>>;
  * @returns The version object
  */
 function parseTagToVersion(tag: string) {
-  const originalTag = tag;
+  if (tag.startsWith("untagged-")) {
+    return;
+  }
 
+  const originalTag = tag;
   let prefix = "";
+
   if (tag.includes("@")) {
     const parts = tag.split("@");
     tag = parts[1];
@@ -96,7 +100,6 @@ function parseTagToVersion(tag: string) {
   }
 
   const coerced = semver.coerce(tag);
-
   if (!coerced) {
     log.debug(`Failed to parse version from tag: ${tag}`);
     return;

--- a/apps/actions-dependencies-updater/src/utils.mts
+++ b/apps/actions-dependencies-updater/src/utils.mts
@@ -174,3 +174,16 @@ function createPathStrings(action: Action): string[] {
     [...path, action.identifier, action.type].join(" -> "),
   );
 }
+
+/**
+ * Given an action identifier, check if it uses a sha reference. This is to ensure that the parsed
+ * action was from an immutable reference.
+ * @param identifier the action identifier
+ * @returns true if the identifier is a sha reference
+ */
+export function isShaRefIdentifier(identifier: string) {
+  const sha1Regex = /^[0-9a-f]{40}$/;
+  const sha256Regex = /^[0-9a-f]{256}$/;
+  const ref = identifier.split("@")[1];
+  return (ref && sha1Regex.test(ref)) || sha256Regex.test(ref);
+}

--- a/apps/actions-dependencies-updater/src/utils.mts
+++ b/apps/actions-dependencies-updater/src/utils.mts
@@ -38,8 +38,10 @@ export function validateRepositoryOrExit(repoDir: string) {
   }
 
   const workflowDir = join(repoDir, ".github", "workflows");
-  if(!existsSync(workflowDir)) {
-    log.info(`No workflows directory found: ${workflowDir} - nothing to check/update`);
+  if (!existsSync(workflowDir)) {
+    log.info(
+      `No workflows directory found: ${workflowDir} - nothing to check/update`,
+    );
     process.exit(0);
   }
 }
@@ -147,25 +149,22 @@ export async function getActionYamlPath(directory: string) {
 }
 
 export function compileDeprecatedPaths(workflowsByName: WorkflowByName) {
-  const deprecatedPaths: string[] = [];
+  const allDeprecatedPaths: string[] = [];
 
   for (const workflow of Object.values(workflowsByName)) {
     for (const job of workflow.jobs) {
-      for (const dependency of job.directDependencies) {
-        if (dependency.type === "node12" || dependency.type === "node16") {
-          deprecatedPaths.push(...createPathStrings(dependency));
-        }
-      }
-
-      for (const dependency of job.indirectDependencies ?? []) {
-        if (dependency.type === "node12" || dependency.type === "node16") {
-          deprecatedPaths.push(...createPathStrings(dependency));
-        }
-      }
+      const deprecatedPaths = job.dependencies
+        .filter(
+          (dependency) =>
+            dependency.type === "node12" || dependency.type === "node16",
+        )
+        .map(createPathStrings)
+        .flat();
+      allDeprecatedPaths.push(...deprecatedPaths);
     }
   }
 
-  const uniquePaths = Array.from(new Set(deprecatedPaths)).sort();
+  const uniquePaths = Array.from(new Set(allDeprecatedPaths)).sort();
   return uniquePaths;
 }
 

--- a/apps/actions-dependencies-updater/src/workflows.mts
+++ b/apps/actions-dependencies-updater/src/workflows.mts
@@ -102,6 +102,7 @@ export async function parseWorkflows(ctx: RunContext) {
  */
 async function parseWorkflow(ctx: RunContext, path: string): Promise<Workflow> {
   const file = basename(path);
+  ctx.debug.workflows++;
 
   log.debug(`Processing workflow: ${file}`);
 
@@ -254,6 +255,7 @@ async function parseActionFromIdentifier(
     return;
   }
 
+  ctx.debug.actions++;
   const action = await parseActionFile(
     identifier,
     referencePath,
@@ -471,5 +473,5 @@ async function getWorkflowYamlFromIdentifier(
   const details = extractDetailsFromActionIdentifier(identifier);
   if (!details) return;
   const { owner, repo, repoPath, ref } = details;
-  return github.getFile(ctx.octokit, owner, repo, repoPath, ref);
+  return github.getFile(ctx, owner, repo, repoPath, ref);
 }


### PR DESCRIPTION
This introduces three new features to the `actions-dependencies-updater`

1. Partial support for `workflow_call` jobs, that is jobs which invoke a workflow rather than have steps
2. A `--skip-checks` flag to skip the recursive dependency checks
3. Debug information tracking for requests to github due to rate limits
4. Cache parsed actions to speed up processing (immutable references only)
5. A runtime cache to track which dependencies are direct, to limit unnecessary requests to github

### Testing

Will test on some repos once I'm no longer rate limited. 
