### PR TITLE
RE-1943: Fixing the optional role session name input on setup-github-token

### DIFF
--- a/.changeset/fast-drinks-reflect.md
+++ b/.changeset/fast-drinks-reflect.md
@@ -1,0 +1,5 @@
+---
+"setup-github-token": patch
+---
+
+Fixing the optional role session name input on setup-github-token

--- a/actions/setup-github-token/action.yml
+++ b/actions/setup-github-token/action.yml
@@ -39,7 +39,9 @@ runs:
         ROLE_SESSION_NAME: ${{ inputs.role-session-name }}
       run: |
         if [[ ${#ROLE_SESSION_NAME} -gt 64 ]]; then
-          echo "role-session-name=$(echo "$ROLE_SESSION_NAME" | cut -c1-64)" >> "$GITHUB_OUTPUT"
+          echo "role-session-name=$(echo $ROLE_SESSION_NAME | cut -c1-64)" >> "$GITHUB_OUTPUT"
+        else
+          echo "role-session-name=$ROLE_SESSION_NAME" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Assume role capable of getting token from gati
@@ -48,7 +50,7 @@ runs:
         aws-region: ${{ inputs.aws-region }}
         mask-aws-account-id: true
         role-duration-seconds: ${{ inputs.aws-role-duration-seconds }}
-        role-session-name: ${{ inputs.role-session-name }}
+        role-session-name: ${{ steps.role-session-name.outputs.role-session-name }}
         role-to-assume: ${{ inputs.aws-role-arn }}
 
     - name: Get github token from gati


### PR DESCRIPTION
## What

The bug is introduced by me in the PR: https://github.com/smartcontractkit/.github/pull/418
Ticket: https://smartcontract-it.atlassian.net/browse/RE-1943

## Why

Making sure that we pass truncated version that isn't longer than 64 characters. We can't override the input in any case but can set an ENV variable from value from output and use it to pass value to the next step. 

## Testing 

PR:  https://github.com/smartcontractkit/releng-test/pull/32

Workflow: https://github.com/smartcontractkit/releng-test/actions/runs/9355569595/job/25751900742#step:2:30