### PR TITLE
The setup-gap action is commonly used in jobs that already have a metrics collection

### DIFF
--- a/.changeset/weak-lions-exist.md
+++ b/.changeset/weak-lions-exist.md
@@ -1,0 +1,6 @@
+---
+"setup-gap": minor
+---
+
+Collect metrics optionally since most use cases already have their own metrics
+collection outside of this actions usage.

--- a/actions/setup-gap/action.yml
+++ b/actions/setup-gap/action.yml
@@ -111,7 +111,6 @@ inputs:
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
-    default: setup-gap
   gc-host:
     description: "grafana hostname"
     required: false
@@ -282,7 +281,7 @@ runs:
         ${{ inputs.argocd-pass }}
 
     - name: Collect metrics
-      if: always()
+      if: always() && inputs.metrics-job-name != ''
       id: collect-gha-metrics
       uses: smartcontractkit/push-gha-metrics-action@e34ae8a4df60f4d9fdef1e32a69747bab130840e # v2.2.0
       with:


### PR DESCRIPTION
We don't want to push metrics for jobs that use this action and already do their own metrics collection