### PR TITLE
chore: update create-gh-action script

### DIFF
--- a/libs/nx-chainlink/src/generators/create-gh-action/files/composite/debug/action.yml.template
+++ b/libs/nx-chainlink/src/generators/create-gh-action/files/composite/debug/action.yml.template
@@ -15,15 +15,17 @@ inputs:
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
-    default: <%= name %>
+  metrics-id:
+    description: "grafana metrics id, used for continuity of metrics during job name changes  - required if metrics-job-name is passed"
+    required: false
   gc-host:
-    description: "grafana hostname"
+    description: "grafana hostname - required if metrics-job-name is passed"
     required: false
   gc-basic-auth:
-    description: "grafana basic auth"
+    description: "grafana basic auth - required if metrics-job-name is passed"
     required: false
   gc-org-id:
-    description: "grafana org/tenant id"
+    description: "grafana org/tenant id - required if metrics-job-name is passed"
     required: false
 
 runs:
@@ -40,10 +42,11 @@ runs:
       run: ${{ github.action_path }}/debug.sh
 
     - name: Collect metrics
-      if: always()
+      if: always() && inputs.metrics-job-name != ''
       id: collect-gha-metrics
-      uses: smartcontractkit/push-gha-metrics-action@0281b09807758be1dcc41651e44e62b353808c47 # v2.1.0
+      uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
       with:
+        id: ${{ inputs.metrics-id }}
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
         org-id: ${{ inputs.gc-org-id}}

--- a/libs/nx-chainlink/src/generators/create-gh-action/files/composite/default/action.yml.template
+++ b/libs/nx-chainlink/src/generators/create-gh-action/files/composite/default/action.yml.template
@@ -15,15 +15,17 @@ inputs:
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
-    default: <%= name %>
+  metrics-id:
+    description: "grafana metrics id, used for continuity of metrics during job name changes  - required if metrics-job-name is passed"
+    required: false
   gc-host:
-    description: "grafana hostname"
+    description: "grafana hostname - required if metrics-job-name is passed"
     required: false
   gc-basic-auth:
-    description: "grafana basic auth"
+    description: "grafana basic auth - required if metrics-job-name is passed"
     required: false
   gc-org-id:
-    description: "grafana org/tenant id"
+    description: "grafana org/tenant id - required if metrics-job-name is passed"
     required: false
 
 runs:
@@ -36,10 +38,11 @@ runs:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 
     - name: Collect metrics
-      if: always()
+      if: always() && inputs.metrics-job-name != ''
       id: collect-gha-metrics
-      uses: smartcontractkit/push-gha-metrics-action@0281b09807758be1dcc41651e44e62b353808c47 # v2.1.0
+      uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
       with:
+        id: ${{ inputs.metrics-id }}
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
         org-id: ${{ inputs.gc-org-id}}


### PR DESCRIPTION
For the`create-gh-action` script templates, updated `push-gha-metrics-action` to `v3.0.1`, and is now conditional based on `metrics-job-name` being passed