### PR TITLE
chore: bump push-gha-metrics-action to v3.0.1

### DIFF
--- a/.changeset/loud-buttons-approve.md
+++ b/.changeset/loud-buttons-approve.md
@@ -1,0 +1,26 @@
+---
+"cicd-build-publish-artifacts-go": patch
+"cicd-build-publish-artifacts-ts": patch
+"guard-from-missing-changesets": patch
+"helm-version-bump-receiver": patch
+"cicd-build-publish-charts": patch
+"cicd-changesets": patch
+"ci-kubeconform": patch
+"ci-lint-charts": patch
+"manifest-build": patch
+"setup-nix-gati": patch
+"update-actions": patch
+"llm-pr-writer": patch
+"ci-lint-misc": patch
+"ci-sonarqube": patch
+"ci-test-sol": patch
+"ci-lint-go": patch
+"ci-lint-ts": patch
+"ci-test-go": patch
+"ci-test-ts": patch
+"setup-gap": patch
+"setup-nix": patch
+"nx-chainlink": patch
+---
+
+Bump push-gha metrics action to v3.0.1, make Grafana inputs optional

--- a/actions/ci-kubeconform/action.yml
+++ b/actions/ci-kubeconform/action.yml
@@ -39,19 +39,21 @@ inputs:
     description: "charts directory"
     required: true
     default: "charts"
-  # grafana inputs
+  # grafana inputs (optional)
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
-    default: ci-kubeconform
+  metrics-id:
+    description: "grafana metrics id, used for continuity of metrics during job name changes - required if metrics-job-name is passed"
+    required: false
   gc-host:
-    description: "grafana hostname"
+    description: "grafana hostname - required if metrics-job-name is passed"
     required: false
   gc-basic-auth:
-    description: "grafana basic auth"
+    description: "grafana basic auth - required if metrics-job-name is passed"
     required: false
   gc-org-id:
-    description: "grafana org/tenant id"
+    description: "grafana org/tenant id - required if metrics-job-name is passed"
     required: false
 
 runs:
@@ -98,10 +100,11 @@ runs:
         helm template . | kubeconform -kubernetes-version ${{ inputs.kubernetes-version }} ${{ env.STRICT }} ${{ env.IGNORE_MISSING_SCHEMAS }} ${{ env.SUMMARY }}
 
     - name: Collect metrics
-      if: always()
+      if: always() && inputs.metrics-job-name != ''
       id: collect-gha-metrics
-      uses: smartcontractkit/push-gha-metrics-action@e34ae8a4df60f4d9fdef1e32a69747bab130840e # v2.2.0
+      uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
       with:
+        id: ${{ inputs.metrics-id || inputs.metrics-job-name }}
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
         org-id: ${{ inputs.gc-org-id}}

--- a/actions/ci-lint-charts/action.yml
+++ b/actions/ci-lint-charts/action.yml
@@ -24,19 +24,21 @@ inputs:
     description: "charts directory"
     required: false
     default: "charts"
-  # grafana inputs
+  # grafana inputs (optional)
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
-    default: ci-lint-charts
+  metrics-id:
+    description: "grafana metrics id, used for continuity of metrics during job name changes - required if metrics-job-name is passed"
+    required: false
   gc-host:
-    description: "grafana hostname"
+    description: "grafana hostname - required if metrics-job-name is passed"
     required: false
   gc-basic-auth:
-    description: "grafana basic auth"
+    description: "grafana basic auth - required if metrics-job-name is passed"
     required: false
   gc-org-id:
-    description: "grafana org/tenant id"
+    description: "grafana org/tenant id - required if metrics-job-name is passed"
     required: false
 
 runs:
@@ -71,10 +73,11 @@ runs:
         ct lint --config "${CHART_TESTING_CONFIG_PATH}" "${CHART_TESTING_EXTRA_ARGS}"
 
     - name: Collect metrics
-      if: always()
+      if: always() && inputs.metrics-job-name != ''
       id: collect-gha-metrics
-      uses: smartcontractkit/push-gha-metrics-action@e34ae8a4df60f4d9fdef1e32a69747bab130840e # v2.2.0
+      uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
       with:
+        id: ${{ inputs.metrics-id || inputs.metrics-job-name }}
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
         org-id: ${{ inputs.gc-org-id}}

--- a/actions/ci-lint-go/action.yml
+++ b/actions/ci-lint-go/action.yml
@@ -11,20 +11,6 @@ inputs:
     description: "number of commits to fetch"
     required: false
     default: "0"
-  # grafana inputs
-  metrics-job-name:
-    description: "grafana metrics job name"
-    required: false
-    default: ci-lint
-  gc-host:
-    description: "grafana hostname"
-    required: false
-  gc-basic-auth:
-    description: "grafana basic auth"
-    required: false
-  gc-org-id:
-    description: "grafana org/tenant id"
-    required: false
   # aws inputs
   aws-role-duration-seconds:
     description: ""
@@ -77,6 +63,22 @@ inputs:
   go-directory:
     description: ""
     default: .
+  # grafana inputs (optional)
+  metrics-job-name:
+    description: "grafana metrics job name"
+    required: false
+  metrics-id:
+    description: "grafana metrics id, used for continuity of metrics during job name changes - required if metrics-job-name is passed"
+    required: false
+  gc-host:
+    description: "grafana hostname - required if metrics-job-name is passed"
+    required: false
+  gc-basic-auth:
+    description: "grafana basic auth - required if metrics-job-name is passed"
+    required: false
+  gc-org-id:
+    description: "grafana org/tenant id - required if metrics-job-name is passed"
+    required: false
 
 runs:
   using: composite
@@ -146,10 +148,11 @@ runs:
         path: ${{ inputs.go-directory }}/golangci-lint-report.xml
 
     - name: Collect metrics
-      if: always()
+      if: always() && inputs.metrics-job-name != ''
       id: collect-gha-metrics
-      uses: smartcontractkit/push-gha-metrics-action@e34ae8a4df60f4d9fdef1e32a69747bab130840e # v2.2.0
+      uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
       with:
+        id: ${{ inputs.metrics-id || inputs.metrics-job-name }}
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
         org-id: ${{ inputs.gc-org-id}}

--- a/actions/ci-lint-misc/action.yml
+++ b/actions/ci-lint-misc/action.yml
@@ -11,19 +11,21 @@ inputs:
     description: "number of commits to fetch"
     required: false
     default: "0"
-  # grafana inputs
+  # grafana inputs (optional)
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
-    default: ci-lint-misc
+  metrics-id:
+    description: "grafana metrics id, used for continuity of metrics during job name changes - required if metrics-job-name is passed"
+    required: false
   gc-host:
-    description: "grafana hostname"
+    description: "grafana hostname - required if metrics-job-name is passed"
     required: false
   gc-basic-auth:
-    description: "grafana basic auth"
+    description: "grafana basic auth - required if metrics-job-name is passed"
     required: false
   gc-org-id:
-    description: "grafana org/tenant id"
+    description: "grafana org/tenant id - required if metrics-job-name is passed"
     required: false
 
 runs:
@@ -44,10 +46,11 @@ runs:
         scandir: "./tools/scripts"
 
     - name: Collect metrics
-      if: always()
+      if: always() && inputs.metrics-job-name != ''
       id: collect-gha-metrics
-      uses: smartcontractkit/push-gha-metrics-action@e34ae8a4df60f4d9fdef1e32a69747bab130840e # v2.2.0
+      uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
       with:
+        id: ${{ inputs.metrics-id || inputs.metrics-job-name }}
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
         org-id: ${{ inputs.gc-org-id}}

--- a/actions/ci-lint-ts/action.yml
+++ b/actions/ci-lint-ts/action.yml
@@ -19,21 +19,6 @@ inputs:
     description: ""
     required: false
     default: main
-  # grafana inputs
-  metrics-job-name:
-    description: "grafana metrics job name"
-    required: false
-    default: ci-lint
-  gc-host:
-    description: "grafana hostname"
-    required: false
-  gc-basic-auth:
-    description: "grafana basic auth"
-    required: false
-  gc-org-id:
-    description: "grafana org/tenant id"
-    required: false
-
   # nodejs inputs
   node-version-file:
     description: ""
@@ -43,6 +28,22 @@ inputs:
     description: ""
     required: false
     default: "^8.0.0"
+  # grafana inputs (optional)
+  metrics-job-name:
+    description: "grafana metrics job name"
+    required: false
+  metrics-id:
+    description: "grafana metrics id, used for continuity of metrics during job name changes - required if metrics-job-name is passed"
+    required: false
+  gc-host:
+    description: "grafana hostname - required if metrics-job-name is passed"
+    required: false
+  gc-basic-auth:
+    description: "grafana basic auth - required if metrics-job-name is passed"
+    required: false
+  gc-org-id:
+    description: "grafana org/tenant id - required if metrics-job-name is passed"
+    required: false
 
 runs:
   using: composite
@@ -73,10 +74,11 @@ runs:
       run: pnpm run lint:affected --base=${{ inputs.base-ref }}
 
     - name: Collect metrics
-      if: always()
+      if: always() && inputs.metrics-job-name != ''
       id: collect-gha-metrics
-      uses: smartcontractkit/push-gha-metrics-action@e34ae8a4df60f4d9fdef1e32a69747bab130840e # v2.2.0
+      uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
       with:
+        id: ${{ inputs.metrics-id || inputs.metrics-job-name }}
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
         org-id: ${{ inputs.gc-org-id}}

--- a/actions/ci-sonarqube/action.yml
+++ b/actions/ci-sonarqube/action.yml
@@ -11,20 +11,6 @@ inputs:
     description: "number of commits to fetch"
     required: false
     default: "0"
-  # grafana inputs
-  metrics-job-name:
-    description: "grafana metrics job name"
-    required: false
-    default: ci-sonarqube
-  gc-host:
-    description: "grafana hostname"
-    required: false
-  gc-basic-auth:
-    description: "grafana basic auth"
-    required: false
-  gc-org-id:
-    description: "grafana org/tenant id"
-    required: false
   # sonarqube inputs
   sonar-token:
     description: "sonarqube token"
@@ -36,6 +22,22 @@ inputs:
     description: "enable linting"
     required: false
     default: "false"
+  # grafana inputs (optional)
+  metrics-job-name:
+    description: "grafana metrics job name"
+    required: false
+  metrics-id:
+    description: "grafana metrics id, used for continuity of metrics during job name changes - required if metrics-job-name is passed"
+    required: false
+  gc-host:
+    description: "grafana hostname - required if metrics-job-name is passed"
+    required: false
+  gc-basic-auth:
+    description: "grafana basic auth - required if metrics-job-name is passed"
+    required: false
+  gc-org-id:
+    description: "grafana org/tenant id - required if metrics-job-name is passed"
+    required: false
 
 runs:
   using: composite
@@ -86,10 +88,11 @@ runs:
         SONAR_HOST_URL: ${{ inputs.sonar-host-url }}
 
     - name: Collect metrics
-      if: always()
+      if: always() && inputs.metrics-job-name != ''
       id: collect-gha-metrics
-      uses: smartcontractkit/push-gha-metrics-action@e34ae8a4df60f4d9fdef1e32a69747bab130840e # v2.2.0
+      uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
       with:
+        id: ${{ inputs.metrics-id || inputs.metrics-job-name }}
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
         org-id: ${{ inputs.gc-org-id}}

--- a/actions/ci-test-go/action.yml
+++ b/actions/ci-test-go/action.yml
@@ -11,20 +11,6 @@ inputs:
     description: "number of commits to fetch"
     required: false
     default: "0"
-  # grafana inputs
-  metrics-job-name:
-    description: "grafana metrics job name"
-    required: false
-    default: ci-test
-  gc-host:
-    description: "grafana hostname"
-    required: false
-  gc-basic-auth:
-    description: "grafana basic auth"
-    required: false
-  gc-org-id:
-    description: "grafana org/tenant id"
-    required: false
   # aws inputs
   aws-role-duration-seconds:
     description: ""
@@ -79,6 +65,22 @@ inputs:
     description: ""
     required: false
     default: "."
+  # grafana inputs (optional)
+  metrics-job-name:
+    description: "grafana metrics job name"
+    required: false
+  metrics-id:
+    description: "grafana metrics id, used for continuity of metrics during job name changes - required if metrics-job-name is passed"
+    required: false
+  gc-host:
+    description: "grafana hostname - required if metrics-job-name is passed"
+    required: false
+  gc-basic-auth:
+    description: "grafana basic auth - required if metrics-job-name is passed"
+    required: false
+  gc-org-id:
+    description: "grafana org/tenant id - required if metrics-job-name is passed"
+    required: false
 
 runs:
   using: composite
@@ -148,10 +150,11 @@ runs:
           ./coverage.txt
 
     - name: Collect metrics
-      if: always()
+      if: always() && inputs.metrics-job-name != ''
       id: collect-gha-metrics
-      uses: smartcontractkit/push-gha-metrics-action@e34ae8a4df60f4d9fdef1e32a69747bab130840e # v2.2.0
+      uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
       with:
+        id: ${{ inputs.metrics-id || inputs.metrics-job-name }}
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
         org-id: ${{ inputs.gc-org-id}}

--- a/actions/ci-test-sol/action.yml
+++ b/actions/ci-test-sol/action.yml
@@ -40,20 +40,6 @@ inputs:
     description: ""
     required: false
     default: "--report lcov"
-  # grafana inputs
-  metrics-job-name:
-    description: "grafana metrics job name"
-    required: false
-    default: ci-test-sol
-  gc-host:
-    description: "grafana hostname"
-    required: false
-  gc-basic-auth:
-    description: "grafana basic auth"
-    required: false
-  gc-org-id:
-    description: "grafana org/tenant id"
-    required: false
   # nodejs inputs
   node-version-file:
     description: ""
@@ -63,6 +49,22 @@ inputs:
     description: ""
     required: false
     default: "^8.0.0"
+  # grafana inputs (optional)
+  metrics-job-name:
+    description: "grafana metrics job name"
+    required: false
+  metrics-id:
+    description: "grafana metrics id, used for continuity of metrics during job name changes - required if metrics-job-name is passed"
+    required: false
+  gc-host:
+    description: "grafana hostname - required if metrics-job-name is passed"
+    required: false
+  gc-basic-auth:
+    description: "grafana basic auth - required if metrics-job-name is passed"
+    required: false
+  gc-org-id:
+    description: "grafana org/tenant id - required if metrics-job-name is passed"
+    required: false
 
 runs:
   using: composite
@@ -139,10 +141,11 @@ runs:
         inputs.forge-coverage-args }}
 
     - name: Collect metrics
-      if: always()
+      if: always() && inputs.metrics-job-name != ''
       id: collect-gha-metrics
-      uses: smartcontractkit/push-gha-metrics-action@e34ae8a4df60f4d9fdef1e32a69747bab130840e # v2.2.0
+      uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
       with:
+        id: ${{ inputs.metrics-id || inputs.metrics-job-name }}
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
         org-id: ${{ inputs.gc-org-id}}

--- a/actions/ci-test-ts/action.yml
+++ b/actions/ci-test-ts/action.yml
@@ -19,20 +19,6 @@ inputs:
     description: ""
     required: false
     default: main
-  # grafana inputs
-  metrics-job-name:
-    description: "grafana metrics job name"
-    required: false
-    default: ci-test
-  gc-host:
-    description: "grafana hostname"
-    required: false
-  gc-basic-auth:
-    description: "grafana basic auth"
-    required: false
-  gc-org-id:
-    description: "grafana org/tenant id"
-    required: false
   # nodejs inputs
   node-version-file:
     description: ""
@@ -42,6 +28,22 @@ inputs:
     description: ""
     required: false
     default: "^8.0.0"
+  # grafana inputs (optional)
+  metrics-job-name:
+    description: "grafana metrics job name"
+    required: false
+  metrics-id:
+    description: "grafana metrics id, used for continuity of metrics during job name changes - required if metrics-job-name is passed"
+    required: false
+  gc-host:
+    description: "grafana hostname - required if metrics-job-name is passed"
+    required: false
+  gc-basic-auth:
+    description: "grafana basic auth - required if metrics-job-name is passed"
+    required: false
+  gc-org-id:
+    description: "grafana org/tenant id - required if metrics-job-name is passed"
+    required: false
 
 runs:
   using: composite
@@ -72,10 +74,11 @@ runs:
       run: pnpm run lint:affected --base=${{ inputs.base-ref }}
 
     - name: Collect metrics
-      if: always()
+      if: always() && inputs.metrics-job-name != ''
       id: collect-gha-metrics
-      uses: smartcontractkit/push-gha-metrics-action@e34ae8a4df60f4d9fdef1e32a69747bab130840e # v2.2.0
+      uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
       with:
+        id: ${{ inputs.metrics-id || inputs.metrics-job-name }}
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
         org-id: ${{ inputs.gc-org-id}}

--- a/actions/cicd-build-publish-artifacts-go/action.yml
+++ b/actions/cicd-build-publish-artifacts-go/action.yml
@@ -26,20 +26,6 @@ inputs:
     description: ""
     required: false
     default: "false"
-  # grafana inputs
-  metrics-job-name:
-    description: "grafana metrics job name"
-    required: false
-    default: cicd-build-publish-artifacts
-  gc-host:
-    description: "grafana hostname"
-    required: false
-  gc-basic-auth:
-    description: "grafana basic auth"
-    required: false
-  gc-org-id:
-    description: "grafana org/tenant id"
-    required: false
   # aws inputs
   aws-role-duration-seconds:
     description: ""
@@ -114,6 +100,22 @@ inputs:
     description: ""
     required: false
     default: "0.10.1"
+  # grafana inputs (optional)
+  metrics-job-name:
+    description: "grafana metrics job name"
+    required: false
+  metrics-id:
+    description: "grafana metrics id, used for continuity of metrics during job name changes - required if metrics-job-name is passed"
+    required: false
+  gc-host:
+    description: "grafana hostname - required if metrics-job-name is passed"
+    required: false
+  gc-basic-auth:
+    description: "grafana basic auth - required if metrics-job-name is passed"
+    required: false
+  gc-org-id:
+    description: "grafana org/tenant id - required if metrics-job-name is passed"
+    required: false
 
 runs:
   using: composite
@@ -223,10 +225,11 @@ runs:
         ZIG_EXEC: ${{ steps.process-params.outputs.zig-exec }}
 
     - name: Collect metrics
-      if: always()
+      if: always() && inputs.metrics-job-name != ''
       id: collect-gha-metrics
-      uses: smartcontractkit/push-gha-metrics-action@e34ae8a4df60f4d9fdef1e32a69747bab130840e # v2.2.0
+      uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
       with:
+        id: ${{ inputs.metrics-id || inputs.metrics-job-name }}
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
         org-id: ${{ inputs.gc-org-id}}

--- a/actions/cicd-build-publish-artifacts-ts/action.yml
+++ b/actions/cicd-build-publish-artifacts-ts/action.yml
@@ -46,20 +46,6 @@ inputs:
   monorepo-release-version:
     description: ""
     required: false
-  # grafana inputs
-  metrics-job-name:
-    description: "grafana metrics job name"
-    required: false
-    default: cicd-build-publish-artifacts
-  gc-host:
-    description: "grafana hostname"
-    required: false
-  gc-basic-auth:
-    description: "grafana basic auth"
-    required: false
-  gc-org-id:
-    description: "grafana org/tenant id"
-    required: false
   # nodejs inputs
   node-version-file:
     description: ""
@@ -78,6 +64,22 @@ inputs:
     description: ""
     required: false
     default: nightly
+  # grafana inputs (optional)
+  metrics-job-name:
+    description: "grafana metrics job name"
+    required: false
+  metrics-id:
+    description: "grafana metrics id, used for continuity of metrics during job name changes - required if metrics-job-name is passed"
+    required: false
+  gc-host:
+    description: "grafana hostname - required if metrics-job-name is passed"
+    required: false
+  gc-basic-auth:
+    description: "grafana basic auth - required if metrics-job-name is passed"
+    required: false
+  gc-org-id:
+    description: "grafana org/tenant id - required if metrics-job-name is passed"
+    required: false
 
 runs:
   using: composite
@@ -145,10 +147,11 @@ runs:
         file_glob: true
 
     - name: Collect metrics
-      if: always()
+      if: always() && inputs.metrics-job-name != ''
       id: collect-gha-metrics
-      uses: smartcontractkit/push-gha-metrics-action@e34ae8a4df60f4d9fdef1e32a69747bab130840e # v2.2.0
+      uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
       with:
+        id: ${{ inputs.metrics-id || inputs.metrics-job-name }}
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
         org-id: ${{ inputs.gc-org-id}}

--- a/actions/cicd-build-publish-charts/action.yml
+++ b/actions/cicd-build-publish-charts/action.yml
@@ -11,20 +11,6 @@ inputs:
     description: "number of commits to fetch"
     required: false
     default: "0"
-  # grafana inputs
-  metrics-job-name:
-    description: "grafana metrics job name"
-    required: false
-    default: cicd-build-publish-charts
-  gc-host:
-    description: "grafana hostname"
-    required: false
-  gc-basic-auth:
-    description: "grafana basic auth"
-    required: false
-  gc-org-id:
-    description: "grafana org/tenant id"
-    required: false
   # general inputs
   package-dir:
     description: "output directory for helm package tarballs"
@@ -55,6 +41,22 @@ inputs:
     required: false
   aws-role-arn:
     description: ""
+    required: false
+  # grafana inputs (optional)
+  metrics-job-name:
+    description: "grafana metrics job name"
+    required: false
+  metrics-id:
+    description: "grafana metrics id, used for continuity of metrics during job name changes - required if metrics-job-name is passed"
+    required: false
+  gc-host:
+    description: "grafana hostname - required if metrics-job-name is passed"
+    required: false
+  gc-basic-auth:
+    description: "grafana basic auth - required if metrics-job-name is passed"
+    required: false
+  gc-org-id:
+    description: "grafana org/tenant id - required if metrics-job-name is passed"
     required: false
 
 runs:
@@ -112,10 +114,11 @@ runs:
           --charts_repo ${{ steps.process-params.outputs.charts-repo }}
 
     - name: Collect metrics
-      if: always()
+      if: always() && inputs.metrics-job-name != ''
       id: collect-gha-metrics
-      uses: smartcontractkit/push-gha-metrics-action@e34ae8a4df60f4d9fdef1e32a69747bab130840e # v2.2.0
+      uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
       with:
+        id: ${{ inputs.metrics-id || inputs.metrics-job-name }}
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
         org-id: ${{ inputs.gc-org-id}}

--- a/actions/cicd-changesets/action.yml
+++ b/actions/cicd-changesets/action.yml
@@ -42,20 +42,6 @@ inputs:
     description: "Use cache for pnpm"
     required: false
     default: "true"
-  # grafana inputs
-  metrics-job-name:
-    description: "grafana metrics job name"
-    required: false
-    default: cicd-changesets
-  gc-host:
-    description: "grafana hostname"
-    required: false
-  gc-basic-auth:
-    description: "grafana basic auth"
-    required: false
-  gc-org-id:
-    description: "grafana org/tenant id"
-    required: false
   # changesets inputs
   changesets-publish-cmd:
     description: ""
@@ -76,6 +62,22 @@ inputs:
     description: "whether to put the PR in draft mode or not"
     required: false
     default: "false"
+  # grafana inputs (optional)
+  metrics-job-name:
+    description: "grafana metrics job name"
+    required: false
+  metrics-id:
+    description: "grafana metrics id, used for continuity of metrics during job name changes - required if metrics-job-name is passed"
+    required: false
+  gc-host:
+    description: "grafana hostname - required if metrics-job-name is passed"
+    required: false
+  gc-basic-auth:
+    description: "grafana basic auth - required if metrics-job-name is passed"
+    required: false
+  gc-org-id:
+    description: "grafana org/tenant id - required if metrics-job-name is passed"
+    required: false
 outputs:
   published:
     description:
@@ -154,10 +156,11 @@ runs:
         echo "pullRequestNumber: ${{ steps.changesets.outputs.pullRequestNumber }}"
 
     - name: Collect metrics
-      if: always()
+      if: always() && inputs.metrics-job-name != ''
       id: collect-gha-metrics
-      uses: smartcontractkit/push-gha-metrics-action@e34ae8a4df60f4d9fdef1e32a69747bab130840e # v2.2.0
+      uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
       with:
+        id: ${{ inputs.metrics-id || inputs.metrics-job-name }}
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
         org-id: ${{ inputs.gc-org-id}}

--- a/actions/guard-from-missing-changesets/action.yml
+++ b/actions/guard-from-missing-changesets/action.yml
@@ -10,24 +10,22 @@ inputs:
       step with `fetch-depth: 0`.
     required: false
     default: "false"
-  # grafana inputs
-  gc-basic-auth:
-    description: "grafana basic auth"
-    required: false
-  gc-org-id:
-    description: "grafana org/tenant id"
-    required: false
-  gc-host:
-    description: "grafana hostname"
-    required: false
+  # grafana inputs (optional)
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
-    default: guard-from-missing-changesets
-  trunk-branch:
-    description: "Trunk branch name"
+  metrics-id:
+    description: "grafana metrics id, used for continuity of metrics during job name changes - required if metrics-job-name is passed"
     required: false
-    default: main
+  gc-host:
+    description: "grafana hostname - required if metrics-job-name is passed"
+    required: false
+  gc-basic-auth:
+    description: "grafana basic auth - required if metrics-job-name is passed"
+    required: false
+  gc-org-id:
+    description: "grafana org/tenant id - required if metrics-job-name is passed"
+    required: false
 
 runs:
   using: composite
@@ -44,10 +42,11 @@ runs:
         TRUNK_BRANCH: ${{ inputs.trunk-branch }}
       run: ${{ github.action_path }}/scripts/fail-if-changesets-missing.sh
     - name: Collect metrics
-      if: always()
+      if: always() && inputs.metrics-job-name != ''
       id: collect-gha-metrics
-      uses: smartcontractkit/push-gha-metrics-action@e34ae8a4df60f4d9fdef1e32a69747bab130840e # v2.2.0
+      uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
       with:
+        id: ${{ inputs.metrics-id || inputs.metrics-job-name }}
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
         org-id: ${{ inputs.gc-org-id}}

--- a/actions/helm-version-bump-receiver/action.yml
+++ b/actions/helm-version-bump-receiver/action.yml
@@ -68,19 +68,21 @@ inputs:
     description: "Used to append to the branch name and the PR title."
     required: true
     default: "sandbox"
-  # grafana inputs
+  # grafana inputs (optional)
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
-    default: helm-version-bump-pr
+  metrics-id:
+    description: "grafana metrics id, used for continuity of metrics during job name changes - required if metrics-job-name is passed"
+    required: false
   gc-host:
-    description: "grafana hostname"
+    description: "grafana hostname - required if metrics-job-name is passed"
     required: false
   gc-basic-auth:
-    description: "grafana basic auth"
+    description: "grafana basic auth - required if metrics-job-name is passed"
     required: false
   gc-org-id:
-    description: "grafana org/tenant id"
+    description: "grafana org/tenant id - required if metrics-job-name is passed"
     required: false
 
 outputs:
@@ -162,10 +164,11 @@ runs:
         token: ${{ inputs.github-token }}
 
     - name: Collect metrics
-      if: always()
+      if: always() && inputs.metrics-job-name != ''
       id: collect-gha-metrics
-      uses: smartcontractkit/push-gha-metrics-action@e34ae8a4df60f4d9fdef1e32a69747bab130840e # v2.2.0
+      uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
       with:
+        id: ${{ inputs.metrics-id || inputs.metrics-job-name }}
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
         org-id: ${{ inputs.gc-org-id}}

--- a/actions/llm-pr-writer/action.yml
+++ b/actions/llm-pr-writer/action.yml
@@ -33,19 +33,21 @@ inputs:
     description: "ref of the workflow to checkout"
     required: false
     default: "main"
-  # grafana inputs
+  # grafana inputs (optional)
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
-    default: llm-pr-writer
+  metrics-id:
+    description: "grafana metrics id, used for continuity of metrics during job name changes - required if metrics-job-name is passed"
+    required: false
   gc-host:
-    description: "grafana hostname"
+    description: "grafana hostname - required if metrics-job-name is passed"
     required: false
   gc-basic-auth:
-    description: "grafana basic auth"
+    description: "grafana basic auth - required if metrics-job-name is passed"
     required: false
   gc-org-id:
-    description: "grafana org/tenant id"
+    description: "grafana org/tenant id - required if metrics-job-name is passed"
     required: false
 
 runs:
@@ -113,7 +115,7 @@ runs:
         gh pr checkout $PR_NUMBER
         diff_command="git diff -W origin/\$(gh pr view --json baseRefName | jq -r '.baseRefName')...HEAD -- ${{ steps.filter.outputs.exclude_filter }}"
         diff_output=$(eval $diff_command)
-        
+
         # get the PR title
         pr_title=$(gh pr view --json title | jq -r '.title')
         printf "PR TITLE: $pr_title\\\n\\\n\\\n" > diff_output.txt
@@ -177,7 +179,7 @@ runs:
         echo "$pr_current_body"
 
         pr_message="**Below is a summarization created by an LLM (${{ inputs.openai-model }}). Be mindful of hallucinations and verify accuracy.**
-        
+
         $(cat chatgpt_output.txt)"
 
         gh pr edit $PR_NUMBER -b "$pr_current_body
@@ -189,8 +191,9 @@ runs:
     - name: Collect metrics
       if: always()
       id: collect-gha-metrics
-      uses: smartcontractkit/push-gha-metrics-action@e34ae8a4df60f4d9fdef1e32a69747bab130840e # v2.2.0
+      uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
       with:
+        id: ${{ inputs.metrics-id || inputs.metrics-job-name }}
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
         org-id: ${{ inputs.gc-org-id}}

--- a/actions/manifest-build/action.yml
+++ b/actions/manifest-build/action.yml
@@ -7,8 +7,8 @@ inputs:
     description: "Additional packages to build on top of the declared check packages (space separated) - not used if setup-only=true"
     required: false
     default: ""
-  
- # cache inputs ----------------------------------
+
+  # cache inputs ----------------------------------
   cache-url:
     description: "Nix cache URL"
     required: false
@@ -18,19 +18,21 @@ inputs:
     required: false
     default: ""
 
-  # grafana inputs --------------------------
+  # grafana inputs (optional) --------------------
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
-    default: manifest-build
+  metrics-id:
+    description: "grafana metrics id, used for continuity of metrics during job name changes - required if metrics-job-name is passed"
+    required: false
   gc-host:
-    description: "grafana hostname"
+    description: "grafana hostname - required if metrics-job-name is passed"
     required: false
   gc-basic-auth:
-    description: "grafana basic auth"
+    description: "grafana basic auth - required if metrics-job-name is passed"
     required: false
   gc-org-id:
-    description: "grafana org/tenant id"
+    description: "grafana org/tenant id - required if metrics-job-name is passed"
     required: false
 
 runs:
@@ -41,7 +43,7 @@ runs:
       run: |
         # run check package builds
         nix flake check
-    - name: Build additional packages to cache 
+    - name: Build additional packages to cache
       if: inputs.add-packages != '' # only run if there are packages specified
       shell: bash
       run: |
@@ -93,10 +95,11 @@ runs:
         nix copy --verbose --narinfo-cache-positive-ttl 0 --to ${{ inputs.cache-url }} ${{ steps.buildPaths.outputs.paths }}
 
     - name: Collect metrics
-      if: always()
+      if: always() && inputs.metrics-job-name != ''
       id: collect-gha-metrics
-      uses: smartcontractkit/push-gha-metrics-action@e34ae8a4df60f4d9fdef1e32a69747bab130840e # v2.2.0
+      uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
       with:
+        id: ${{ inputs.metrics-id || inputs.metrics-job-name }}
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
         org-id: ${{ inputs.gc-org-id }}

--- a/actions/setup-gap/action.yml
+++ b/actions/setup-gap/action.yml
@@ -107,18 +107,21 @@ inputs:
     description:
       "The region for the EKS cluster, if different from aws-region input."
     required: false
-  # grafana inputs
+  # grafana inputs (optional)
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
+  metrics-id:
+    description: "grafana metrics id, used for continuity of metrics during job name changes - required if metrics-job-name is passed"
+    required: false
   gc-host:
-    description: "grafana hostname"
+    description: "grafana hostname - required if metrics-job-name is passed"
     required: false
   gc-basic-auth:
-    description: "grafana basic auth"
+    description: "grafana basic auth - required if metrics-job-name is passed"
     required: false
   gc-org-id:
-    description: "grafana org/tenant id"
+    description: "grafana org/tenant id - required if metrics-job-name is passed"
     required: false
 
 runs:
@@ -283,8 +286,9 @@ runs:
     - name: Collect metrics
       if: always() && inputs.metrics-job-name != ''
       id: collect-gha-metrics
-      uses: smartcontractkit/push-gha-metrics-action@e34ae8a4df60f4d9fdef1e32a69747bab130840e # v2.2.0
+      uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
       with:
+        id: ${{ inputs.metrics-id || inputs.metrics-job-name }}
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
         org-id: ${{ inputs.gc-org-id}}

--- a/actions/setup-nix-gati/action.yml
+++ b/actions/setup-nix-gati/action.yml
@@ -20,11 +20,13 @@ inputs:
     description: "Enable magic nix cache"
     required: false
     default: false
-  # grafana inputs
+  # grafana inputs (optional)
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
-    default: ""
+  metrics-id:
+    description: "grafana metrics id, used for continuity of metrics during job name changes - required if metrics-job-name is passed"
+    required: false
   gc-host:
     description: "grafana hostname"
     required: false
@@ -70,6 +72,7 @@ runs:
       id: collect-gha-metrics
       uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
       with:
+        id: ${{ inputs.metrics-id || inputs.metrics-job-name }}
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
         org-id: ${{ inputs.gc-org-id}}

--- a/actions/setup-nix/action.yml
+++ b/actions/setup-nix/action.yml
@@ -50,19 +50,21 @@ inputs:
     required: false
     default: ""
 
-  # grafana inputs --------------------------
+  # grafana inputs (optional) ----------------------
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
-    default: manifest-build
+  metrics-id:
+    description: "grafana metrics id, used for continuity of metrics during job name changes - required if metrics-job-name is passed"
+    required: false
   gc-host:
-    description: "grafana hostname"
+    description: "grafana hostname - required if metrics-job-name is passed"
     required: false
   gc-basic-auth:
-    description: "grafana basic auth"
+    description: "grafana basic auth - required if metrics-job-name is passed"
     required: false
   gc-org-id:
-    description: "grafana org/tenant id"
+    description: "grafana org/tenant id - required if metrics-job-name is passed"
     required: false
 
 runs:
@@ -128,10 +130,11 @@ runs:
         private-key: ${{ inputs.github-token }}
 
     - name: Collect metrics
-      if: always()
+      if: always() && inputs.metrics-job-name != ''
       id: collect-gha-metrics
-      uses: smartcontractkit/push-gha-metrics-action@e34ae8a4df60f4d9fdef1e32a69747bab130840e # v2.2.0
+      uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
       with:
+        id: ${{ inputs.metrics-id || inputs.metrics-job-name }}
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
         org-id: ${{ inputs.gc-org-id }}

--- a/actions/update-actions/action.yml
+++ b/actions/update-actions/action.yml
@@ -31,19 +31,21 @@ inputs:
   aws-lambda-url-updater:
     description: ""
     required: true
-  # grafana inputs
+  # grafana inputs (optional)
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
-    default: update-actions
+  metrics-id:
+    description: "grafana metrics id, used for continuity of metrics during job name changes - required if metrics-job-name is passed"
+    required: false
   gc-host:
-    description: "grafana hostname"
+    description: "grafana hostname - required if metrics-job-name is passed"
     required: false
   gc-basic-auth:
-    description: "grafana basic auth"
+    description: "grafana basic auth - required if metrics-job-name is passed"
     required: false
   gc-org-id:
-    description: "grafana org/tenant id"
+    description: "grafana org/tenant id - required if metrics-job-name is passed"
     required: false
 
 runs:
@@ -100,10 +102,11 @@ runs:
           <376532+app-token-issuer-releng-renovate[bot]@users.noreply.github.com>"
 
     - name: Collect metrics
-      if: always()
+      if: always() && inputs.metrics-job-name != ''
       id: collect-gha-metrics
-      uses: smartcontractkit/push-gha-metrics-action@e34ae8a4df60f4d9fdef1e32a69747bab130840e # v2.2.0
+      uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
       with:
+        id: ${{ inputs.metrics-id || inputs.metrics-job-name }}
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
         org-id: ${{ inputs.gc-org-id}}

--- a/libs/nx-chainlink/src/generators/create-gh-action/files/composite/debug/action.yml.template
+++ b/libs/nx-chainlink/src/generators/create-gh-action/files/composite/debug/action.yml.template
@@ -11,7 +11,7 @@ inputs:
     description: "number of commits to fetch"
     required: false
     default: "0"
-  # grafana inputs
+  # grafana inputs (optional)
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
@@ -46,7 +46,7 @@ runs:
       id: collect-gha-metrics
       uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
       with:
-        id: ${{ inputs.metrics-id }}
+        id: ${{ inputs.metrics-id || inputs.metrics-job-name }}
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
         org-id: ${{ inputs.gc-org-id}}

--- a/libs/nx-chainlink/src/generators/create-gh-action/files/composite/default/action.yml.template
+++ b/libs/nx-chainlink/src/generators/create-gh-action/files/composite/default/action.yml.template
@@ -11,7 +11,7 @@ inputs:
     description: "number of commits to fetch"
     required: false
     default: "0"
-  # grafana inputs
+  # grafana inputs (optional)
   metrics-job-name:
     description: "grafana metrics job name"
     required: false
@@ -42,7 +42,7 @@ runs:
       id: collect-gha-metrics
       uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
       with:
-        id: ${{ inputs.metrics-id }}
+        id: ${{ inputs.metrics-id || inputs.metrics-job-name }}
         basic-auth: ${{ inputs.gc-basic-auth }}
         hostname: ${{ inputs.gc-host }}
         org-id: ${{ inputs.gc-org-id}}


### PR DESCRIPTION
* bump push-gha-metrics-action to v3.0.1
* make grafana inputs optional
    * Only try and run metrics action if `metrics-job-name` was passed
    * This also includes backwards compatibility for usages that do not include the `metrics-id` input (required parameter for v3), if not included it will default to the `metrics-job-name`.