### PR TITLE
ci: use gha-workflow-validator for all actions

### DIFF
--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -168,6 +168,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: GHA Workflow Validator
-        uses: smartcontractkit/.github/actions/gha-workflow-validator@7d4c3591affba99d0b073e527569ec6638518d41 # gha-workflow-validator@0.1.0
+        uses: smartcontractkit/.github/actions/gha-workflow-validator@d316f66b2990ea4daa479daa3de6fc92b00f863e # gha-workflow-validator@0.2.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
+        with:
+          include-all-action-definitions: true


### PR DESCRIPTION
Use `gha-workflow-validator` v0.2.0 to validate all changes to all action definitions in in the repo, not just those in the .github directory.

This is useful for this monorepo which contains many composite actions which should be validated similarly to a workflow. 