### PR TITLE
Optionally allow hotfix suffix in the monorepo tag

### DIFF
--- a/.changeset/grumpy-mayflies-explain.md
+++ b/.changeset/grumpy-mayflies-explain.md
@@ -1,0 +1,5 @@
+---
+"check-git-tag-for-monorepo": minor
+---
+
+Optionally allow hotfix suffix in the monorepo tag

--- a/actions/check-git-tag-for-monorepo/README.md
+++ b/actions/check-git-tag-for-monorepo/README.md
@@ -1,4 +1,5 @@
 # check-git-tag-for-monorepo
 
 > Checks if git tag is for a monorepo component <component>@<version>.
-> Optionally (`allow-hotfix` input) allows <component>@<version>-hotfix-<increment, e.g. timestamp>.
+> Optionally (`allow-hotfix` input) allows
+> <component>@<version>-hotfix-<increment, e.g. timestamp>.

--- a/actions/check-git-tag-for-monorepo/README.md
+++ b/actions/check-git-tag-for-monorepo/README.md
@@ -1,3 +1,4 @@
 # check-git-tag-for-monorepo
 
-> checks if git tag is for a monorepo component <component>@<version>
+> Checks if git tag is for a monorepo component <component>@<version>.
+> Optionally (`allow-hotfix` input) allows <component>@<version>-hotfix-<increment, e.g. timestamp>.

--- a/actions/check-git-tag-for-monorepo/action.yml
+++ b/actions/check-git-tag-for-monorepo/action.yml
@@ -7,6 +7,10 @@ inputs:
     description: ""
     required: false
     default: ${{ github.ref_name }}
+  allow-hotfix:
+    description: "optionally allow tags with -hotfix-<increment/timestamp> suffix"
+    required: false
+    default: "false"
 outputs:
   name:
     description: ""
@@ -25,5 +29,6 @@ runs:
       id: run-script
       env:
         TAG_REF: ${{ inputs.tag-ref }}
+        ALLOW_HOTFIX: ${{ inputs.allow-hotfix }}
       shell: bash
       run: ${{ github.action_path }}/scripts/check-git-tag-for-monorepo.sh

--- a/actions/check-git-tag-for-monorepo/action.yml
+++ b/actions/check-git-tag-for-monorepo/action.yml
@@ -8,7 +8,8 @@ inputs:
     required: false
     default: ${{ github.ref_name }}
   allow-hotfix:
-    description: "optionally allow tags with -hotfix-<increment/timestamp> suffix"
+    description:
+      "optionally allow tags with -hotfix-<increment/timestamp> suffix"
     required: false
     default: "false"
 outputs:

--- a/actions/check-git-tag-for-monorepo/package.json
+++ b/actions/check-git-tag-for-monorepo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "check-git-tag-for-monorepo",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "description": "checks if git tag is for a monorepo component <component>@<version>",
   "private": true,
   "scripts": {},

--- a/actions/check-git-tag-for-monorepo/package.json
+++ b/actions/check-git-tag-for-monorepo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "check-git-tag-for-monorepo",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "checks if git tag is for a monorepo component <component>@<version>",
   "private": true,
   "scripts": {},

--- a/actions/check-git-tag-for-monorepo/scripts/check-git-tag-for-monorepo.sh
+++ b/actions/check-git-tag-for-monorepo/scripts/check-git-tag-for-monorepo.sh
@@ -16,6 +16,13 @@ if [[ "$TAG_REF" =~ ^[a-zA-Z0-9_.-]*@[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     echo "name=${NAME}" | tee -a "$GITHUB_OUTPUT"
     echo "version=${VERSION}" | tee -a "$GITHUB_OUTPUT"
     echo "release=true" | tee -a "$GITHUB_OUTPUT"
+elif [[ "$TAG_REF" =~ ^[a-zA-Z0-9_.-]*@[0-9]+\.[0-9]+\.[0-9]+-hotfix-[a-zA-Z0-9_.-]+$ ]] && [[ "$ALLOW_HOTFIX" == "true" ]]; then
+    NAME=${TAG_REF%%@*}
+    VERSION=${TAG_REF#*@}
+    echo "Tag Format is a monorepo tag with a hotfix suffix."
+    echo "name=${NAME}" | tee -a "$GITHUB_OUTPUT"
+    echo "version=${VERSION}" | tee -a "$GITHUB_OUTPUT"
+    echo "release=true" | tee -a "$GITHUB_OUTPUT"
 else
     echo "No monorepo tag found."
     echo "release=false" | tee -a "$GITHUB_OUTPUT"


### PR DESCRIPTION
The change is backward compatible and optionally allows using semantic version compatible tag with the `-hotfix-<increment, e.g. timestamp>` suffix.