### PR TITLE
fix: update ci-test-ts to run nx test targets

### DIFF
--- a/.changeset/young-roses-impress.md
+++ b/.changeset/young-roses-impress.md
@@ -1,0 +1,7 @@
+---
+"ci-test-ts": minor
+"nx-chainlink": patch
+---
+
+- update ci-test-ts to run correct pnpm commands
+- fix a unused variable error in `ns-chainlink`

--- a/actions/ci-test-ts/action.yml
+++ b/actions/ci-test-ts/action.yml
@@ -15,10 +15,6 @@ inputs:
     description: ""
     required: false
     default: "false"
-  base-ref:
-    description: ""
-    required: false
-    default: main
   # nodejs inputs
   node-version-file:
     description: ""
@@ -66,15 +62,14 @@ runs:
         run-install: "true"
       continue-on-error: true
 
-    - name: Run lint
-      if: inputs.check-only-affected != 'true'
+    - name: Run test
       shell: bash
-      run: pnpm run lint
+      run: pnpm run test
 
     - name: Run lint affected
       if: inputs.check-only-affected == 'true'
       shell: bash
-      run: pnpm run lint:affected --base=${{ inputs.base-ref }}
+      run: pnpm run test:affected
 
     - name: Collect metrics
       if: always() && inputs.metrics-job-name != ''

--- a/libs/nx-chainlink/src/generators/create-gh-action/generator.spec.ts
+++ b/libs/nx-chainlink/src/generators/create-gh-action/generator.spec.ts
@@ -9,6 +9,7 @@ describe("create-gh-action generator", () => {
   const options: CreateGhActionGeneratorSchema = {
     name: "test",
     description: "this is a test",
+    debug: false,
   };
 
   beforeEach(() => {


### PR DESCRIPTION
Reverting the changes to `ci-test-ts` as the steps are the same as in `ci-lint-ts` to run `nx` test targets. 

I've tested the commands on https://github.com/smartcontractkit/releng-ts-app and they both work good.