### PR TITLE
Group Dependencies in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,9 +21,14 @@
   },
   "packageRules": [
     {
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["patch"],
-      "enabled": false
+      "groupName": "major-minor dependencies grouped by manager",
+      "branchName": "{{manager}}-dependencies",
+      "matchUpdateTypes": ["major", "minor"]
+    },
+    {
+      "groupName": "all patch dependencies",
+      "branchName": "patch-dependencies",
+      "matchUpdateTypes": ["patch"]
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,14 +21,9 @@
   },
   "packageRules": [
     {
-      "groupName": "major-minor dependencies grouped by manager",
+      "groupName": "minor-patch dependencies grouped by manager",
       "branchName": "{{manager}}-dependencies",
-      "matchUpdateTypes": ["major", "minor"]
-    },
-    {
-      "groupName": "all patch dependencies",
-      "branchName": "patch-dependencies",
-      "matchUpdateTypes": ["patch"]
+      "matchUpdateTypes": ["minor", "patch"]
     }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,6 +200,8 @@ importers:
 
   actions/nops-upgrade-checker: {}
 
+  actions/policy-bot-config-validator: {}
+
   actions/setup-gap: {}
 
   actions/setup-github-token: {}


### PR DESCRIPTION
Started looking into this after discussions [here](https://chainlink-core.slack.com/archives/C03UV9B7M3L/p1719583508860899?thread_ts=1719571377.932819&cid=C03UV9B7M3L) 

- Renovate will group all minor and patch dependencies together by package manager name and create PRs with branch named after package manager `npm-dependencies`, `github-actions-dependencies` etc
- Major dependencies will continue to be raised separately per dependency