### PR TITLE
RE-1920 implement revoke gati token

### DIFF
--- a/.changeset/few-mails-act.md
+++ b/.changeset/few-mails-act.md
@@ -1,0 +1,5 @@
+---
+"setup-github-token": minor
+---
+
+Add support for revoking the token at the end of the job

--- a/actions/setup-github-token/README.md
+++ b/actions/setup-github-token/README.md
@@ -1,22 +1,14 @@
 # setup-github-token action
 
 ## Complete example usage
-jobs:
-  release:
-    name: Release
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Setup GitHub Token
-        id: setup-github-token
-        uses: smartcontractkit/.github/actions/setup-github-token@<commit> # setup-github-token@x.y.z
-        with:
-          aws-role-arn: ${{ secrets.AWS_ROLE_ARN_GATI_CHANGESETS }}
-          aws-lambda-url: ${{ secrets.GATI_LAMBDA_FUNCTION_URL }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          aws-role-duration-seconds: "1800"
+
+jobs: release: name: Release runs-on: ubuntu-latest permissions: id-token: write
+contents: read steps: - name: Setup GitHub Token id: setup-github-token uses:
+smartcontractkit/.github/actions/setup-github-token@<commit> #
+setup-github-token@x.y.z with: aws-role-arn:
+${{ secrets.AWS_ROLE_ARN_GATI_CHANGESETS }} aws-lambda-url:
+${{ secrets.GATI_LAMBDA_FUNCTION_URL }} aws-region: ${{ secrets.AWS_REGION }}
+aws-role-duration-seconds: "1800"
 
       - name: Echo GATI token
         shell: bash
@@ -29,4 +21,4 @@ jobs:
           aws-role-arn: ${{ secrets.AWS_ROLE_ARN_GATI_CHANGESETS }}
           aws-lambda-url: ${{ secrets.GATI_LAMBDA_FUNCTION_URL }}
           aws-region: ${{ secrets.AWS_REGION }}
-          revoke-token: 'true'
+          revoke-token: ${{ steps.setup-github-token.outputs.access-token }}

--- a/actions/setup-github-token/README.md
+++ b/actions/setup-github-token/README.md
@@ -2,14 +2,25 @@
 
 ## Complete example usage
 
-jobs: release: name: Release runs-on: ubuntu-latest permissions: id-token: write
-contents: read steps: - name: Setup GitHub Token id: setup-github-token uses:
-smartcontractkit/.github/actions/setup-github-token@<commit> #
-setup-github-token@x.y.z with: aws-role-arn:
-${{ secrets.AWS_ROLE_ARN_GATI_CHANGESETS }} aws-lambda-url:
-${{ secrets.GATI_LAMBDA_FUNCTION_URL }} aws-region: ${{ secrets.AWS_REGION }}
-aws-role-duration-seconds: "1800"
+```bash
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Setup GitHub Token
+        id: setup-github-token
+        uses: smartcontractkit/.github/actions/setup-github-token@<commit> # setup-github-token@x.y.z
+        with:
+          aws-role-arn: ${{ secrets.AWS_ROLE_ARN_GATI_CHANGESETS }}
+          aws-lambda-url: ${{ secrets.GATI_LAMBDA_FUNCTION_URL }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-role-duration-seconds: "1800"
 
+      # any job logic
       - name: Echo GATI token
         shell: bash
         run: echo ${{ steps.setup-github-token.outputs.access-token }} | shasum
@@ -22,3 +33,4 @@ aws-role-duration-seconds: "1800"
           aws-lambda-url: ${{ secrets.GATI_LAMBDA_FUNCTION_URL }}
           aws-region: ${{ secrets.AWS_REGION }}
           revoke-token: ${{ steps.setup-github-token.outputs.access-token }}
+```

--- a/actions/setup-github-token/README.md
+++ b/actions/setup-github-token/README.md
@@ -1,1 +1,32 @@
 # setup-github-token action
+
+## Complete example usage
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Setup GitHub Token
+        id: setup-github-token
+        uses: smartcontractkit/.github/actions/setup-github-token@<commit> # setup-github-token@x.y.z
+        with:
+          aws-role-arn: ${{ secrets.AWS_ROLE_ARN_GATI_CHANGESETS }}
+          aws-lambda-url: ${{ secrets.GATI_LAMBDA_FUNCTION_URL }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-role-duration-seconds: "1800"
+
+      - name: Echo GATI token
+        shell: bash
+        run: echo ${{ steps.setup-github-token.outputs.access-token }} | shasum
+
+      - name: Revoke GitHub Token
+        id: revoke-github-token
+        uses: smartcontractkit/.github/actions/setup-github-token@<commit> # setup-github-token@x.y.z
+        with:
+          aws-role-arn: ${{ secrets.AWS_ROLE_ARN_GATI_CHANGESETS }}
+          aws-lambda-url: ${{ secrets.GATI_LAMBDA_FUNCTION_URL }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          revoke-token: 'true'

--- a/actions/setup-github-token/action.yml
+++ b/actions/setup-github-token/action.yml
@@ -2,6 +2,10 @@ name: Setup GitHub Token
 description: Setup a GitHub Token from GATI
 
 inputs:
+  revoke-token:
+    description: something
+    required: false
+    default: "false"
   aws-role-arn:
     description: ARN of role capable of getting token from GATI
     required: true
@@ -37,6 +41,7 @@ runs:
     - name: Check the role session name lengths and truncate if needed
       shell: bash
       id: role-session-name
+      if: inputs.revoke-token == "false"
       env:
         ROLE_SESSION_NAME: ${{ inputs.role-session-name }}
       run: |
@@ -47,6 +52,7 @@ runs:
         fi
 
     - name: Assume role capable of getting token from gati
+      if: inputs.revoke-token == "false"
       uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
       with:
         aws-region: ${{ inputs.aws-region }}
@@ -58,14 +64,26 @@ runs:
 
     - name: Get github token from gati
       id: get-gh-token
+      if: inputs.revoke-token == "false"
       uses: smartcontractkit/chainlink-github-actions/github-app-token-issuer@main
       with:
         url: ${{ inputs.aws-lambda-url }}
 
     - name: Configure github token
-      if: inputs.set-git-config == 'true'
+      if: inputs.set-git-config == "true" && inputs.revoke-token == "false"
       shell: bash
       run: |
         git config --global \
           url."https://x-access-token:${{ steps.get-gh-token.outputs.access-token }}@github.com/".insteadOf \
           "https://github.com/"
+
+    - name: Revoke github token
+      if: inputs.revoke-token == "true"
+      shell: bash
+      run: |
+        curl -v -L \
+          -X DELETE \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ steps.get-gh-token.outputs.access-token }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/installation/token

--- a/actions/setup-github-token/action.yml
+++ b/actions/setup-github-token/action.yml
@@ -5,7 +5,7 @@ inputs:
   revoke-token:
     description: something
     required: false
-    default: "false"
+    default: 'false'
   aws-role-arn:
     description: ARN of role capable of getting token from GATI
     required: true
@@ -26,7 +26,7 @@ inputs:
   set-git-config:
     description: Set git config
     required: false
-    default: "false"
+    default: 'false'
 
 outputs:
   access-token:
@@ -41,7 +41,7 @@ runs:
     - name: Check the role session name lengths and truncate if needed
       shell: bash
       id: role-session-name
-      if: inputs.revoke-token == "false"
+      if: inputs.revoke-token == 'false'
       env:
         ROLE_SESSION_NAME: ${{ inputs.role-session-name }}
       run: |
@@ -52,7 +52,7 @@ runs:
         fi
 
     - name: Assume role capable of getting token from gati
-      if: inputs.revoke-token == "false"
+      if: inputs.revoke-token == 'false'
       uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
       with:
         aws-region: ${{ inputs.aws-region }}
@@ -64,13 +64,13 @@ runs:
 
     - name: Get github token from gati
       id: get-gh-token
-      if: inputs.revoke-token == "false"
+      if: inputs.revoke-token == 'false'
       uses: smartcontractkit/chainlink-github-actions/github-app-token-issuer@main
       with:
         url: ${{ inputs.aws-lambda-url }}
 
     - name: Configure github token
-      if: inputs.set-git-config == "true" && inputs.revoke-token == "false"
+      if: inputs.set-git-config == 'true' && inputs.revoke-token == 'false'
       shell: bash
       run: |
         git config --global \
@@ -78,7 +78,7 @@ runs:
           "https://github.com/"
 
     - name: Revoke github token
-      if: inputs.revoke-token == "true"
+      if: inputs.revoke-token == 'true'
       shell: bash
       run: |
         curl -v -L \

--- a/actions/setup-github-token/action.yml
+++ b/actions/setup-github-token/action.yml
@@ -41,7 +41,7 @@ runs:
     - name: Check the role session name lengths and truncate if needed
       shell: bash
       id: role-session-name
-      if: inputs.revoke-token == ""
+      if: inputs.revoke-token == ''
       env:
         ROLE_SESSION_NAME: ${{ inputs.role-session-name }}
       run: |
@@ -52,7 +52,7 @@ runs:
         fi
 
     - name: Assume role capable of getting token from gati
-      if: inputs.revoke-token == ""
+      if: inputs.revoke-token == ''
       uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
       with:
         aws-region: ${{ inputs.aws-region }}
@@ -64,13 +64,13 @@ runs:
 
     - name: Get github token from gati
       id: get-gh-token
-      if: inputs.revoke-token == ""
+      if: inputs.revoke-token == ''
       uses: smartcontractkit/chainlink-github-actions/github-app-token-issuer@main
       with:
         url: ${{ inputs.aws-lambda-url }}
 
     - name: Configure github token
-      if: inputs.set-git-config == 'true' && inputs.revoke-token == ""
+      if: inputs.set-git-config == 'true' && inputs.revoke-token == ''
       shell: bash
       run: |
         git config --global \
@@ -78,10 +78,10 @@ runs:
           "https://github.com/"
 
     - name: Revoke github token
-      if: inputs.revoke-token != ""
+      if: inputs.revoke-token != ''
       shell: bash
       run: |
-        curl -v -f -L \
+        curl -fIL \
           -X DELETE \
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${{ inputs.revoke-token }}" \

--- a/actions/setup-github-token/action.yml
+++ b/actions/setup-github-token/action.yml
@@ -5,7 +5,7 @@ inputs:
   revoke-token:
     description: something
     required: false
-    default: 'false'
+    default: ""
   aws-role-arn:
     description: ARN of role capable of getting token from GATI
     required: true
@@ -26,7 +26,7 @@ inputs:
   set-git-config:
     description: Set git config
     required: false
-    default: 'false'
+    default: "false"
 
 outputs:
   access-token:
@@ -41,7 +41,7 @@ runs:
     - name: Check the role session name lengths and truncate if needed
       shell: bash
       id: role-session-name
-      if: inputs.revoke-token == 'false'
+      if: inputs.revoke-token == ""
       env:
         ROLE_SESSION_NAME: ${{ inputs.role-session-name }}
       run: |
@@ -52,7 +52,7 @@ runs:
         fi
 
     - name: Assume role capable of getting token from gati
-      if: inputs.revoke-token == 'false'
+      if: inputs.revoke-token == ""
       uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
       with:
         aws-region: ${{ inputs.aws-region }}
@@ -64,13 +64,13 @@ runs:
 
     - name: Get github token from gati
       id: get-gh-token
-      if: inputs.revoke-token == 'false'
+      if: inputs.revoke-token == ""
       uses: smartcontractkit/chainlink-github-actions/github-app-token-issuer@main
       with:
         url: ${{ inputs.aws-lambda-url }}
 
     - name: Configure github token
-      if: inputs.set-git-config == 'true' && inputs.revoke-token == 'false'
+      if: inputs.set-git-config == 'true' && inputs.revoke-token == ""
       shell: bash
       run: |
         git config --global \
@@ -78,12 +78,12 @@ runs:
           "https://github.com/"
 
     - name: Revoke github token
-      if: inputs.revoke-token == 'true'
+      if: inputs.revoke-token != ""
       shell: bash
       run: |
-        curl -v -L \
+        curl -v -f -L \
           -X DELETE \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{ steps.get-gh-token.outputs.access-token }}" \
+          -H "Authorization: Bearer ${{ inputs.revoke-token }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/installation/token

--- a/actions/setup-github-token/package.json
+++ b/actions/setup-github-token/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-github-token",
-  "version": "0.2.1",
+  "version": "0.1.0",
   "description": "",
   "private": true,
   "scripts": {},

--- a/actions/setup-github-token/package.json
+++ b/actions/setup-github-token/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-github-token",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "description": "",
   "private": true,
   "scripts": {},


### PR DESCRIPTION
Github doesn’t allow explicit ordering of steps, meaning we cannot revoke the token within our action `setup-github-token`. Instead we will have to call a step separately at the end of all steps in the job to revoke the token.

Since it is going to be one single command, creating a separate action seems redundant. I've implemented a change to the existing `setup-github-token` to also allow user's to revoke the token and add an additional input revoke which when set will revoke the token. We can even rename this action to  `github-token-issuer` to avoid the confusion.

Tested here - https://github.com/smartcontractkit/mercury-pipeline/pull/1032/checks