### PR TITLE
Bumping the minor version of CRIB GH action

### DIFF
--- a/.changeset/calm-ducks-hope.md
+++ b/.changeset/calm-ducks-hope.md
@@ -1,0 +1,5 @@
+---
+"setup-crib-environment": minor
+---
+
+Initial version of the GH action.

--- a/actions/setup-crib-environment/README.md
+++ b/actions/setup-crib-environment/README.md
@@ -1,1 +1,3 @@
 # setup-crib-environment action
+
+> Enables PR flow for CRIB


### PR DESCRIPTION
In my previous PR the change-set file was missing. This would just build a new version of the action.