### PR TITLE
Run teardown in the post step

### DIFF
--- a/actions/setup-crib-environment/action.yml
+++ b/actions/setup-crib-environment/action.yml
@@ -151,7 +151,9 @@ runs:
         ./cribbit.sh "$NAMESPACE"
 
         devspace deploy --skip-build -o=${{ inputs.image-tag }}
-
+  # Run teardown at the of the Workflow Job, that way, CRIB workflow users
+  # should be able to run tests against provisioned environment
+  post:
     - name: Tear down CRIB ephemeral environment
       shell: bash
       if: ${{ inputs.disable-environment-teardown != 'true' }}


### PR DESCRIPTION
Execute teardown in the post step to allow users of the workflow to run tests against provisioned env.