### PR TITLE
Adding an extra step to label the Kubernetes namespace and associate it with GitHub context

### DIFF
--- a/.changeset/brave-balloons-juggle.md
+++ b/.changeset/brave-balloons-juggle.md
@@ -1,0 +1,5 @@
+---
+"crib-purge-environment": minor
+---
+
+Improving the params description

--- a/.changeset/shaggy-jokes-glow.md
+++ b/.changeset/shaggy-jokes-glow.md
@@ -1,0 +1,6 @@
+---
+"crib-deploy-environment": minor
+---
+
+Adding an extra step to label the Kubernetes namespace and associate it with
+GitHub context

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+### What
+
+<!--
+Brief, point form descriptions of what you changed
+Also, reference any Jira/Github issues here
+-->
+
+### Why
+
+<!--
+ Why is this change needed?
+-->
+
+<!--
+### Notes
+- Notes are optional
+- Note anything of importance here: such as explanations/reasoning, pull requests that block this one, or…
+- TODO items…
+-->

--- a/actions/crib-deploy-environment/README.md
+++ b/actions/crib-deploy-environment/README.md
@@ -1,3 +1,33 @@
-# crib-deploy-environment action
+# Setup CRIB Environment action
 
 > Enables PR flow for CRIB
+
+## Description
+
+This composite action is designed for setting up a CRIB environment. It deploys
+a CRIB, configures GAP, sets up Nix, and deploys to an ephemeral environment.
+
+## Inputs
+
+| **Input**                    | **Description**                                                                                                                                                   | **Required** | **Default**           |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ | --------------------- |
+| `api-gateway-host`           | API Gateway host for GAP, used to access the Kubernetes API.                                                                                                      | Yes          |                       |
+| `aws-region`                 | AWS region where resources will be deployed.                                                                                                                      | Yes          |                       |
+| `aws-role-arn`               | AWS Role ARN to be used for setting up GAP.                                                                                                                       | Yes          |                       |
+| `devspace-ingress-cidrs`     | DevSpace ingress CIDRs to control access.                                                                                                                         | No           | `0.0.0.0/0`           |
+| `devspace-profiles`          | Comma-separated list of DevSpace profiles to apply when running DevSpace commands. Example: `ci,values-dev-simulated-core-ocr1`.                                  | No           | `""`                  |
+| `ecr-private-registry`       | ECR private registry account ID for Production, needed for GAP.                                                                                                   | No           | `""`                  |
+| `ecr-private-registry-stage` | ECR private registry account ID for Staging.                                                                                                                      | No           | `""`                  |
+| `github-token`               | The `GITHUB_TOKEN` issued for the workflow.                                                                                                                       | No           | `${{ github.token }}` |
+| `image-tag`                  | Docker image tag for the product.                                                                                                                                 | No           | `latest`              |
+| `ingress-base-domain`        | Base domain for DevSpace ingress.                                                                                                                                 | Yes          |                       |
+| `k8s-cluster-name`           | Kubernetes cluster name.                                                                                                                                          | Yes          |                       |
+| `ns-ttl`                     | Namespace TTL, which defines how long a namespace will remain alive after creation, unless crib-purge-environment is configured to purge it once the job is done. | No           | `1h`                  |
+| `product`                    | The name of the product (e.g., `core`, `ccip`).                                                                                                                   | No           | `core`                |
+
+## Outputs
+
+| **Output**           | **Description**                                            |
+| -------------------- | ---------------------------------------------------------- |
+| `devspace-namespace` | Kubernetes namespace used to provision a CRIB environment. |
+| **Value**            | `${{ steps.generate-ns-name.outputs.devspace-namespace }}` |

--- a/actions/crib-deploy-environment/README.md
+++ b/actions/crib-deploy-environment/README.md
@@ -6,28 +6,3 @@
 
 This composite action is designed for setting up a CRIB environment. It deploys
 a CRIB, configures GAP, sets up Nix, and deploys to an ephemeral environment.
-
-## Inputs
-
-| **Input**                    | **Description**                                                                                                                                                   | **Required** | **Default**           |
-| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ | --------------------- |
-| `api-gateway-host`           | API Gateway host for GAP, used to access the Kubernetes API.                                                                                                      | Yes          |                       |
-| `aws-region`                 | AWS region where resources will be deployed.                                                                                                                      | Yes          |                       |
-| `aws-role-arn`               | AWS Role ARN to be used for setting up GAP.                                                                                                                       | Yes          |                       |
-| `devspace-ingress-cidrs`     | DevSpace ingress CIDRs to control access.                                                                                                                         | No           | `0.0.0.0/0`           |
-| `devspace-profiles`          | Comma-separated list of DevSpace profiles to apply when running DevSpace commands. Example: `ci,values-dev-simulated-core-ocr1`.                                  | No           | `""`                  |
-| `ecr-private-registry`       | ECR private registry account ID for Production, needed for GAP.                                                                                                   | No           | `""`                  |
-| `ecr-private-registry-stage` | ECR private registry account ID for Staging.                                                                                                                      | No           | `""`                  |
-| `github-token`               | The `GITHUB_TOKEN` issued for the workflow.                                                                                                                       | No           | `${{ github.token }}` |
-| `image-tag`                  | Docker image tag for the product.                                                                                                                                 | No           | `latest`              |
-| `ingress-base-domain`        | Base domain for DevSpace ingress.                                                                                                                                 | Yes          |                       |
-| `k8s-cluster-name`           | Kubernetes cluster name.                                                                                                                                          | Yes          |                       |
-| `ns-ttl`                     | Namespace TTL, which defines how long a namespace will remain alive after creation, unless crib-purge-environment is configured to purge it once the job is done. | No           | `1h`                  |
-| `product`                    | The name of the product (e.g., `core`, `ccip`).                                                                                                                   | No           | `core`                |
-
-## Outputs
-
-| **Output**           | **Description**                                            |
-| -------------------- | ---------------------------------------------------------- |
-| `devspace-namespace` | Kubernetes namespace used to provision a CRIB environment. |
-| **Value**            | `${{ steps.generate-ns-name.outputs.devspace-namespace }}` |

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -5,61 +5,61 @@ description:
 
 inputs:
   api-gateway-host:
-    description: API Gateway host for K8s
+    description: "API Gateway host for GAP, used to access the Kubernetes API."
     required: true
   aws-region:
-    description: AWS region
+    description: "AWS region."
     required: true
   aws-role-arn:
-    description: AWS Role ARN for CRIB
+    description: "AWS Role ARN to be used for setting up GAP."
     required: true
   devspace-ingress-cidrs:
-    default: 0.0.0.0/0
-    description: DevSpace ingress CIDRs
+    default: "0.0.0.0/0"
+    description: "DevSpace ingress CIDRs."
     required: false
   devspace-profiles:
     default: ""
-    required: false
     description: |
-      Coma separated list of devspace profiles to apply when running devspace commands.
-      Example: ci,values-dev-simulated-core-ocr1
+      "Comma-separated list of DevSpace profiles to apply when running DevSpace commands.
+      Example: ci,values-dev-simulated-core-ocr1."
+    required: false
   ecr-private-registry:
     default: ""
-    description: ECR private registry account ID in Prod, needed for GAP
+    description:
+      "ECR private registry account ID in Production, needed for GAP."
     required: false
   ecr-private-registry-stage:
     default: ""
-    description: ECR private registry account ID in Staging
+    description: "ECR private registry account ID in Staging."
     required: false
   github-token:
     description: "The `GITHUB_TOKEN` issued for the workflow."
-    required: false
     default: ${{ github.token }}
+    required: false
   image-tag:
-    default: latest
-    description: Docker image tag for the product
+    default: "latest"
+    description: "Docker image tag for the product."
     required: false
   ingress-base-domain:
-    description: DevSpace ingress base domain
+    description: "DevSpace ingress base domain."
     required: true
   k8s-cluster-name:
-    description: K8s cluster name
+    description: "Kubernetes cluster name."
     required: true
-  kube-cache-dir:
-    default: /dev/null
-    description: Configure kube cache dir
-    required: false
   ns-ttl:
-    default: 1h
-    description: Namespace TTL, used by Kyverno for cleanup
+    default: "1h"
+    description:
+      "Namespace TTL, which defines how long a namespace will remain alive after
+      creation."
     required: false
   product:
-    default: core
-    description: Product name
+    default: "core"
+    description: "The name of the product (e.g., core, ccip)."
     required: false
+
 outputs:
   devspace-namespace:
-    description: Kubernetes namespace used to provision CRIB
+    description: "Kubernetes namespace used to provision a CRIB environment."
     value: ${{ steps.generate-ns-name.outputs.devspace-namespace }}
 
 runs:
@@ -112,11 +112,36 @@ runs:
         enable-aws: true
         aws-region: ${{ inputs.aws-region }}
 
-    - name: Generate CRIB Namespace Name
+    - name: Generate CRIB Namespace Name and labels
       id: generate-ns-name
       shell: bash
       run: |
         echo "devspace-namespace=crib-ci-$(uuidgen | cut -c1-5)" >> $GITHUB_OUTPUT
+        # This will work only for PRs, push event itself does not contain PR information.
+        echo "pr-number=${{ github.event.number }}" >> $GITHUB_OUTPUT
+        echo "workflow-job=${{ github.job }}" >> $GITHUB_OUTPUT
+        echo "repo-name=$(basename $GITHUB_REPOSITORY)" >> $GITHUB_OUTPUT
+        echo "branch-name=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        echo "commit-sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+        echo "workflow-run-number=${{ github.run_number }}" >> $GITHUB_OUTPUT
+
+    - name: Crate and label CRIB namespace
+      shell: bash
+      run: |
+        NAMESPACE="${{ steps.generate-ns-name.outputs.devspace-namespace }}"
+        echo "Creating $NAMESPACE Kubernetes namespace.."
+        kubectl create ns "$NAMESPACE"
+
+        kubectl label namespace $NAMESPACE \
+          repo=${{ steps.generate-ns-name.outputs.repo-name }} \
+          branch=${{ steps.generate-ns-name.outputs.branch-name }} \
+          commit=${{ steps.generate-ns-name.outputs.commit-sha }} \
+          pr-number=${{ steps.generate-ns-name.outputs.pr-number || 'none' }} \
+          workflow-job=${{ steps.generate-ns-name.outputs.workflow-job }} \
+          workflow-run-number=${{ steps.generate-ns-name.outputs.workflow-run-number }}
+
+        echo "Kubernetes namespace [$NAMESPACE] successfully labeled:"
+        kubectl get namespace $NAMESPACE --show-labels
 
     - name: Deploy to CRIB ephemeral environment
       working-directory:
@@ -128,8 +153,8 @@ runs:
         CRIB_SKIP_DOCKER_ECR_LOGIN: true
         CRIB_SKIP_HELM_ECR_LOGIN: true
         DEVSPACE_IMAGE:
-          "${{
-          inputs.ecr-private-registry-stage}}.dkr.ecr.us-west-2.amazonaws.com/chainlink-devspace"
+          "${{ inputs.ecr-private-registry-stage
+          }}.dkr.ecr.us-west-2.amazonaws.com/chainlink-devspace"
         DEVSPACE_INGRESS_BASE_DOMAIN: ${{ inputs.ingress-base-domain }}
         DEVSPACE_INGRESS_CIDRS: ${{ inputs.devspace-ingress-cidrs }}
         PROFILES: ${{ inputs.devspace-profiles }}
@@ -143,7 +168,6 @@ runs:
         # Get the namespace name from GitHub Actions output
         NAMESPACE="${{ steps.generate-ns-name.outputs.devspace-namespace }}"
         echo "Using $NAMESPACE Kubernetes namespace"
-        kubectl create ns "$NAMESPACE"
 
         # Kyverno needs some time to inject the RoleBinding
         sleep 3

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -152,9 +152,7 @@ runs:
         CRIB_CI_ENV: true
         CRIB_SKIP_DOCKER_ECR_LOGIN: true
         CRIB_SKIP_HELM_ECR_LOGIN: true
-        DEVSPACE_IMAGE:
-          "${{ inputs.ecr-private-registry-stage
-          }}.dkr.ecr.us-west-2.amazonaws.com/chainlink-devspace"
+        DEVSPACE_IMAGE: "${{inputs.ecr-private-registry-stage}}.dkr.ecr.us-west-2.amazonaws.com/chainlink-devspace"
         DEVSPACE_INGRESS_BASE_DOMAIN: ${{ inputs.ingress-base-domain }}
         DEVSPACE_INGRESS_CIDRS: ${{ inputs.devspace-ingress-cidrs }}
         PROFILES: ${{ inputs.devspace-profiles }}

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -125,7 +125,7 @@ runs:
         echo "commit-sha=${{ github.sha }}" >> $GITHUB_OUTPUT
         echo "workflow-run-number=${{ github.run_number }}" >> $GITHUB_OUTPUT
 
-    - name: Crate and label CRIB namespace
+    - name: Create and label CRIB namespace
       shell: bash
       run: |
         NAMESPACE="${{ steps.generate-ns-name.outputs.devspace-namespace }}"

--- a/actions/crib-purge-environment/README.md
+++ b/actions/crib-purge-environment/README.md
@@ -6,14 +6,3 @@ The **`crib-purge-environment`** action is designed to destroy a CRIB ephemeral
 environment. It should be run after the `crib-deployment-environment` action to
 clean up resources. This action depends on the environment setup provided by the
 dependent composite action.
-
-## Inputs
-
-| **Input**          | **Description**                                                                                                            | **Required** | **Default** |
-| ------------------ | -------------------------------------------------------------------------------------------------------------------------- | ------------ | ----------- |
-| `namespace`        | The CRIB namespace that should be destroyed.                                                                               | Yes          |             |
-| `metrics-job-name` | The name of the Grafana metrics job. Required if other Grafana metrics inputs are provided.                                | No           |             |
-| `metrics-id`       | The Grafana metrics ID used for continuity of metrics during job name changes. Required if `metrics-job-name` is provided. | No           |             |
-| `gc-host`          | The Grafana hostname. Required if `metrics-job-name` is provided.                                                          | No           |             |
-| `gc-basic-auth`    | The basic authentication credentials for Grafana. Required if `metrics-job-name` is provided.                              | No           |             |
-| `gc-org-id`        | The Grafana organization or tenant ID. Required if `metrics-job-name` is provided.                                         | No           |             |

--- a/actions/crib-purge-environment/README.md
+++ b/actions/crib-purge-environment/README.md
@@ -1,3 +1,19 @@
-# crib-purge-environment
+# CRIB Purge Environment action
 
-> Action to destroy CRIB epehemeral environment
+## Description
+
+The **`crib-purge-environment`** action is designed to destroy a CRIB ephemeral
+environment. It should be run after the `crib-deployment-environment` action to
+clean up resources. This action depends on the environment setup provided by the
+dependent composite action.
+
+## Inputs
+
+| **Input**          | **Description**                                                                                                            | **Required** | **Default** |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------- | ------------ | ----------- |
+| `namespace`        | The CRIB namespace that should be destroyed.                                                                               | Yes          |             |
+| `metrics-job-name` | The name of the Grafana metrics job. Required if other Grafana metrics inputs are provided.                                | No           |             |
+| `metrics-id`       | The Grafana metrics ID used for continuity of metrics during job name changes. Required if `metrics-job-name` is provided. | No           |             |
+| `gc-host`          | The Grafana hostname. Required if `metrics-job-name` is provided.                                                          | No           |             |
+| `gc-basic-auth`    | The basic authentication credentials for Grafana. Required if `metrics-job-name` is provided.                              | No           |             |
+| `gc-org-id`        | The Grafana organization or tenant ID. Required if `metrics-job-name` is provided.                                         | No           |             |

--- a/actions/crib-purge-environment/action.yml
+++ b/actions/crib-purge-environment/action.yml
@@ -1,31 +1,37 @@
 name: crib-purge-environment
 description: |
   Action to destroy CRIB epehemeral environment.
-  It requires to run crib-deployment-environment beforehand 
+  It requires to run crib-deployment-environment beforehand
   and depends on the environment setup from a dependent composite action.
 
 inputs:
   namespace:
-    description: CRIB Namespace that should be destroyed
+    description: "The CRIB namespace that should be destroyed."
     required: true
-  # grafana inputs (optional)
+  # Grafana inputs (optional)
   metrics-job-name:
-    description: "grafana metrics job name"
+    description:
+      "The name of the Grafana metrics job. Required if other Grafana metrics
+      inputs are provided."
     required: false
   metrics-id:
     description:
-      "grafana metrics id, used for continuity of metrics during job name
-      changes  - required if metrics-job-name is passed"
+      "The Grafana metrics ID used for continuity of metrics during job name
+      changes. Required if `metrics-job-name` is provided."
     required: false
   gc-host:
-    description: "grafana hostname - required if metrics-job-name is passed"
+    description:
+      "The Grafana hostname. Required if `metrics-job-name` is provided."
     required: false
   gc-basic-auth:
-    description: "grafana basic auth - required if metrics-job-name is passed"
+    description:
+      "The basic authentication credentials for Grafana. Required if
+      `metrics-job-name` is provided."
     required: false
   gc-org-id:
     description:
-      "grafana org/tenant id - required if metrics-job-name is passed"
+      "The Grafana organization or tenant ID. Required if `metrics-job-name` is
+      provided."
     required: false
 
 runs:


### PR DESCRIPTION
## What 

- Add an extra step to label the Kubernetes namespace and associate it with the GitHub context.
- Improve parameter descriptions.
- Add basic documentation to the composite CRIB actions.



## Why 

As a CRIB user, I’d like to be able to debug if something fails. I want to find the namespace by PR number, GitHub branch, or commit.
