### PR TITLE
Sanitize branch name for valid K8s label value

### DIFF
--- a/.changeset/modern-cycles-grow.md
+++ b/.changeset/modern-cycles-grow.md
@@ -1,0 +1,5 @@
+---
+"crib-deploy-environment": patch
+---
+
+Sanitize branch name for valid K8s label value

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -132,13 +132,20 @@ runs:
     - name: Create and label CRIB namespace
       shell: bash
       run: |
+        # a valid label must be an empty string or consist of alphanumeric characters,
+        # ‘-’, ‘_’ or ‘.’, and must start and end with an alphanumeric character
+        # (e.g. ‘MyValue’,  or ‘my_value’,  or ‘12345’, regex used for validation is
+        # ‘(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?’)
+        sanitized_branch=$(echo "${{ steps.generate-ns-name.outputs.branch-name }}" \
+          | sed 's/[^a-zA-Z0-9._-]/_/g')
+
         NAMESPACE="${{ steps.generate-ns-name.outputs.devspace-namespace }}"
         echo "Creating $NAMESPACE Kubernetes namespace.."
         kubectl create ns "$NAMESPACE"
 
         kubectl label namespace $NAMESPACE \
           repo=${{ steps.generate-ns-name.outputs.repo-name }} \
-          branch=${{ steps.generate-ns-name.outputs.branch-name }} \
+          branch="${sanitized_branch}" \
           commit=${{ steps.generate-ns-name.outputs.commit-sha }} \
           pr-number=${{ steps.generate-ns-name.outputs.pr-number || 'none' }} \
           workflow-job=${{ steps.generate-ns-name.outputs.workflow-job }} \


### PR DESCRIPTION
### What

See title.

### Why

Fixes this error:

> error: invalid label value: “branch=crib-264/crib-slack-alerts”: a valid label must be an empty string or consist of alphanumeric characters, ‘-’, ‘_’ or ‘.’, and must start and end with an alphanumeric character (e.g. ‘MyValue’,  or ‘my_value’,  or ‘12345’, regex used for validation is ‘(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?’)
