### PR TITLE
Apply TTL label from input

### DIFF
--- a/.changeset/big-dragons-cough.md
+++ b/.changeset/big-dragons-cough.md
@@ -2,4 +2,4 @@
 "crib-deploy-environment": patch
 ---
 
-Apply ttl label from based on action inputs
+Apply kyverno ttl label based on action inputs

--- a/.changeset/big-dragons-cough.md
+++ b/.changeset/big-dragons-cough.md
@@ -1,0 +1,5 @@
+---
+"crib-deploy-environment": patch
+---
+
+Apply ttl label from based on action inputs

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -154,6 +154,7 @@ runs:
         kubectl create ns "$NAMESPACE"
 
         kubectl label namespace $NAMESPACE \
+          cleanup.kyverno.io/ttl=${{ inputs.ns-ttl }}
           repo=${{ steps.generate-ns-name.outputs.repo-name }} \
           branch="${sanitized_branch}" \
           commit=${{ steps.generate-ns-name.outputs.commit-sha }} \
@@ -178,7 +179,6 @@ runs:
         DEVSPACE_INGRESS_CIDRS: ${{ inputs.devspace-ingress-cidrs }}
         PROFILES: ${{ inputs.devspace-profiles }}
         KUBECACHEDIR: /dev/null
-        NS_TTL: ${{ inputs.ns-ttl }}
         SETUP_AWS_PROFILE: false
         SETUP_EKS_CONFIG: false
       run: |


### PR DESCRIPTION
After removing the post deploy hook here: https://github.com/smartcontractkit/crib/pull/119/files#diff-1b44374eedc5da9022d1ee7a59efe99af06e54c90b30e980355438e7023c3041L106 which was necessary to fix a [bug](https://chainlink-core.slack.com/archives/C0637K4BBC2/p1724400971167039).

TTL label is no longer applied in the CI flow. This should backfill previous behavior in the CI flow