### PR TITLE
CRIB-350: adding CCIP UI to the smoke test

### DIFF
--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -193,9 +193,10 @@ runs:
         # Kyverno needs some time to inject the RoleBinding
         sleep 3
 
-        # Check if product is ccip and set ATLAS_ENABLED accordingly
+        # Check if product is ccip and set ATLAS_ENABLED and CCIP_UI_ENABLED accordingly
         if [[ "${{ inputs.product }}" == "ccip" ]]; then
           export ATLAS_ENABLED=true
+          export CCIP_UI_ENABLED=true
         fi
 
         nix develop -c ./cribbit.sh "$NAMESPACE"


### PR DESCRIPTION
Once https://github.com/smartcontractkit/crib/pull/132 is merged, the CCIP UI application will be included in CRIB. This change is to make sure our smoke test covers it as well.

It's harmless to merge it before https://github.com/smartcontractkit/crib/pull/132, since it's a new env var which is atm not interpreted by CRIB.