### PR TITLE
crib-setup-deployment version bump after https://github.com/smartcontractkit/.github/pull/587

### DIFF
--- a/.changeset/great-camels-tell.md
+++ b/.changeset/great-camels-tell.md
@@ -1,0 +1,6 @@
+---
+"crib-deploy-environment": minor
+---
+
+The CRIB CCIP smoke tests will set CCIP_UI_ENABLED to true, in order to test the
+newly added component.


### PR DESCRIPTION
my bad, did the PR before I read the README.md instructions. This bumps the version of crib-setup-environment, which already contains the desired change.