### PR TITLE
fix: set gap-name default to execute-api

### DIFF
--- a/.changeset/lemon-experts-wonder.md
+++ b/.changeset/lemon-experts-wonder.md
@@ -1,0 +1,5 @@
+---
+"setup-gap": minor
+---
+
+change gap-name default value to execute-api

--- a/actions/setup-gap/action.yml
+++ b/actions/setup-gap/action.yml
@@ -13,7 +13,7 @@ inputs:
       docker container name. Required if using multiple invocations of this in
       the same job."
     required: false
-    default: default
+    default: execute-api
   use-tls:
     description:
       "Enable TLS for the local sigv4 proxy container. Ignored if `use-k8s:


### PR DESCRIPTION
### Changes

- Update default value to `gap-name` to `execute-api`. I believe this should almost always be `execute-api` except for certain crib use-cases?

### Testing 

Discovered this error when trying using `setup-gap@main` for a new workflow.

```
ERRO[0003] error proxying request                        message="{\"message\":\"Credential should be scoped to correct service: 'execute-api'. \"}" request="POST https://<redacted>.execute-api.us-west-2.amazonaws.com/primary/<endpoint>" status_code=403
```


---

https://github.com/awslabs/aws-sigv4-proxy?tab=readme-ov-file#configuration
| Flag (or short form)          | Type     | Description                                                | Default |
|-------------------------------|----------|------------------------------------------------------------|---------|
| `name`                        | String   | AWS Service to sign for                                    | None    |