### PR TITLE
Skip flaky tests, until they are fixed in CI

### DIFF
--- a/apps/go-mod-validator/test/e2e.test.ts
+++ b/apps/go-mod-validator/test/e2e.test.ts
@@ -100,7 +100,7 @@ describe("e2e tests", () => {
     annotationSpy.mockClear();
   });
 
-  describe("chainlink", () => {
+  describe.skip("chainlink", () => {
     describe("non pull request mode", () => {
       it("should fail on wsrpc", async () => {
         const nockDone = await setupNonPR(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,8 @@ importers:
 
   actions/crib-purge-environment: {}
 
+  actions/ctf-build-test-image: {}
+
   actions/dispatch-workflow: {}
 
   actions/get-latest-github-release: {}


### PR DESCRIPTION
These tests has beed failing last few days and they are blocking many PRs in the repo.
We should figure out the fix and re-enable them once they are stable

We have removed temporarily `ci-tests` check from protected branch, to unblock PRs. After this PR we could re-enable it.

CC: @HenryNguyen5 