### PR TITLE
Migrate CTF actions from smartcontractkit/chainlink-github-actions

### DIFF
--- a/.changeset/fluffy-meals-allow.md
+++ b/.changeset/fluffy-meals-allow.md
@@ -1,0 +1,5 @@
+---
+"ctf-cleanup": minor
+---
+
+Add ctf-cleanup action

--- a/.changeset/ninety-suits-suffer.md
+++ b/.changeset/ninety-suits-suffer.md
@@ -1,0 +1,5 @@
+---
+"ctf-run-tests-binary": minor
+---
+
+Add ctf-run-tests-binary action

--- a/.changeset/plenty-pans-fly.md
+++ b/.changeset/plenty-pans-fly.md
@@ -1,0 +1,5 @@
+---
+"ctf-build-image": minor
+---
+
+Add ctf-build-image action

--- a/.changeset/proud-eels-greet.md
+++ b/.changeset/proud-eels-greet.md
@@ -1,0 +1,5 @@
+---
+"ctf-show-grafana-in-test-summary": minor
+---
+
+Add ctf-show-grafana-in-test-summary action

--- a/.changeset/proud-falcons-repair.md
+++ b/.changeset/proud-falcons-repair.md
@@ -1,0 +1,5 @@
+---
+"ctf-setup-run-tests-environment": minor
+---
+
+Add ctf-setup-run-tests-environment action

--- a/.changeset/swift-radios-stare.md
+++ b/.changeset/swift-radios-stare.md
@@ -1,0 +1,5 @@
+---
+"ctf-setup-go": minor
+---
+
+Add ctf-setup-go action

--- a/.changeset/tidy-days-perform.md
+++ b/.changeset/tidy-days-perform.md
@@ -1,0 +1,5 @@
+---
+"ctf-run-tests": minor
+---
+
+Add ctf-run-tests action

--- a/.changeset/tough-worms-look.md
+++ b/.changeset/tough-worms-look.md
@@ -1,0 +1,5 @@
+---
+"ctf-check-mod-version": minor
+---
+
+Add ctf-check-mod-version action

--- a/.changeset/tough-zoos-allow.md
+++ b/.changeset/tough-zoos-allow.md
@@ -1,0 +1,5 @@
+---
+"ctf-build-tests": minor
+---
+
+Add ctf-build-tests action

--- a/actions/ctf-build-image/README.md
+++ b/actions/ctf-build-image/README.md
@@ -1,0 +1,3 @@
+# ctf-build-image
+
+> Common action for building chainlink test images

--- a/actions/ctf-build-image/action.yml
+++ b/actions/ctf-build-image/action.yml
@@ -1,0 +1,190 @@
+name: ctf-build-image
+description: "Common action for building chainlink test images"
+
+inputs:
+  cl_repo:
+    required: true
+    description: The chainlink repository to use
+    default: ${{ github.repository }}
+  cl_ref:
+    required: false
+    description: The git ref from the chainlink repository to use
+    default: develop
+  cl_dockerfile:
+    required: false
+    description: The chainlink dockerfile to use to build the image with
+    default: core/chainlink.Dockerfile
+  push_tag:
+    required: true
+    description:
+      The full docker tag to use for the push to ecr, does not push anything if
+      tag is empty
+  dep_solana_sha:
+    required: false
+    description: chainlink-solana commit or branch
+  dep_cosmos_sha:
+    required: false
+    description: chainlink-cosmos commit or branch
+  dep_starknet_sha:
+    required: false
+    description: chainlink-starknet commit or branch
+  dep_atlas_sha:
+    required: false
+    description: atlas commit or branch
+  dep_common_sha:
+    required: false
+    description: chainlink-common commit or branch
+  dep_evm_sha:
+    required: false
+    description: chainlink-integrations/evm/relayer commit or branch
+  QA_AWS_REGION:
+    required: true
+    description: The AWS region to use
+  QA_AWS_ROLE_TO_ASSUME:
+    required: true
+    description: The AWS role to assume
+  QA_PRIVATE_GHA_PULL:
+    required: false
+    description: Token to pull private repos
+  GOPRIVATE:
+    required: false
+    description: private repos needed for go
+  GO_COVER_FLAG:
+    required: false
+    default: false
+    description: Build chainlink binary with cover flag
+  should_checkout:
+    required: false
+    description:
+      Do we want to checkout the chainlink code branch, sometimes we don't need
+      to
+  docker_secrets:
+    description: Secrets to pass to the docker build and push action
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout Chainlink repo
+      if: ${{ inputs.should_checkout == 'true' }}
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        repository: ${{ inputs.cl_repo }}
+        ref: ${{ inputs.cl_ref }}
+    - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      env:
+        GOPRIVATE: ${{ inputs.GOPRIVATE }}
+      with:
+        go-version-file: "go.mod"
+        check-latest: true
+        cache: false
+    - name: Replace GHA URL
+      shell: bash
+      env:
+        GOPRIVATE: ${{ inputs.GOPRIVATE }}
+        QA_PRIVATE_GHA_PULL: ${{ inputs.QA_PRIVATE_GHA_PULL }}
+      run:
+        git config --global url.https://${{ inputs.QA_PRIVATE_GHA_PULL
+        }}@github.com/.insteadOf https://github.com/
+    - name: Replace Solana deps
+      if: ${{ inputs.dep_solana_sha }}
+      shell: bash
+      run:
+        go get github.com/smartcontractkit/chainlink-solana@${{
+        inputs.dep_solana_sha }}
+    - name: Replace Cosmos deps
+      if: ${{ inputs.dep_cosmos_sha }}
+      shell: bash
+      run:
+        go get github.com/smartcontractkit/chainlink-cosmos@${{
+        inputs.dep_cosmos_sha }}
+    - name: Replace StarkNet deps
+      if: ${{ inputs.dep_starknet_sha }}
+      shell: bash
+      run:
+        go get github.com/smartcontractkit/chainlink-starknet/relayer@${{
+        inputs.dep_starknet_sha }}
+    - name: Replace Atlas deps
+      if: ${{ inputs.dep_atlas_sha }}
+      shell: bash
+      env:
+        GOPRIVATE: ${{ inputs.GOPRIVATE }}
+      run: go get github.com/smartcontractkit/atlas@${{ inputs.dep_atlas_sha }}
+    - name: Replace chainlink-common deps
+      if: ${{ inputs.dep_common_sha }}
+      shell: bash
+      run:
+        go get github.com/smartcontractkit/chainlink-common@${{
+        inputs.dep_common_sha }}
+
+    # TODO: Remove this when it is no longer needed and uncomment the replace lower down.
+    - name: Replace the chainlink-integration deps
+      if: ${{ inputs.dep_evm_sha }}
+      shell: bash
+      env:
+        MODULE: github.com/smartcontractkit/chainlink-integrations/evm/relayer
+        COMMIT_HASH: ${{ inputs.dep_evm_sha }}
+      run: |
+        # Update to the evm/relayer code we wish to test against
+        go env -w GOPRIVATE=github.com/smartcontractkit/chainlink-integrations
+        go get ${MODULE}@${COMMIT_HASH}
+        # push replace into core go.mod, remove this once the evm migration is complete
+        PSEUDO_VERSION=$(go list -m -mod=mod ${MODULE}@${COMMIT_HASH} | awk '{print $2}')
+        go mod edit -replace=github.com/smartcontractkit/chainlink/v2/core/chains/evm=${MODULE}@${PSEUDO_VERSION}
+        go mod tidy
+    # TODO: put this back in when the replace above is no longer needed
+    # - name: Replace chainlink-integrations/evm/relayer deps
+    #   if: ${{ inputs.dep_evm_sha }}
+    #   shell: bash
+    #   run: go get github.com/smartcontractkit/chainlink-integrations/evm/relayer@${{ inputs.dep_evm_sha }}
+    - name: Tidy
+      shell: bash
+      env:
+        GOPRIVATE: ${{ inputs.GOPRIVATE }}
+      run: go mod tidy
+    - name: Cat go.mod
+      shell: bash
+      run: cat go.mod
+    - name: Setup push_tag
+      id: push
+      shell: bash
+      run: |
+        if [ "${{ inputs.push_tag }}" != "" ]; then
+          # tag exists so we can push
+          echo "push=true" >>$GITHUB_OUTPUT
+        else
+          # tag is empty, don't push
+          echo "push=false" >>$GITHUB_OUTPUT
+        fi
+    - name: Configure AWS Credentials
+      if: steps.push.outputs.push == 'true'
+      uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+      with:
+        aws-region: ${{ inputs.QA_AWS_REGION }}
+        role-to-assume: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}
+        role-duration-seconds: 3600
+        mask-aws-account-id: true
+    - name: Login to Amazon ECR
+      if: steps.push.outputs.push == 'true'
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+      with:
+        mask-password: "true"
+    - name: Set up Docker Buildx
+      if: steps.push.outputs.push == 'true'
+      uses: docker/setup-buildx-action@0d103c3126aa41d772a8362f6aa67afac040f80c # v3.1.0
+    - name: Build and Push
+      uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
+      with:
+        context: .
+        file: ${{ inputs.cl_dockerfile }}
+        # comma separated like: KEY1=VAL1,KEY2=VAL2,...
+        build-args: |
+          COMMIT_SHA=${{ github.sha }}
+          CHAINLINK_USER=chainlink
+          GO_COVER_FLAG=${{ inputs.GO_COVER_FLAG }}
+        tags: ${{ inputs.push_tag }}
+        push: ${{ steps.push.outputs.push }}
+        secrets: ${{ inputs.docker_secrets }}
+        # enabled by default as of v4 - disable while upgrading action reference (v3 -> v5)
+        provenance: false

--- a/actions/ctf-build-image/package.json
+++ b/actions/ctf-build-image/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ctf-build-image",
+  "version": "0.0.0",
+  "description": "",
+  "private": true,
+  "scripts": {},
+  "author": "@smartcontractkit",
+  "license": "MIT",
+  "dependencies": {},
+  "repository": "https://github.com/smartcontractkit/.github"
+}

--- a/actions/ctf-build-image/project.json
+++ b/actions/ctf-build-image/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "ctf-build-image",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "actions/ctf-build-image",
+  "targets": {}
+}

--- a/actions/ctf-build-tests/README.md
+++ b/actions/ctf-build-tests/README.md
@@ -1,0 +1,3 @@
+# ctf-build-tests
+
+> Builds a test binary for chainlink integration tests

--- a/actions/ctf-build-tests/action.yml
+++ b/actions/ctf-build-tests/action.yml
@@ -1,0 +1,98 @@
+name: ctf-build-tests
+description: "Builds a test binary for chainlink integration tests"
+
+inputs:
+  binary_name:
+    required: false
+    description: Name of the artifact to upload
+    default: test-logs
+  test_download_vendor_packages_command:
+    required: false
+    description: The command to download the go modules
+    default: make download
+  test_type:
+    required: false
+    description: The name of the test type you plan to run, e.g. smoke
+    default: smoke
+  token:
+    required: false
+    description: The GITHUB_TOKEN for the workflow
+    default: ${{ github.token }}
+  go_version:
+    required: false
+    description: Go version to install
+  go_mod_path:
+    required: false
+    description: The go.mod file path
+  go_tags:
+    required: false
+    description: Go tags to use when building
+  cache_restore_only:
+    required: false
+    description:
+      Only restore the cache, set to true if you want to restore and save on
+      cache hit miss
+    default: "false"
+  cache_key_id:
+    required: false
+    description: Cache go vendors unique id
+    default: go
+  dep_chainlink_integration_tests:
+    required: false
+    description: chainlink/integration-tests commit or branch
+  CGO_ENABLED:
+    required: false
+    description: Whether to have cgo enabled, defaults to disabled
+    default: "0"
+
+runs:
+  using: composite
+  steps:
+    # Setup Tools and libraries
+    - name: Setup Go
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go@v2.3.7
+      with:
+        test_download_vendor_packages_command:
+          ${{ inputs.test_download_vendor_packages_command }}
+        go_version: ${{ inputs.go_version }}
+        go_mod_path: ${{ inputs.go_mod_path }}
+        cache_restore_only: ${{ inputs.cache_restore_only }}
+        cache_key_id: ${{ inputs.cache_key_id }}
+        should_tidy: "true"
+
+    - name: Replace chainlink/integration-tests deps
+      if: ${{ inputs.dep_chainlink_integration_tests }}
+      shell: bash
+      run: |
+        # find test go root by using the go_mod_path and change to that directory
+        TEST_LIB_PATH="${{ inputs.go_mod_path }}"
+        if [ "${#TEST_LIB_PATH}" -gt "6" ]; then
+            TEST_LIB_PATH=${TEST_LIB_PATH%go.mod}
+            cd "${TEST_LIB_PATH}"
+        fi
+
+        go version
+        # update the integration-tests lib to the branch or commit
+        go get github.com/smartcontractkit/chainlink/integration-tests@${{ inputs.dep_chainlink_integration_tests }}
+        go mod tidy
+
+    - name: Build Tests
+      shell: bash
+      env:
+        CGO_ENABLED: ${{ inputs.CGO_ENABLED }}
+      run: |
+        PATH=$PATH:$(go env GOPATH)/bin
+        export PATH
+        TAGS="${{ inputs.go_tags }}"
+        if [ -n "$TAGS" ]; then
+            echo "Using build tags: $TAGS"
+            TAGS="-tags ${TAGS} "
+        fi
+        cd ./integration-tests && go test -c $TAGS-ldflags="-s -w" -o ./tests ./${{ inputs.test_type }}
+        echo "Built binary at ./integration-tests/tests"
+
+    - name: Publish Binary
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+      with:
+        name: ${{ inputs.binary_name }}
+        path: ./integration-tests/tests

--- a/actions/ctf-build-tests/package.json
+++ b/actions/ctf-build-tests/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ctf-build-tests",
+  "version": "0.0.0",
+  "description": "",
+  "private": true,
+  "scripts": {},
+  "author": "@smartcontractkit",
+  "license": "MIT",
+  "dependencies": {},
+  "repository": "https://github.com/smartcontractkit/.github"
+}

--- a/actions/ctf-build-tests/project.json
+++ b/actions/ctf-build-tests/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "ctf-build-tests",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "actions/ctf-build-tests",
+  "targets": {}
+}

--- a/actions/ctf-check-mod-version/README.md
+++ b/actions/ctf-check-mod-version/README.md
@@ -1,0 +1,3 @@
+# ctf-check-mod-version
+
+> Check go mod version and optionally enforce semantic version

--- a/actions/ctf-check-mod-version/action.yml
+++ b/actions/ctf-check-mod-version/action.yml
@@ -1,0 +1,62 @@
+name: ctf-check-mod-version
+description: "Check go mod version and optionally enforce semantic version "
+
+inputs:
+  go-project-path:
+    required: true
+    description:
+      The path to the base of the go project where the go.mod file lives
+  module-name:
+    required: true
+    description: The module name to get
+  enforce-semantic-tag:
+    required: false
+    description: Should we enforce the version to be a semantic tag
+    default: "false"
+outputs:
+  version:
+    description: Did we clean up pods
+    value: ${{ steps.version.outputs.version }}
+  is_semantic:
+    description: Is the version a proper semantic version
+    value: ${{ steps.enforce.outputs.pass }}
+
+runs:
+  using: composite
+  steps:
+    - name: Get version
+      id: version
+      shell: bash
+      env:
+        go_project_path: ${{ inputs.go-project-path }}
+        package_name: ${{ inputs.module-name }}
+      run: |
+        cd ${go_project_path}
+        # Extract the version of the package from go.mod
+        version=$(grep "$package_name " go.mod | awk '{print $2}')
+        echo "Found version: $version"
+        # Check if version is empty
+        if [ -z "$version" ]; then
+            echo "There is no version for $package_name"
+            exit 1  # Exit with a failure code
+        else
+            echo "Found version: $version"
+        fi
+        echo "version=${version}" >>$GITHUB_OUTPUT
+    - name: Enforce Semantic version
+      id: enforce
+      shell: bash
+      env:
+        version: ${{ steps.version.outputs.version }}
+        enforce: ${{ inputs.enforce-semantic-tag }}
+      run: |
+        if [[ $version =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "The version $version is a semantic version."
+            echo "pass=true" >>$GITHUB_OUTPUT
+        else
+            echo "pass=false" >>$GITHUB_OUTPUT
+            if [ "$enforce" = "true" ]; then
+                echo "The version $version is not a semantic version, it should be a proper release tag and not based off a commit."
+                exit 1
+            fi
+        fi

--- a/actions/ctf-check-mod-version/package.json
+++ b/actions/ctf-check-mod-version/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ctf-check-mod-version",
+  "version": "0.0.0",
+  "description": "",
+  "private": true,
+  "scripts": {},
+  "author": "@smartcontractkit",
+  "license": "MIT",
+  "dependencies": {},
+  "repository": "https://github.com/smartcontractkit/.github"
+}

--- a/actions/ctf-check-mod-version/project.json
+++ b/actions/ctf-check-mod-version/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "ctf-check-mod-version",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "actions/ctf-check-mod-version",
+  "targets": {}
+}

--- a/actions/ctf-cleanup/README.md
+++ b/actions/ctf-cleanup/README.md
@@ -1,0 +1,3 @@
+# ctf-cleanup
+
+> Common CTF action for cleaning up k8s namespaces

--- a/actions/ctf-cleanup/action.yml
+++ b/actions/ctf-cleanup/action.yml
@@ -1,0 +1,59 @@
+name: ctf-cleanup
+description: "Common CTF action for cleaning up k8s namespaces"
+
+inputs:
+  triggered_by:
+    required: true
+    description: The triggered-by label for the k8s namespace
+    default: ci
+  should_cleanup:
+    required: false
+    description:
+      Whether to run the cleanup at the end, soak tests and such would not want
+      to automatically cleanup
+    default: "true"
+outputs:
+  did_skip_clean:
+    description: Did we clean up pods
+    value: ${{ steps.skipped.outputs.did_skip || 'false' }}
+
+runs:
+  using: composite
+  steps:
+    - name: check kubectl
+      if: inputs.should_cleanup == 'true'
+      id: kubectlcheck
+      shell: bash
+      run: |
+        VERSION=$(kubectl get ns -l=triggered-by=${{ inputs.triggered_by }}-${{ github.event.pull_request.number || github.run_id }} || echo "failed")
+        FAIL="${VERSION: -6}"
+        echo "${FAIL}"
+        if [ "${FAIL}" = "failed" ]; then
+          echo "pass=false" >>$GITHUB_OUTPUT
+          echo "The k8s environment was not setup, so there are no environments to cleanup"
+        else
+          echo "pass=true" >>$GITHUB_OUTPUT
+        fi
+    - name: cleanup k8s cluster namespaces
+      if:
+        steps.kubectlcheck.outputs.pass == 'true' && inputs.should_cleanup ==
+        'true'
+      shell: bash
+      run: |
+        echo "looking for namespaces"
+        ITEMS=$(kubectl get ns -l=triggered-by=${{ inputs.triggered_by }}-${{ github.event.pull_request.number || github.run_id }} -o jsonpath='{.items}')
+        COUNT=$(echo "${ITEMS}" | jq '. | length')
+        echo "found ${COUNT} namespaces to cleanup"
+        for ((i=0;i<${COUNT};i++)); do
+          name=$(echo "${ITEMS}" | jq -r ".[${i}].metadata.name")
+          echo "deleting namespace: ${name}"
+          kubectl delete ns "${name}" || echo "namespace no longer exists"
+        done
+        echo "completed cleanup"
+    - name: Skipped cleanup
+      id: skipped
+      if: inputs.should_cleanup == 'false'
+      shell: bash
+      run: |
+        echo "Skipped cleanup"
+        echo "did_skip=true" >>$GITHUB_OUTPUT

--- a/actions/ctf-cleanup/package.json
+++ b/actions/ctf-cleanup/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ctf-cleanup",
+  "version": "0.0.0",
+  "description": "",
+  "private": true,
+  "scripts": {},
+  "author": "@smartcontractkit",
+  "license": "MIT",
+  "dependencies": {},
+  "repository": "https://github.com/smartcontractkit/.github"
+}

--- a/actions/ctf-cleanup/project.json
+++ b/actions/ctf-cleanup/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "ctf-cleanup",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "actions/ctf-cleanup",
+  "targets": {}
+}

--- a/actions/ctf-run-tests-binary/README.md
+++ b/actions/ctf-run-tests-binary/README.md
@@ -1,0 +1,3 @@
+# ctf-run-tests-binary
+
+> Run CTF test binary

--- a/actions/ctf-run-tests-binary/action.yml
+++ b/actions/ctf-run-tests-binary/action.yml
@@ -1,0 +1,154 @@
+name: ctf-run-tests-binary
+description: "Run CTF test binary"
+
+inputs:
+  artifacts_location:
+    required: false
+    description: Location of where error logs are written
+    default: ./logs
+  artifacts_name:
+    required: false
+    description: Name of the artifact to upload
+    default: test-logs
+  test_command_to_run:
+    required: true
+    description:
+      The command to run the tests by calling your binary (note that -test.json
+      is not supported)
+    # https://github.com/golang/go/issues/22996
+  cl_repo:
+    required: false
+    description: The Chainlink ecr repository to use
+    default: public.ecr.aws/z0b1w9r9/chainlink
+  cl_image_tag:
+    required: false
+    description: The chainlink image to use
+    default: develop
+  build_gauntlet_command:
+    required: false
+    description: How to build gauntlet if necessary
+    default: "false"
+  download_contract_artifacts_path:
+    required: false
+    description: Path where the contract artifacts need to be placed
+    default: "none"
+  token:
+    required: false
+    description: The GITHUB_TOKEN for the workflow
+    default: ${{ github.token }}
+  triggered_by:
+    required: true
+    description:
+      The triggered-by label for the k8s namespace, required for cleanup
+    default: ci
+  cache_restore_only:
+    required: false
+    description:
+      Only restore the cache, set to true if you want to restore and save on
+      cache hit miss
+    default: "false"
+  cache_key_id:
+    required: false
+    description: Cache go vendors unique id
+    default: go
+  aws_registries:
+    required: false
+    description: AWS registries to log into for the test if needed
+  aws_role_duration_seconds:
+    required: false
+    default: "3600"
+    description: The duration to be logged into the aws role for
+  dockerhub_username:
+    description:
+      Username for Docker Hub to avoid rate limits when pulling public images
+    required: false
+  dockerhub_password:
+    description:
+      Password for Docker Hub to avoid rate limits when pulling public images
+    required: false
+  QA_AWS_REGION:
+    required: true
+    description: The AWS region to use
+  QA_AWS_ROLE_TO_ASSUME:
+    required: true
+    description: The AWS role to assume
+  QA_KUBECONFIG:
+    required: false
+    description: The kubernetes configuration to use
+  should_cleanup:
+    required: false
+    description:
+      Whether to run the cleanup at the end, soak tests and such would not want
+      to automatically cleanup
+    default: "false"
+  binary_name:
+    required: true
+    description: Name of the binary artifact to run
+    default: tests
+  should_tidy:
+    required: false
+    description: Should we check go mod tidy
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Environment
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@v2.3.20
+      with:
+        go_necessary: "false"
+        cache_restore_only: ${{ inputs.cache_restore_only }}
+        cache_key_id: ${{ inputs.cache_key_id }}
+        aws_registries: ${{ inputs.aws_registries }}
+        aws_role_duration_seconds: ${{ inputs.aws_role_duration_seconds }}
+        dockerhub_username: ${{ inputs.dockerhub_username }}
+        dockerhub_password: ${{ inputs.dockerhub_password }}
+        QA_AWS_REGION: ${{ inputs.QA_AWS_REGION }}
+        QA_AWS_ROLE_TO_ASSUME: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}
+        QA_KUBECONFIG: ${{ inputs.QA_KUBECONFIG }}
+        should_tidy: ${{ inputs.should_tidy }}
+
+    # Download any external artifacts
+    - name: Download Artifacts
+      if: inputs.download_contract_artifacts_path != 'none'
+      uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+      with:
+        name: artifacts
+        path: ${{ inputs.download_contract_artifacts_path }}
+
+    # Generate any excutables needed to run tests
+    - name: Generate gauntlet executable
+      if: inputs.build_gauntlet_command != 'false'
+      shell: bash
+      run: ${{ inputs.build_gauntlet_command }}
+
+    # Run the tests
+    - name: Run Tests
+      shell: bash
+      env:
+        CHAINLINK_IMAGE: ${{ inputs.cl_repo }}
+        CHAINLINK_VERSION: ${{ inputs.cl_image_tag }}
+        CHAINLINK_ENV_USER: ${{ github.actor }}
+        CGO_ENABLED: ${{ inputs.CGO_ENABLED }}
+      run: |
+        export TEST_TRIGGERED_BY=${{ inputs.triggered_by }}-${{ github.event.pull_request.number || github.run_id }}
+        # Handle bots as users
+        export CHAINLINK_ENV_USER=${CHAINLINK_ENV_USER//"[bot]"/-bot}
+
+        chmod +x ./${{ inputs.binary_name }}
+
+        ${{ inputs.test_command_to_run }}
+
+    - name: Publish Artifacts
+      if: failure()
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+      with:
+        name: ${{ inputs.artifacts_name }}
+        path: ${{ inputs.artifacts_location }}
+
+    - name: cleanup
+      if: always()
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/cleanup@v2.3.6
+      with:
+        triggered_by: ${{ inputs.triggered_by }}
+        should_cleanup: ${{ inputs.should_cleanup }}

--- a/actions/ctf-run-tests-binary/package.json
+++ b/actions/ctf-run-tests-binary/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ctf-run-tests-binary",
+  "version": "0.0.0",
+  "description": "",
+  "private": true,
+  "scripts": {},
+  "author": "@smartcontractkit",
+  "license": "MIT",
+  "dependencies": {},
+  "repository": "https://github.com/smartcontractkit/.github"
+}

--- a/actions/ctf-run-tests-binary/project.json
+++ b/actions/ctf-run-tests-binary/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "ctf-run-tests-binary",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "actions/ctf-run-tests-binary",
+  "targets": {}
+}

--- a/actions/ctf-run-tests/README.md
+++ b/actions/ctf-run-tests/README.md
@@ -1,0 +1,3 @@
+# ctf-run-tests
+
+> Common runner for chainlink-testing-framework based tests

--- a/actions/ctf-run-tests/action.yml
+++ b/actions/ctf-run-tests/action.yml
@@ -1,0 +1,317 @@
+name: ctf-run-tests
+description: "Common runner for chainlink-testing-framework based tests"
+
+inputs:
+  artifacts_location:
+    required: false
+    description: Location of where error logs are written
+    default: ./integration-tests/smoke/logs
+  artifacts_name:
+    required: false
+    description: Name of the artifact to upload
+    default: test-logs
+  test_command_to_run:
+    required: true
+    description: The command to run the tests
+  test_download_vendor_packages_command:
+    required: false
+    description: The command to download the go modules
+    default: make download
+  test_secrets_defaults_base64:
+    required: false
+    description:
+      The base64-encoded .env file with key=value with secrets to use as
+      defaults
+  test_secrets_override_base64:
+    required: false
+    description:
+      The base64-encoded .env file with key=value with secrets to override
+      defaults
+  test_config_override_path:
+    required: false
+    description:
+      The path to the test config file used to override the default test config
+  test_config_override_base64:
+    required: false
+    description: The base64-encoded test config override
+  test_type:
+    required: false
+    description:
+      The type of test to run. Used by some tests to select test configuration
+  test_suite:
+    required: false
+    description: The test suite to run. Used by k8s remote runner tests
+  default_e2e_test_chainlink_image:
+    required: false
+    description: The default chainlink image to use if override not set
+  default_e2e_test_chainlink_upgrade_image:
+    required: false
+    description:
+      The default chainlink image to use for upgrade tests if override not set
+  cl_repo:
+    required: false
+    description: The Chainlink ecr repository to use
+    default: public.ecr.aws/z0b1w9r9/chainlink
+  cl_image_tag:
+    required: false
+    description: The chainlink image to use
+    default: develop
+  build_gauntlet_command:
+    required: false
+    description: How to build gauntlet if necessary
+    default: "false"
+  download_contract_artifacts_path:
+    required: false
+    description: Path where the contract artifacts need to be placed
+    default: "none"
+  publish_report_paths:
+    required: false
+    description: The path of the output report
+    default: "./tests-smoke-report.xml"
+  publish_check_name:
+    required: false
+    description: The check name for publishing the reports
+    default: Smoke Test Results
+  token:
+    required: false
+    description: The GITHUB_TOKEN for the workflow
+    default: ${{ github.token }}
+  publish_test_results_comment_mode:
+    required: false
+    description:
+      comment_mode value for EnricoMi/publish-unit-test-result-action@v1
+    default: always
+  publish_test_results_commit:
+    required: false
+    description:
+      Commit SHA to which test results are published. Only needed if the value
+      of GITHUB_SHA does not work for you.
+  triggered_by:
+    required: true
+    description:
+      The triggered-by label for the k8s namespace, required for cleanup
+    default: ci
+  go_version:
+    required: false
+    description: Go version to install
+  go_mod_path:
+    required: false
+    description: The go.mod file path
+  go_coverage_src_dir:
+    required: false
+    description: The source directory for go coverage files
+  go_coverage_dest_dir:
+    required: false
+    description: The destination directory to store go coverage files
+  cache_restore_only:
+    required: false
+    description:
+      Only restore the cache, set to true if you want to restore and save on
+      cache hit miss
+    default: "false"
+  cache_key_id:
+    required: false
+    description: Cache go vendors unique id
+    default: go
+  aws_registries:
+    required: false
+    description: AWS registries to log into for the test if needed
+  aws_role_duration_seconds:
+    required: false
+    default: "3600"
+    description: The duration to be logged into the aws role for
+  dockerhub_username:
+    description:
+      Username for Docker Hub to avoid rate limits when pulling public images
+    required: false
+  dockerhub_password:
+    description:
+      Password for Docker Hub to avoid rate limits when pulling public images
+    required: false
+  dep_chainlink_integration_tests:
+    required: false
+    description: chainlink/integration-tests commit or branch
+  QA_AWS_REGION:
+    required: true
+    description: The AWS region to use
+  QA_AWS_ROLE_TO_ASSUME:
+    required: true
+    description: The AWS role to assume
+  QA_KUBECONFIG:
+    required: false
+    description: The kubernetes configuration to use
+  CGO_ENABLED:
+    required: false
+    description: Whether to have cgo enabled, defaults to enabled
+    default: "1"
+  run_setup:
+    required: false
+    description: Should we run the setup before running the tests
+    default: "true"
+  should_cleanup:
+    required: false
+    description:
+      Whether to run the cleanup at the end, soak tests and such would not want
+      to automatically cleanup
+    default: "false"
+  should_tidy:
+    required: false
+    description: Should we check go mod tidy
+    default: "true"
+  no_cache:
+    required: false
+    description: Do not use a go cache
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    # Setup Tools and libraries
+    - name: Setup environment
+      if: inputs.run_setup == 'true'
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@e4dd107855e2359e2d762a48872a3e9365e70f11 # v2.3.30
+      with:
+        test_download_vendor_packages_command:
+          ${{ inputs.test_download_vendor_packages_command }}
+        go_version: ${{ inputs.go_version }}
+        go_mod_path: ${{ inputs.go_mod_path }}
+        cache_restore_only: ${{ inputs.cache_restore_only }}
+        cache_key_id: ${{ inputs.cache_key_id }}
+        aws_registries: ${{ inputs.aws_registries }}
+        aws_role_duration_seconds: ${{ inputs.aws_role_duration_seconds }}
+        dockerhub_username: ${{ inputs.dockerhub_username }}
+        dockerhub_password: ${{ inputs.dockerhub_password }}
+        QA_AWS_REGION: ${{ inputs.QA_AWS_REGION }}
+        QA_AWS_ROLE_TO_ASSUME: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}
+        QA_KUBECONFIG: ${{ inputs.QA_KUBECONFIG }}
+        should_tidy: ${{ inputs.should_tidy }}
+        no_cache: ${{ inputs.no_cache }}
+
+    - name: Replace chainlink/integration-tests deps
+      if: ${{ inputs.dep_chainlink_integration_tests }}
+      shell: bash
+      run: |
+        # find test go root by using the go_mod_path and change to that directory
+        TEST_LIB_PATH="${{ inputs.go_mod_path }}"
+        if [ "${#TEST_LIB_PATH}" -gt "6" ]; then
+            TEST_LIB_PATH=${TEST_LIB_PATH%go.mod}
+            cd "${TEST_LIB_PATH}"
+        fi
+
+        # update the integration-tests lib to the branch or commit
+        go get github.com/smartcontractkit/chainlink/integration-tests@${{ inputs.dep_chainlink_integration_tests }}
+        go mod tidy
+
+    # Download any external artifacts
+    - name: Download Artifacts
+      if: inputs.download_contract_artifacts_path != 'none'
+      uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+      with:
+        name: artifacts
+        path: ${{ inputs.download_contract_artifacts_path }}
+
+    # Generate any excutables needed to run tests
+    - name: Generate gauntlet executable
+      if: inputs.build_gauntlet_command != 'false'
+      shell: bash
+      run: ${{ inputs.build_gauntlet_command }}
+
+    # TODO: Remove this once gotestloghelper has replaced all usages of gotestfmt
+    - name: Set Up gotestfmt
+      uses: GoTestTools/gotestfmt-action@8b4478c7019be847373babde9300210e7de34bfb # v2.2.0
+      with:
+        token: ${{ inputs.token }} # Avoids rate-limiting
+
+    # gotestfmt gives us pretty test output
+    - name: Set Up gotestloghelper
+      shell: bash
+      run:
+        go install
+        github.com/smartcontractkit/chainlink-testing-framework/tools/gotestloghelper@v1.1.1
+
+    - name: Set default enironment variables
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.test_type }}" ]; then
+          echo "TEST_TYPE=${{ inputs.test_type }}" >> $GITHUB_ENV
+          echo "TEST_TEST_TYPE=${{ inputs.test_type }}" >> $GITHUB_ENV
+        fi
+        if [ -n "${{ inputs.test_suite }}" ]; then
+          echo "TEST_SUITE=${{ inputs.test_suite }}" >> $GITHUB_ENV
+          echo "TEST_TEST_SUITE=${{ inputs.test_suite }}" >> $GITHUB_ENV
+        fi
+
+    # If default and/or custom secrets provided, decode them, mask them and set them as env vars to override the default secrets
+    - name: Set default test secrets from dotenv file
+      if: inputs.test_secrets_defaults_base64 != ''
+      shell: bash
+      run:
+        go run ${{ github.action_path }}/mask-testsecrets/main.go "${{
+        inputs.test_secrets_defaults_base64 }}"
+
+    # Custom secrets override the default secrets
+    - name: Set custom test secrets from dotenv file
+      if: inputs.test_secrets_override_base64 != ''
+      shell: bash
+      run:
+        go run ${{ github.action_path }}/mask-testsecrets/main.go "${{
+        inputs.test_secrets_override_base64 }}"
+
+    - name: Set default E2E_TEST_* env vars if they are not set already
+      shell: bash
+      run: |
+        if [[ -z "${{ env.E2E_TEST_CHAINLINK_IMAGE }}" ]]; then
+          echo "E2E_TEST_CHAINLINK_IMAGE=${{ inputs.default_e2e_test_chainlink_image }}" >> $GITHUB_ENV
+        fi
+        if [[ -z "${{ env.E2E_TEST_CHAINLINK_UPGRADE_IMAGE }}" ]]; then
+          echo "E2E_TEST_CHAINLINK_UPGRADE_IMAGE=${{ inputs.default_e2e_test_chainlink_upgrade_image }}" >> $GITHUB_ENV
+        fi
+
+    - name: Set test config override from config file
+      if: inputs.test_config_override_path != ''
+      shell: bash
+      run: |
+        BASE64_CONFIG_OVERRIDE=$(base64 -w 0 -i ${{ inputs.test_config_override_path }})
+        echo ::add-mask::$BASE64_CONFIG_OVERRIDE
+        echo "BASE64_CONFIG_OVERRIDE=$BASE64_CONFIG_OVERRIDE" >> $GITHUB_ENV
+
+    # Override the default test config if a custom one is provided
+    - name: Use test config override
+      if: inputs.test_config_override_base64 != ''
+      shell: bash
+      run: |
+        BASE64_CONFIG_OVERRIDE=${{ inputs.test_config_override_base64 }}
+        echo ::add-mask::$BASE64_CONFIG_OVERRIDE
+        echo "BASE64_CONFIG_OVERRIDE=$BASE64_CONFIG_OVERRIDE" >> $GITHUB_ENV
+
+    # Run the tests
+    - name: Run Tests
+      shell: bash
+      env:
+        CHAINLINK_IMAGE: ${{ inputs.cl_repo }} # TODO: to remove
+        CHAINLINK_VERSION: ${{ inputs.cl_image_tag }} # TODO: to remove
+        CHAINLINK_ENV_USER: ${{ github.actor }}
+        CGO_ENABLED: ${{ inputs.CGO_ENABLED }}
+        GO_COVERAGE_SRC_DIR: ${{ inputs.go_coverage_src_dir }}
+        GO_COVERAGE_DEST_DIR: ${{ inputs.go_coverage_dest_dir }}
+      run: |
+        PATH=$PATH:$(go env GOPATH)/bin
+        export PATH
+        export TEST_TRIGGERED_BY=${{ inputs.triggered_by }}-${{ github.event.pull_request.number || github.run_id }}
+        # Handle bots as users
+        export CHAINLINK_ENV_USER=${CHAINLINK_ENV_USER//"[bot]"/-bot}
+        ${{ inputs.test_command_to_run }}
+
+    - name: Publish Artifacts
+      if: failure()
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+      with:
+        name: ${{ inputs.artifacts_name }}
+        path: ${{ inputs.artifacts_location }}
+
+    - name: cleanup
+      if: always()
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/cleanup@v2.3.6
+      with:
+        triggered_by: ${{ inputs.triggered_by }}
+        should_cleanup: ${{ inputs.should_cleanup }}

--- a/actions/ctf-run-tests/mask-testsecrets/go.mod
+++ b/actions/ctf-run-tests/mask-testsecrets/go.mod
@@ -1,0 +1,3 @@
+module github.com/smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests/mask-testsecrets
+
+go 1.21.3

--- a/actions/ctf-run-tests/mask-testsecrets/main.go
+++ b/actions/ctf-run-tests/mask-testsecrets/main.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+type DotenvParseError struct {
+	Line int // Line where the error occurred
+}
+
+// Error implements the error interface for DotenvParseError.
+func (e *DotenvParseError) Error() string {
+	return fmt.Sprintf("could not parse dotenv due to invalid KEY=\"VALUE\" in line: %d. Only KEY=VALUE or KEY=\"VALUE\" are supported. To include special characters such as an apostrophe in the VALUE, enclose the VALUE in double quotes (e.g., KEY=\"'VALUE'\")", e.Line)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run main.go <base64_dot_env_string>")
+		return
+	}
+
+	decodedBytes, err := base64.StdEncoding.DecodeString(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Could not decode provided base64 string")
+		os.Exit(1)
+	}
+
+	envVars, err := parseEnvVars(string(decodedBytes))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	for key, value := range envVars {
+		mustMaskSecret(key, value)
+		mustAddToGithubEnv(key, value)
+	}
+}
+
+func parseEnvVars(envStr string) (map[string]string, error) {
+	envVars := make(map[string]string)
+	// Regular expression to match configurations in the form of KEY=VALUE or KEY="VALUE".
+	// To include special characters such as an apostrophe in the VALUE, enclose the VALUE in double quotes (e.g., KEY="'VALUE'").
+	// Restrictions:
+	// - KEY must not be enclosed in any type of quotes.
+	// - VALUE can be unquoted or enclosed in double quotes, but not single quotes.
+	re := regexp.MustCompile(`^[^" '=]+=".*"$|^[^" '=]+=[^" ']+$`)
+
+	lines := strings.Split(envStr, "\n")
+	for i, line := range lines {
+		line = strings.TrimSpace(line) // Trim space from start and end
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue // Skip empty lines and comments
+		}
+		if strings.HasPrefix(line, "export ") {
+			line = strings.TrimSpace(strings.TrimPrefix(line, "export"))
+		}
+
+		// Validate the line with regex before processing
+		if re.MatchString(line) {
+			parts := strings.SplitN(line, "=", 2)
+			if len(parts) == 2 {
+				key := strings.TrimSpace(parts[0])
+				value := removeSurroundingQuotes(strings.TrimSpace(parts[1]))
+				envVars[key] = value
+			}
+		} else {
+			return nil, &DotenvParseError{Line: i + 1}
+		}
+	}
+	return envVars, nil
+}
+
+func removeSurroundingQuotes(s string) string {
+	if len(s) >= 2 {
+		if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}
+
+func mustAddToGithubEnv(key, value string) {
+	command := fmt.Sprintf("echo \"%s=%s\" >> $GITHUB_ENV", key, value)
+	cmd := exec.Command("bash", "-c", command)
+	err := cmd.Run()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to add '%s' to GITHUB_ENV", key)
+		os.Exit(1)
+	}
+}
+
+func mustMaskSecret(description string, secret string) {
+	if secret != "" {
+		fmt.Printf("Mask '%s'\n", description)
+		fmt.Printf("::add-mask::%s\n", secret)
+		cmd := exec.Command("bash", "-c", "echo ::add-mask::$0", "_", secret)
+		err := cmd.Run()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to mask secret '%s'", description)
+			os.Exit(1)
+		}
+	}
+}

--- a/actions/ctf-run-tests/mask-testsecrets/main_test.go
+++ b/actions/ctf-run-tests/mask-testsecrets/main_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestParseEnvVars checks various scenarios for parsing environment variables.
+func TestParseEnvVars(t *testing.T) {
+	tests := []struct {
+		name     string
+		envStr   string
+		expected map[string]string
+		err      error
+	}{
+		{
+			name: "Simple Key-Value",
+			envStr: `KEY=VALUE
+ANOTHER_KEY=VALUE2
+KEY3="VALUE1 VALUE2"`,
+			expected: map[string]string{"KEY": "VALUE", "ANOTHER_KEY": "VALUE2", "KEY3": "VALUE1 VALUE2"},
+		},
+		{
+			name:     "Export Prefix",
+			envStr:   "export KEY=VALUE\nexport ANOTHER_KEY=VALUE",
+			expected: map[string]string{"KEY": "VALUE", "ANOTHER_KEY": "VALUE"},
+		},
+		{
+			name: "Values with Quotes",
+			envStr: `KEY="some value"
+ANOTHER_KEY="another value"
+KEY3="'value3'"
+KEY4="'value4',"`,
+			expected: map[string]string{"KEY": "some value", "ANOTHER_KEY": "another value", "KEY3": "'value3'", "KEY4": "'value4',"},
+		},
+		{
+			name: "With Comments",
+			envStr: `# This is a comment
+export VAR1="Value 1"
+#VAR2='Value2'
+VAR3=Value3
+# export VAR4="Value4"`,
+			expected: map[string]string{"VAR1": "Value 1", "VAR3": "Value3"},
+		},
+		{
+			name: "Comma after Value",
+			envStr: `KEY=VALUE,
+KEY2="VALUE2",`,
+			err: &DotenvParseError{Line: 2},
+		},
+		{
+			name: "Fail on Single Quotes",
+			envStr: `KEY1=VALUE1
+KEY2="VALUE2"
+ANOTHER_KEY='VALUE'
+		`,
+			err: &DotenvParseError{Line: 3},
+		},
+		{
+			name: "Key with Double Quotes",
+			envStr: `KEY="VALUE"
+"ANOTHER_KEY"=VALUE`,
+			err: &DotenvParseError{Line: 2},
+		},
+		{
+			name: "Key with Single Quotes",
+			envStr: `KEY="VALUE"
+'ANOTHER_KEY'=VALUE`,
+			err: &DotenvParseError{Line: 2},
+		},
+		{
+			name: "Value with Spaces",
+			envStr: `KEY="VALUE"
+KEY2=VALUE 2`,
+			err: &DotenvParseError{Line: 2},
+		},
+		{
+			name: "Empty Line",
+			envStr: `KEY="VALUE"
+
+KEY2=VALUE2`,
+			expected: map[string]string{"KEY": "VALUE", "KEY2": "VALUE2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseEnvVars(tt.envStr)
+			// Check for error type and line number
+			if err != nil && tt.err == nil {
+				t.Errorf("parseEnvVars(%q) error = %v, want nil", tt.envStr, err)
+			}
+			if err != nil && tt.err != nil {
+				if err.Error() != tt.err.Error() {
+					t.Errorf("parseEnvVars(%q) error = %v, want %v", tt.envStr, err, tt.err)
+				}
+			}
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("parseEnvVars(%q) = %v, want %v", tt.envStr, result, tt.expected)
+			}
+		})
+	}
+}

--- a/actions/ctf-run-tests/package.json
+++ b/actions/ctf-run-tests/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ctf-run-tests",
+  "version": "0.0.0",
+  "description": "",
+  "private": true,
+  "scripts": {},
+  "author": "@smartcontractkit",
+  "license": "MIT",
+  "dependencies": {},
+  "repository": "https://github.com/smartcontractkit/.github"
+}

--- a/actions/ctf-run-tests/project.json
+++ b/actions/ctf-run-tests/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "ctf-run-tests",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "actions/ctf-run-tests",
+  "targets": {}
+}

--- a/actions/ctf-setup-go/README.md
+++ b/actions/ctf-setup-go/README.md
@@ -1,0 +1,3 @@
+# ctf-setup-go
+
+> Common golang setup for CTF

--- a/actions/ctf-setup-go/action.yml
+++ b/actions/ctf-setup-go/action.yml
@@ -1,0 +1,101 @@
+name: ctf-setup-go
+description: "Common golang setup for CTF"
+
+inputs:
+  go_version:
+    required: false
+    description: Go version to install
+  go_mod_path:
+    required: false
+    description: The go.mod file path
+    default: "go.mod"
+  cache_restore_only:
+    required: false
+    description:
+      Only restore the cache, set to true if you want to restore and save on
+      cache hit miss
+    default: "false"
+  cache_builds:
+    required: false
+    description: Cache go builds
+    default: "false"
+  cache_key_id:
+    required: true
+    description: Cache key id
+  no_cache:
+    required: false
+    description: Do not use a go cache
+    default: "false"
+  should_tidy:
+    required: false
+    description: Should we check go mod tidy
+    default: "true"
+  test_download_vendor_packages_command:
+    required: false
+    description: The command to download the go modules
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Go
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      with:
+        go-version: ${{ inputs.go_version }}
+        go-version-file: ${{ inputs.go_mod_path }}
+        check-latest: true
+        cache: false
+
+    - name: Set go cache keys
+      shell: bash
+      id: go-cache-dir
+      run: |
+        echo "gomodcache=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+        echo "gobuildcache=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+
+    - name: Cache Go Modules
+      if: inputs.cache_restore_only == 'false' && inputs.no_cache == 'false'
+      uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
+      id: cache-packages
+      with:
+        path: ${{ steps.go-cache-dir.outputs.gomodcache }}
+        key:
+          ${{ runner.os }}-${{ inputs.cache_key_id }}-gomod-${{
+          hashFiles(inputs.go_mod_path) }}
+        restore-keys: |
+          ${{ runner.os }}-${{ inputs.cache_key_id }}-gomod-
+
+    - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      if: inputs.cache_restore_only == 'false' && inputs.cache_builds == 'true'
+      name: Cache Go Builds
+      with:
+        path: ${{ steps.go-cache-dir.outputs.gobuildcache }}
+        # The lifetime of go build outputs is pretty short, so we make our primary cache key be the branch name
+        key:
+          ${{ runner.os }}-${{ inputs.cache_key_id }}-gobuild-${{
+          hashFiles(inputs.go_mod_path) }}
+        restore-keys: |
+          ${{ runner.os }}-${{ inputs.cache_key_id }}-gobuild-
+
+    - name: Restore Go Modules
+      if: inputs.cache_restore_only != 'false' && inputs.no_cache == 'false'
+      uses: actions/cache/restore@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
+      id: restore-cache-packages
+      with:
+        path: |
+          ${{ steps.go-cache-dir.outputs.gomodcache }}
+        key:
+          ${{ runner.os }}-${{ inputs.cache_key_id }}-gomod-${{
+          hashFiles(inputs.go_mod_path) }}
+        restore-keys: |
+          ${{ runner.os }}-${{ inputs.cache_key_id }}-gomod-
+
+    - name: Tidy and check files
+      if: ${{ inputs.should_tidy == 'true' }}
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/go-mod-tidy@v2.3.6
+      with:
+        go_mod_path: ${{ inputs.go_mod_path }}
+
+    - name: Run go mod download
+      if: inputs.test_download_vendor_packages_command
+      shell: bash
+      run: ${{ inputs.test_download_vendor_packages_command }}

--- a/actions/ctf-setup-go/package.json
+++ b/actions/ctf-setup-go/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ctf-setup-go",
+  "version": "0.0.0",
+  "description": "",
+  "private": true,
+  "scripts": {},
+  "author": "@smartcontractkit",
+  "license": "MIT",
+  "dependencies": {},
+  "repository": "https://github.com/smartcontractkit/.github"
+}

--- a/actions/ctf-setup-go/project.json
+++ b/actions/ctf-setup-go/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "ctf-setup-go",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "actions/ctf-setup-go",
+  "targets": {}
+}

--- a/actions/ctf-setup-run-tests-environment/README.md
+++ b/actions/ctf-setup-run-tests-environment/README.md
@@ -1,0 +1,3 @@
+# ctf-setup-run-tests-environment
+
+> Common test env setup for CTF

--- a/actions/ctf-setup-run-tests-environment/action.yml
+++ b/actions/ctf-setup-run-tests-environment/action.yml
@@ -1,0 +1,133 @@
+name: ctf-setup-run-tests-environment
+description: "Common test env setup for CTF"
+
+inputs:
+  test_download_vendor_packages_command:
+    required: false
+    description: The command to download the go modules
+    default: make download
+  go_version:
+    required: false
+    description: Go version to install
+  go_mod_path:
+    required: false
+    description: The go.mod file path
+    default: "go.mod"
+  go_necessary:
+    required: false
+    description:
+      Whether to install go, should be true unless you already have a test
+      binary
+    default: "true"
+  cache_restore_only:
+    required: false
+    description:
+      Only restore the cache, set to true if you want to restore and save on
+      cache hit miss
+    default: "false"
+  cache_key_id:
+    required: false
+    description: Cache go vendors unique id
+    default: go
+  aws_registries:
+    required: false
+    description: AWS registries to log into for the test if needed
+  aws_role_duration_seconds:
+    required: false
+    default: "3600"
+    description: The duration to be logged into the aws role for
+  dockerhub_username:
+    description:
+      Username for Docker Hub to avoid rate limits when pulling public images
+    required: false
+  dockerhub_password:
+    description:
+      Password for Docker Hub to avoid rate limits when pulling public images
+    required: false
+  QA_AWS_REGION:
+    required: true
+    description: The AWS region to use
+  QA_AWS_ROLE_TO_ASSUME:
+    required: true
+    description: The AWS role to assume
+  QA_KUBECONFIG:
+    required: false
+    description: The kubernetes configuration to use
+  should_tidy:
+    required: false
+    description: Should we check go mod tidy
+    default: "true"
+  no_cache:
+    required: false
+    description: Do not use a go cache
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    # Go setup and caching
+    - name: Setup Go
+      if: inputs.go_necessary == 'true'
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go@e4dd107855e2359e2d762a48872a3e9365e70f11 # v2.3.30
+      with:
+        go_version: ${{ inputs.go_version }}
+        go_mod_path: ${{ inputs.go_mod_path }}
+        cache_restore_only: ${{ inputs.cache_restore_only }}
+        cache_key_id: ${{ inputs.cache_key_id }}
+        should_tidy: ${{ inputs.should_tidy }}
+        no_cache: ${{ inputs.no_cache }}
+        test_download_vendor_packages_command:
+          ${{ inputs.test_download_vendor_packages_command }}
+
+    # Setup AWS cred and K8s context
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+      with:
+        aws-region: ${{ inputs.QA_AWS_REGION }}
+        role-to-assume: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}
+        role-duration-seconds: ${{ inputs.aws_role_duration_seconds }}
+        mask-aws-account-id: true
+
+    - name: Set Kubernetes Context
+      if: inputs.QA_KUBECONFIG
+      uses: azure/k8s-set-context@27bfb387305b8f0ab5495d692e4a3304db7d0669 # v4.0.0
+      with:
+        method: kubeconfig
+        kubeconfig: ${{ inputs.QA_KUBECONFIG }}
+
+    # Login to AWS ECR registries if needed
+    - name: Login to Amazon ECR
+      if: inputs.aws_registries && inputs.QA_AWS_REGION
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+      with:
+        registries: ${{ inputs.aws_registries }}
+      env:
+        AWS_REGION: ${{ inputs.QA_AWS_REGION }}
+
+    # To avoid rate limiting from Docker Hub, we can login with a paid user account.
+    - name: Login to Docker Hub
+      if: inputs.dockerhub_username && inputs.dockerhub_password
+      uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+      with:
+        username: ${{ inputs.dockerhub_username }}
+        password: ${{ inputs.dockerhub_password }}
+
+    # Helm Setup
+    - uses: azure/setup-helm@29960d0f5f19214b88e1d9ba750a9914ab0f1a2f # v4.0.0
+      with:
+        version: v3.13.1
+    - name: Add required helm charts including chainlink-qa
+      shell: bash
+      run: |
+        helm repo add bitnami https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+        helm repo add chainlink-qa https://raw.githubusercontent.com/smartcontractkit/qa-charts/gh-pages/
+
+    # Display tool versions
+    - name: Tool Versions
+      shell: bash
+      run: |
+        go version
+        aws --version
+        helm version
+        helm repo list

--- a/actions/ctf-setup-run-tests-environment/package.json
+++ b/actions/ctf-setup-run-tests-environment/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ctf-setup-run-tests-environment",
+  "version": "0.0.0",
+  "description": "",
+  "private": true,
+  "scripts": {},
+  "author": "@smartcontractkit",
+  "license": "MIT",
+  "dependencies": {},
+  "repository": "https://github.com/smartcontractkit/.github"
+}

--- a/actions/ctf-setup-run-tests-environment/project.json
+++ b/actions/ctf-setup-run-tests-environment/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "ctf-setup-run-tests-environment",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "actions/ctf-setup-run-tests-environment",
+  "targets": {}
+}

--- a/actions/ctf-show-grafana-in-test-summary/README.md
+++ b/actions/ctf-show-grafana-in-test-summary/README.md
@@ -1,0 +1,3 @@
+# ctf-show-grafana-in-test-summary
+
+> Show Grafana url in test summary

--- a/actions/ctf-show-grafana-in-test-summary/action.yml
+++ b/actions/ctf-show-grafana-in-test-summary/action.yml
@@ -1,0 +1,38 @@
+name: ctf-show-grafana-in-test-summary
+description: "Show Grafana url in test summary"
+
+inputs:
+  test_directories:
+    required: true
+    description: Comma-separated directories in which the tests are located
+    default: ./integration-tests/smoke
+
+runs:
+  using: composite
+  steps:
+    - name: Print failed test summary
+      shell: bash
+      run: |
+        IFS=',' read -r -a directories <<< "$(echo "${{ inputs.test_directories }}" | tr -d '[:space:]')"
+        for inputDir in "${directories[@]}"; do
+          cleanTestDir=${inputDir%/}
+          directory="$cleanTestDir/.test_summary"
+          echo "Looking for test summary in: $directory"
+          files=("$directory"/*)
+          if [ -d "$directory" ]; then
+            echo "Test summary folder found in $inputDir"
+            if [ ${#files[@]} -gt 0 ]; then
+              first_file="${files[0]}"
+              echo "Name of the first test summary file: $(basename "$first_file")"
+              echo "### Failed Test Execution Logs Dashboard (over VPN):" >> $GITHUB_STEP_SUMMARY
+              cat "$first_file" | jq -r 'if .loki then (.loki[] | if .value != "" then "* [\(.test_name)](\(.value))" else "No URL found for \(.test_name)" end) else "No Grafana URLs found" end' >> $GITHUB_STEP_SUMMARY
+              if [ ${#files[@]} -gt 1 ]; then
+                echo "Found more than one test summary file in $inputDir. This is incorrect, there should be only one file"
+              fi
+            else
+              echo "Test summary directory in $inputDir is empty. This should not happen"
+            fi
+          else
+            echo "No test summary folder found in $inputDir. If no test failed or log collection wasn't explicitly requested this is correct. Exiting"
+          fi
+        done

--- a/actions/ctf-show-grafana-in-test-summary/package.json
+++ b/actions/ctf-show-grafana-in-test-summary/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ctf-show-grafana-in-test-summary",
+  "version": "0.0.0",
+  "description": "",
+  "private": true,
+  "scripts": {},
+  "author": "@smartcontractkit",
+  "license": "MIT",
+  "dependencies": {},
+  "repository": "https://github.com/smartcontractkit/.github"
+}

--- a/actions/ctf-show-grafana-in-test-summary/project.json
+++ b/actions/ctf-show-grafana-in-test-summary/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "ctf-show-grafana-in-test-summary",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "actions/ctf-show-grafana-in-test-summary",
+  "targets": {}
+}


### PR DESCRIPTION
This PR migrates all GitHub Actions (GHA) from the [smartcontractkit/chainlink-github-actions](https://github.com/smartcontractkit/chainlink-github-actions/tree/main/chainlink-testing-framework) repository to this repo. Once merged, I will proceed to update all workflows that utilize these actions and subsequently remove the actions from the original smartcontractkit/chainlink-github-actions repository.