### PR TITLE
Add ctf-setup-go action

### DIFF
--- a/.changeset/swift-radios-stare.md
+++ b/.changeset/swift-radios-stare.md
@@ -1,0 +1,5 @@
+---
+"ctf-setup-go": minor
+---
+
+Add ctf-setup-go action

--- a/actions/ctf-setup-go/README.md
+++ b/actions/ctf-setup-go/README.md
@@ -1,0 +1,3 @@
+# ctf-setup-go
+
+> Common golang setup for CTF

--- a/actions/ctf-setup-go/action.yml
+++ b/actions/ctf-setup-go/action.yml
@@ -1,0 +1,108 @@
+name: ctf-setup-go
+description: "Common golang setup for CTF"
+
+inputs:
+  go_version:
+    required: false
+    description: Go version to install
+  go_mod_path:
+    required: false
+    description: The go.mod file path
+    default: "go.mod"
+  cache_restore_only:
+    required: false
+    description:
+      Only restore the cache, set to true if you want to restore and save on
+      cache hit miss
+    default: "false"
+  cache_builds:
+    required: false
+    description: Cache go builds
+    default: "false"
+  cache_key_id:
+    required: true
+    description: Cache key id
+  no_cache:
+    required: false
+    description: Do not use a go cache
+    default: "false"
+  should_tidy:
+    required: false
+    description: Should we check go mod tidy
+    default: "true"
+  test_download_vendor_packages_command:
+    required: false
+    description: The command to download the go modules
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Go
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      with:
+        go-version: ${{ inputs.go_version }}
+        go-version-file: ${{ inputs.go_mod_path }}
+        check-latest: true
+        cache: false
+
+    - name: Set go cache keys
+      shell: bash
+      id: go-cache-dir
+      run: |
+        echo "gomodcache=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+        echo "gobuildcache=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+
+    - name: Cache Go Modules
+      if: inputs.cache_restore_only == 'false' && inputs.no_cache == 'false'
+      uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
+      id: cache-packages
+      with:
+        path: ${{ steps.go-cache-dir.outputs.gomodcache }}
+        key:
+          ${{ runner.os }}-${{ inputs.cache_key_id }}-gomod-${{
+          hashFiles(inputs.go_mod_path) }}
+        restore-keys: |
+          ${{ runner.os }}-${{ inputs.cache_key_id }}-gomod-
+
+    - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      if: inputs.cache_restore_only == 'false' && inputs.cache_builds == 'true'
+      name: Cache Go Builds
+      with:
+        path: ${{ steps.go-cache-dir.outputs.gobuildcache }}
+        # The lifetime of go build outputs is pretty short, so we make our primary cache key be the branch name
+        key:
+          ${{ runner.os }}-${{ inputs.cache_key_id }}-gobuild-${{
+          hashFiles(inputs.go_mod_path) }}
+        restore-keys: |
+          ${{ runner.os }}-${{ inputs.cache_key_id }}-gobuild-
+
+    - name: Restore Go Modules
+      if: inputs.cache_restore_only != 'false' && inputs.no_cache == 'false'
+      uses: actions/cache/restore@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
+      id: restore-cache-packages
+      with:
+        path: |
+          ${{ steps.go-cache-dir.outputs.gomodcache }}
+        key:
+          ${{ runner.os }}-${{ inputs.cache_key_id }}-gomod-${{
+          hashFiles(inputs.go_mod_path) }}
+        restore-keys: |
+          ${{ runner.os }}-${{ inputs.cache_key_id }}-gomod-
+
+    - name: Tidy and check files
+      if: ${{ inputs.should_tidy == 'true' }}
+      shell: bash
+      run: |
+        # find test go root by using the go_mod_path and change to that directory
+        TEST_LIB_PATH="${{ inputs.go_mod_path }}"
+        if [ "${#TEST_LIB_PATH}" -gt "6" ]; then
+            TEST_LIB_PATH=${TEST_LIB_PATH%go.mod}
+            cd "${TEST_LIB_PATH}"
+        fi
+        go mod tidy
+        git diff --stat --exit-code
+
+    - name: Run go mod download
+      if: inputs.test_download_vendor_packages_command
+      shell: bash
+      run: ${{ inputs.test_download_vendor_packages_command }}

--- a/actions/ctf-setup-go/package.json
+++ b/actions/ctf-setup-go/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ctf-setup-go",
+  "version": "0.0.0",
+  "description": "",
+  "private": true,
+  "scripts": {},
+  "author": "@smartcontractkit",
+  "license": "MIT",
+  "dependencies": {},
+  "repository": "https://github.com/smartcontractkit/.github"
+}

--- a/actions/ctf-setup-go/project.json
+++ b/actions/ctf-setup-go/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "ctf-setup-go",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "actions/ctf-setup-go",
+  "targets": {}
+}


### PR DESCRIPTION
This migrates ctf-setup-go from [smartcontractkit/chainlink-github-actions](https://github.com/smartcontractkit/chainlink-github-actions/tree/main/chainlink-testing-framework) repository to this repo. Once merged, I will proceed to update all workflows that utilize these actions and subsequently remove the actions from the original smartcontractkit/chainlink-github-actions repository.