### PR TITLE
Add ctf-cleanup action

### DIFF
--- a/.changeset/fluffy-meals-allow.md
+++ b/.changeset/fluffy-meals-allow.md
@@ -1,0 +1,5 @@
+---
+"ctf-cleanup": minor
+---
+
+Add ctf-cleanup action

--- a/actions/ctf-cleanup/README.md
+++ b/actions/ctf-cleanup/README.md
@@ -1,0 +1,3 @@
+# ctf-cleanup
+
+> Common CTF action for cleaning up k8s namespaces

--- a/actions/ctf-cleanup/action.yml
+++ b/actions/ctf-cleanup/action.yml
@@ -1,0 +1,59 @@
+name: ctf-cleanup
+description: "Common CTF action for cleaning up k8s namespaces"
+
+inputs:
+  triggered_by:
+    required: true
+    description: The triggered-by label for the k8s namespace
+    default: ci
+  should_cleanup:
+    required: false
+    description:
+      Whether to run the cleanup at the end, soak tests and such would not want
+      to automatically cleanup
+    default: "true"
+outputs:
+  did_skip_clean:
+    description: Did we clean up pods
+    value: ${{ steps.skipped.outputs.did_skip || 'false' }}
+
+runs:
+  using: composite
+  steps:
+    - name: check kubectl
+      if: inputs.should_cleanup == 'true'
+      id: kubectlcheck
+      shell: bash
+      run: |
+        VERSION=$(kubectl get ns -l=triggered-by=${{ inputs.triggered_by }}-${{ github.event.pull_request.number || github.run_id }} || echo "failed")
+        FAIL="${VERSION: -6}"
+        echo "${FAIL}"
+        if [ "${FAIL}" = "failed" ]; then
+          echo "pass=false" >>$GITHUB_OUTPUT
+          echo "The k8s environment was not setup, so there are no environments to cleanup"
+        else
+          echo "pass=true" >>$GITHUB_OUTPUT
+        fi
+    - name: cleanup k8s cluster namespaces
+      if:
+        steps.kubectlcheck.outputs.pass == 'true' && inputs.should_cleanup ==
+        'true'
+      shell: bash
+      run: |
+        echo "looking for namespaces"
+        ITEMS=$(kubectl get ns -l=triggered-by=${{ inputs.triggered_by }}-${{ github.event.pull_request.number || github.run_id }} -o jsonpath='{.items}')
+        COUNT=$(echo "${ITEMS}" | jq '. | length')
+        echo "found ${COUNT} namespaces to cleanup"
+        for ((i=0;i<${COUNT};i++)); do
+          name=$(echo "${ITEMS}" | jq -r ".[${i}].metadata.name")
+          echo "deleting namespace: ${name}"
+          kubectl delete ns "${name}" || echo "namespace no longer exists"
+        done
+        echo "completed cleanup"
+    - name: Skipped cleanup
+      id: skipped
+      if: inputs.should_cleanup == 'false'
+      shell: bash
+      run: |
+        echo "Skipped cleanup"
+        echo "did_skip=true" >>$GITHUB_OUTPUT

--- a/actions/ctf-cleanup/package.json
+++ b/actions/ctf-cleanup/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ctf-cleanup",
+  "version": "0.0.0",
+  "description": "",
+  "private": true,
+  "scripts": {},
+  "author": "@smartcontractkit",
+  "license": "MIT",
+  "dependencies": {},
+  "repository": "https://github.com/smartcontractkit/.github"
+}

--- a/actions/ctf-cleanup/project.json
+++ b/actions/ctf-cleanup/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "ctf-cleanup",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "actions/ctf-cleanup",
+  "targets": {}
+}


### PR DESCRIPTION
This migrates ctf-cleanup from [smartcontractkit/chainlink-github-actions](https://github.com/smartcontractkit/chainlink-github-actions/tree/main/chainlink-testing-framework) repository to this repo. Once merged, I will proceed to update all workflows that utilize these actions and subsequently remove the actions from the original smartcontractkit/chainlink-github-actions repository.