### PR TITLE
Add ctf-setup-run-tests-environment action

### DIFF
--- a/.changeset/proud-falcons-repair.md
+++ b/.changeset/proud-falcons-repair.md
@@ -1,0 +1,5 @@
+---
+"ctf-setup-run-tests-environment": minor
+---
+
+Add ctf-setup-run-tests-environment action

--- a/actions/ctf-setup-run-tests-environment/README.md
+++ b/actions/ctf-setup-run-tests-environment/README.md
@@ -1,0 +1,3 @@
+# ctf-setup-run-tests-environment
+
+> Common test env setup for CTF

--- a/actions/ctf-setup-run-tests-environment/action.yml
+++ b/actions/ctf-setup-run-tests-environment/action.yml
@@ -1,0 +1,133 @@
+name: ctf-setup-run-tests-environment
+description: "Common test env setup for CTF"
+
+inputs:
+  test_download_vendor_packages_command:
+    required: false
+    description: The command to download the go modules
+    default: make download
+  go_version:
+    required: false
+    description: Go version to install
+  go_mod_path:
+    required: false
+    description: The go.mod file path
+    default: "go.mod"
+  go_necessary:
+    required: false
+    description:
+      Whether to install go, should be true unless you already have a test
+      binary
+    default: "true"
+  cache_restore_only:
+    required: false
+    description:
+      Only restore the cache, set to true if you want to restore and save on
+      cache hit miss
+    default: "false"
+  cache_key_id:
+    required: false
+    description: Cache go vendors unique id
+    default: go
+  aws_registries:
+    required: false
+    description: AWS registries to log into for the test if needed
+  aws_role_duration_seconds:
+    required: false
+    default: "3600"
+    description: The duration to be logged into the aws role for
+  dockerhub_username:
+    description:
+      Username for Docker Hub to avoid rate limits when pulling public images
+    required: false
+  dockerhub_password:
+    description:
+      Password for Docker Hub to avoid rate limits when pulling public images
+    required: false
+  QA_AWS_REGION:
+    required: true
+    description: The AWS region to use
+  QA_AWS_ROLE_TO_ASSUME:
+    required: true
+    description: The AWS role to assume
+  QA_KUBECONFIG:
+    required: false
+    description: The kubernetes configuration to use
+  should_tidy:
+    required: false
+    description: Should we check go mod tidy
+    default: "true"
+  no_cache:
+    required: false
+    description: Do not use a go cache
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    # Go setup and caching
+    - name: Setup Go
+      if: inputs.go_necessary == 'true'
+      uses: smartcontractkit/.github/actions/ctf-setup-go@b0d756c57fcdbcff187e74166562a029fdd5d1b9 # ctf-setup-go@0.0.0
+      with:
+        go_version: ${{ inputs.go_version }}
+        go_mod_path: ${{ inputs.go_mod_path }}
+        cache_restore_only: ${{ inputs.cache_restore_only }}
+        cache_key_id: ${{ inputs.cache_key_id }}
+        should_tidy: ${{ inputs.should_tidy }}
+        no_cache: ${{ inputs.no_cache }}
+        test_download_vendor_packages_command:
+          ${{ inputs.test_download_vendor_packages_command }}
+
+    # Setup AWS cred and K8s context
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+      with:
+        aws-region: ${{ inputs.QA_AWS_REGION }}
+        role-to-assume: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}
+        role-duration-seconds: ${{ inputs.aws_role_duration_seconds }}
+        mask-aws-account-id: true
+
+    - name: Set Kubernetes Context
+      if: inputs.QA_KUBECONFIG
+      uses: azure/k8s-set-context@27bfb387305b8f0ab5495d692e4a3304db7d0669 # v4.0.0
+      with:
+        method: kubeconfig
+        kubeconfig: ${{ inputs.QA_KUBECONFIG }}
+
+    # Login to AWS ECR registries if needed
+    - name: Login to Amazon ECR
+      if: inputs.aws_registries && inputs.QA_AWS_REGION
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+      with:
+        registries: ${{ inputs.aws_registries }}
+      env:
+        AWS_REGION: ${{ inputs.QA_AWS_REGION }}
+
+    # To avoid rate limiting from Docker Hub, we can login with a paid user account.
+    - name: Login to Docker Hub
+      if: inputs.dockerhub_username && inputs.dockerhub_password
+      uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+      with:
+        username: ${{ inputs.dockerhub_username }}
+        password: ${{ inputs.dockerhub_password }}
+
+    # Helm Setup
+    - uses: azure/setup-helm@29960d0f5f19214b88e1d9ba750a9914ab0f1a2f # v4.0.0
+      with:
+        version: v3.13.1
+    - name: Add required helm charts including chainlink-qa
+      shell: bash
+      run: |
+        helm repo add bitnami https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+        helm repo add chainlink-qa https://raw.githubusercontent.com/smartcontractkit/qa-charts/gh-pages/
+
+    # Display tool versions
+    - name: Tool Versions
+      shell: bash
+      run: |
+        go version
+        aws --version
+        helm version
+        helm repo list

--- a/actions/ctf-setup-run-tests-environment/package.json
+++ b/actions/ctf-setup-run-tests-environment/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ctf-setup-run-tests-environment",
+  "version": "0.0.0",
+  "description": "",
+  "private": true,
+  "scripts": {},
+  "author": "@smartcontractkit",
+  "license": "MIT",
+  "dependencies": {},
+  "repository": "https://github.com/smartcontractkit/.github"
+}

--- a/actions/ctf-setup-run-tests-environment/project.json
+++ b/actions/ctf-setup-run-tests-environment/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "ctf-setup-run-tests-environment",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "actions/ctf-setup-run-tests-environment",
+  "targets": {}
+}


### PR DESCRIPTION
This migrates `ctf-setup-run-tests-environment` from [smartcontractkit/chainlink-github-actions](https://github.com/smartcontractkit/chainlink-github-actions/tree/main/chainlink-testing-framework) repository to this repo. Once merged, I will proceed to update all workflows that utilize these actions and subsequently remove the actions from the original smartcontractkit/chainlink-github-actions repository.