### PR TITLE
Add ctf-build-image action

### DIFF
--- a/.changeset/plenty-pans-fly.md
+++ b/.changeset/plenty-pans-fly.md
@@ -1,0 +1,5 @@
+---
+"ctf-build-image": minor
+---
+
+Add ctf-build-image action

--- a/actions/ctf-build-image/README.md
+++ b/actions/ctf-build-image/README.md
@@ -1,0 +1,3 @@
+# ctf-build-image
+
+> Common action for building chainlink test images

--- a/actions/ctf-build-image/action.yml
+++ b/actions/ctf-build-image/action.yml
@@ -1,0 +1,190 @@
+name: ctf-build-image
+description: "Common action for building chainlink test images"
+
+inputs:
+  cl_repo:
+    required: true
+    description: The chainlink repository to use
+    default: ${{ github.repository }}
+  cl_ref:
+    required: false
+    description: The git ref from the chainlink repository to use
+    default: develop
+  cl_dockerfile:
+    required: false
+    description: The chainlink dockerfile to use to build the image with
+    default: core/chainlink.Dockerfile
+  push_tag:
+    required: true
+    description:
+      The full docker tag to use for the push to ecr, does not push anything if
+      tag is empty
+  dep_solana_sha:
+    required: false
+    description: chainlink-solana commit or branch
+  dep_cosmos_sha:
+    required: false
+    description: chainlink-cosmos commit or branch
+  dep_starknet_sha:
+    required: false
+    description: chainlink-starknet commit or branch
+  dep_atlas_sha:
+    required: false
+    description: atlas commit or branch
+  dep_common_sha:
+    required: false
+    description: chainlink-common commit or branch
+  dep_evm_sha:
+    required: false
+    description: chainlink-integrations/evm/relayer commit or branch
+  QA_AWS_REGION:
+    required: true
+    description: The AWS region to use
+  QA_AWS_ROLE_TO_ASSUME:
+    required: true
+    description: The AWS role to assume
+  QA_PRIVATE_GHA_PULL:
+    required: false
+    description: Token to pull private repos
+  GOPRIVATE:
+    required: false
+    description: private repos needed for go
+  GO_COVER_FLAG:
+    required: false
+    default: false
+    description: Build chainlink binary with cover flag
+  should_checkout:
+    required: false
+    description:
+      Do we want to checkout the chainlink code branch, sometimes we don't need
+      to
+  docker_secrets:
+    description: Secrets to pass to the docker build and push action
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout Chainlink repo
+      if: ${{ inputs.should_checkout == 'true' }}
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        repository: ${{ inputs.cl_repo }}
+        ref: ${{ inputs.cl_ref }}
+    - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      env:
+        GOPRIVATE: ${{ inputs.GOPRIVATE }}
+      with:
+        go-version-file: "go.mod"
+        check-latest: true
+        cache: false
+    - name: Replace GHA URL
+      shell: bash
+      env:
+        GOPRIVATE: ${{ inputs.GOPRIVATE }}
+        QA_PRIVATE_GHA_PULL: ${{ inputs.QA_PRIVATE_GHA_PULL }}
+      run:
+        git config --global url.https://${{ inputs.QA_PRIVATE_GHA_PULL
+        }}@github.com/.insteadOf https://github.com/
+    - name: Replace Solana deps
+      if: ${{ inputs.dep_solana_sha }}
+      shell: bash
+      run:
+        go get github.com/smartcontractkit/chainlink-solana@${{
+        inputs.dep_solana_sha }}
+    - name: Replace Cosmos deps
+      if: ${{ inputs.dep_cosmos_sha }}
+      shell: bash
+      run:
+        go get github.com/smartcontractkit/chainlink-cosmos@${{
+        inputs.dep_cosmos_sha }}
+    - name: Replace StarkNet deps
+      if: ${{ inputs.dep_starknet_sha }}
+      shell: bash
+      run:
+        go get github.com/smartcontractkit/chainlink-starknet/relayer@${{
+        inputs.dep_starknet_sha }}
+    - name: Replace Atlas deps
+      if: ${{ inputs.dep_atlas_sha }}
+      shell: bash
+      env:
+        GOPRIVATE: ${{ inputs.GOPRIVATE }}
+      run: go get github.com/smartcontractkit/atlas@${{ inputs.dep_atlas_sha }}
+    - name: Replace chainlink-common deps
+      if: ${{ inputs.dep_common_sha }}
+      shell: bash
+      run:
+        go get github.com/smartcontractkit/chainlink-common@${{
+        inputs.dep_common_sha }}
+
+    # TODO: Remove this when it is no longer needed and uncomment the replace lower down.
+    - name: Replace the chainlink-integration deps
+      if: ${{ inputs.dep_evm_sha }}
+      shell: bash
+      env:
+        MODULE: github.com/smartcontractkit/chainlink-integrations/evm/relayer
+        COMMIT_HASH: ${{ inputs.dep_evm_sha }}
+      run: |
+        # Update to the evm/relayer code we wish to test against
+        go env -w GOPRIVATE=github.com/smartcontractkit/chainlink-integrations
+        go get ${MODULE}@${COMMIT_HASH}
+        # push replace into core go.mod, remove this once the evm migration is complete
+        PSEUDO_VERSION=$(go list -m -mod=mod ${MODULE}@${COMMIT_HASH} | awk '{print $2}')
+        go mod edit -replace=github.com/smartcontractkit/chainlink/v2/core/chains/evm=${MODULE}@${PSEUDO_VERSION}
+        go mod tidy
+    # TODO: put this back in when the replace above is no longer needed
+    # - name: Replace chainlink-integrations/evm/relayer deps
+    #   if: ${{ inputs.dep_evm_sha }}
+    #   shell: bash
+    #   run: go get github.com/smartcontractkit/chainlink-integrations/evm/relayer@${{ inputs.dep_evm_sha }}
+    - name: Tidy
+      shell: bash
+      env:
+        GOPRIVATE: ${{ inputs.GOPRIVATE }}
+      run: go mod tidy
+    - name: Cat go.mod
+      shell: bash
+      run: cat go.mod
+    - name: Setup push_tag
+      id: push
+      shell: bash
+      run: |
+        if [ "${{ inputs.push_tag }}" != "" ]; then
+          # tag exists so we can push
+          echo "push=true" >>$GITHUB_OUTPUT
+        else
+          # tag is empty, don't push
+          echo "push=false" >>$GITHUB_OUTPUT
+        fi
+    - name: Configure AWS Credentials
+      if: steps.push.outputs.push == 'true'
+      uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+      with:
+        aws-region: ${{ inputs.QA_AWS_REGION }}
+        role-to-assume: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}
+        role-duration-seconds: 3600
+        mask-aws-account-id: true
+    - name: Login to Amazon ECR
+      if: steps.push.outputs.push == 'true'
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+      with:
+        mask-password: "true"
+    - name: Set up Docker Buildx
+      if: steps.push.outputs.push == 'true'
+      uses: docker/setup-buildx-action@0d103c3126aa41d772a8362f6aa67afac040f80c # v3.1.0
+    - name: Build and Push
+      uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
+      with:
+        context: .
+        file: ${{ inputs.cl_dockerfile }}
+        # comma separated like: KEY1=VAL1,KEY2=VAL2,...
+        build-args: |
+          COMMIT_SHA=${{ github.sha }}
+          CHAINLINK_USER=chainlink
+          GO_COVER_FLAG=${{ inputs.GO_COVER_FLAG }}
+        tags: ${{ inputs.push_tag }}
+        push: ${{ steps.push.outputs.push }}
+        secrets: ${{ inputs.docker_secrets }}
+        # enabled by default as of v4 - disable while upgrading action reference (v3 -> v5)
+        provenance: false

--- a/actions/ctf-build-image/package.json
+++ b/actions/ctf-build-image/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ctf-build-image",
+  "version": "0.0.0",
+  "description": "",
+  "private": true,
+  "scripts": {},
+  "author": "@smartcontractkit",
+  "license": "MIT",
+  "dependencies": {},
+  "repository": "https://github.com/smartcontractkit/.github"
+}

--- a/actions/ctf-build-image/project.json
+++ b/actions/ctf-build-image/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "ctf-build-image",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "actions/ctf-build-image",
+  "targets": {}
+}


### PR DESCRIPTION
This migrates ctf-build-image from [smartcontractkit/chainlink-github-actions](https://github.com/smartcontractkit/chainlink-github-actions/tree/main/chainlink-testing-framework) repository to this repo. Once merged, I will proceed to update all workflows that utilize these actions and subsequently remove the actions from the original smartcontractkit/chainlink-github-actions repository.