### PR TITLE
Add ctf-show-grafana-in-test-summary action

### DIFF
--- a/.changeset/proud-eels-greet.md
+++ b/.changeset/proud-eels-greet.md
@@ -1,0 +1,5 @@
+---
+"ctf-show-grafana-in-test-summary": minor
+---
+
+Add ctf-show-grafana-in-test-summary action

--- a/actions/ctf-show-grafana-in-test-summary/README.md
+++ b/actions/ctf-show-grafana-in-test-summary/README.md
@@ -1,0 +1,3 @@
+# ctf-show-grafana-in-test-summary
+
+> Show Grafana url in test summary

--- a/actions/ctf-show-grafana-in-test-summary/action.yml
+++ b/actions/ctf-show-grafana-in-test-summary/action.yml
@@ -1,0 +1,38 @@
+name: ctf-show-grafana-in-test-summary
+description: "Show Grafana url in test summary"
+
+inputs:
+  test_directories:
+    required: true
+    description: Comma-separated directories in which the tests are located
+    default: ./integration-tests/smoke
+
+runs:
+  using: composite
+  steps:
+    - name: Print failed test summary
+      shell: bash
+      run: |
+        IFS=',' read -r -a directories <<< "$(echo "${{ inputs.test_directories }}" | tr -d '[:space:]')"
+        for inputDir in "${directories[@]}"; do
+          cleanTestDir=${inputDir%/}
+          directory="$cleanTestDir/.test_summary"
+          echo "Looking for test summary in: $directory"
+          files=("$directory"/*)
+          if [ -d "$directory" ]; then
+            echo "Test summary folder found in $inputDir"
+            if [ ${#files[@]} -gt 0 ]; then
+              first_file="${files[0]}"
+              echo "Name of the first test summary file: $(basename "$first_file")"
+              echo "### Failed Test Execution Logs Dashboard (over VPN):" >> $GITHUB_STEP_SUMMARY
+              cat "$first_file" | jq -r 'if .loki then (.loki[] | if .value != "" then "* [\(.test_name)](\(.value))" else "No URL found for \(.test_name)" end) else "No Grafana URLs found" end' >> $GITHUB_STEP_SUMMARY
+              if [ ${#files[@]} -gt 1 ]; then
+                echo "Found more than one test summary file in $inputDir. This is incorrect, there should be only one file"
+              fi
+            else
+              echo "Test summary directory in $inputDir is empty. This should not happen"
+            fi
+          else
+            echo "No test summary folder found in $inputDir. If no test failed or log collection wasn't explicitly requested this is correct. Exiting"
+          fi
+        done

--- a/actions/ctf-show-grafana-in-test-summary/package.json
+++ b/actions/ctf-show-grafana-in-test-summary/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ctf-show-grafana-in-test-summary",
+  "version": "0.0.0",
+  "description": "",
+  "private": true,
+  "scripts": {},
+  "author": "@smartcontractkit",
+  "license": "MIT",
+  "dependencies": {},
+  "repository": "https://github.com/smartcontractkit/.github"
+}

--- a/actions/ctf-show-grafana-in-test-summary/project.json
+++ b/actions/ctf-show-grafana-in-test-summary/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "ctf-show-grafana-in-test-summary",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "actions/ctf-show-grafana-in-test-summary",
+  "targets": {}
+}


### PR DESCRIPTION
This migrates ctf-show-grafana-in-test-summary from [smartcontractkit/chainlink-github-actions](https://github.com/smartcontractkit/chainlink-github-actions/tree/main/chainlink-testing-framework) repository to this repo. Once merged, I will proceed to update all workflows that utilize these actions and subsequently remove the actions from the original smartcontractkit/chainlink-github-actions repository.