### PR TITLE
Add ctf-check-mod-version action

### DIFF
--- a/.changeset/shiny-kids-taste.md
+++ b/.changeset/shiny-kids-taste.md
@@ -1,0 +1,5 @@
+---
+"ctf-check-mod-version": minor
+---
+
+Add ctf-check-mod-version action

--- a/actions/ctf-check-mod-version/README.md
+++ b/actions/ctf-check-mod-version/README.md
@@ -1,0 +1,3 @@
+# ctf-check-mod-version
+
+> Check go mod version and optionally enforce semantic version

--- a/actions/ctf-check-mod-version/action.yml
+++ b/actions/ctf-check-mod-version/action.yml
@@ -1,0 +1,62 @@
+name: ctf-check-mod-version
+description: "Check go mod version and optionally enforce semantic version "
+
+inputs:
+  go-project-path:
+    required: true
+    description:
+      The path to the base of the go project where the go.mod file lives
+  module-name:
+    required: true
+    description: The module name to get
+  enforce-semantic-tag:
+    required: false
+    description: Should we enforce the version to be a semantic tag
+    default: "false"
+outputs:
+  version:
+    description: Did we clean up pods
+    value: ${{ steps.version.outputs.version }}
+  is_semantic:
+    description: Is the version a proper semantic version
+    value: ${{ steps.enforce.outputs.pass }}
+
+runs:
+  using: composite
+  steps:
+    - name: Get version
+      id: version
+      shell: bash
+      env:
+        go_project_path: ${{ inputs.go-project-path }}
+        package_name: ${{ inputs.module-name }}
+      run: |
+        cd ${go_project_path}
+        # Extract the version of the package from go.mod
+        version=$(grep "$package_name " go.mod | awk '{print $2}')
+        echo "Found version: $version"
+        # Check if version is empty
+        if [ -z "$version" ]; then
+            echo "There is no version for $package_name"
+            exit 1  # Exit with a failure code
+        else
+            echo "Found version: $version"
+        fi
+        echo "version=${version}" >>$GITHUB_OUTPUT
+    - name: Enforce Semantic version
+      id: enforce
+      shell: bash
+      env:
+        version: ${{ steps.version.outputs.version }}
+        enforce: ${{ inputs.enforce-semantic-tag }}
+      run: |
+        if [[ $version =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "The version $version is a semantic version."
+            echo "pass=true" >>$GITHUB_OUTPUT
+        else
+            echo "pass=false" >>$GITHUB_OUTPUT
+            if [ "$enforce" = "true" ]; then
+                echo "The version $version is not a semantic version, it should be a proper release tag and not based off a commit."
+                exit 1
+            fi
+        fi

--- a/actions/ctf-check-mod-version/package.json
+++ b/actions/ctf-check-mod-version/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ctf-check-mod-version",
+  "version": "0.0.0",
+  "description": "",
+  "private": true,
+  "scripts": {},
+  "author": "@smartcontractkit",
+  "license": "MIT",
+  "dependencies": {},
+  "repository": "https://github.com/smartcontractkit/.github"
+}

--- a/actions/ctf-check-mod-version/project.json
+++ b/actions/ctf-check-mod-version/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "ctf-check-mod-version",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "actions/ctf-check-mod-version",
+  "targets": {}
+}


### PR DESCRIPTION
This migrates ctf-check-mod-version from [smartcontractkit/chainlink-github-actions](https://github.com/smartcontractkit/chainlink-github-actions/tree/main/chainlink-testing-framework) repository to this repo. Once merged, I will proceed to update all workflows that utilize these actions and subsequently remove the actions from the original smartcontractkit/chainlink-github-actions repository.