### PR TITLE
Add ctf-build-tests action

### DIFF
--- a/.changeset/wet-plants-occur.md
+++ b/.changeset/wet-plants-occur.md
@@ -1,0 +1,5 @@
+---
+"ctf-build-tests": minor
+---
+
+Add ctf-build-tests action

--- a/actions/ctf-build-tests/README.md
+++ b/actions/ctf-build-tests/README.md
@@ -1,0 +1,3 @@
+# ctf-build-tests
+
+> Builds a test binary for chainlink integration tests

--- a/actions/ctf-build-tests/action.yml
+++ b/actions/ctf-build-tests/action.yml
@@ -1,0 +1,98 @@
+name: ctf-build-tests
+description: "Builds a test binary for chainlink integration tests"
+
+inputs:
+  binary_name:
+    required: false
+    description: Name of the artifact to upload
+    default: test-logs
+  test_download_vendor_packages_command:
+    required: false
+    description: The command to download the go modules
+    default: make download
+  test_type:
+    required: false
+    description: The name of the test type you plan to run, e.g. smoke
+    default: smoke
+  token:
+    required: false
+    description: The GITHUB_TOKEN for the workflow
+    default: ${{ github.token }}
+  go_version:
+    required: false
+    description: Go version to install
+  go_mod_path:
+    required: false
+    description: The go.mod file path
+  go_tags:
+    required: false
+    description: Go tags to use when building
+  cache_restore_only:
+    required: false
+    description:
+      Only restore the cache, set to true if you want to restore and save on
+      cache hit miss
+    default: "false"
+  cache_key_id:
+    required: false
+    description: Cache go vendors unique id
+    default: go
+  dep_chainlink_integration_tests:
+    required: false
+    description: chainlink/integration-tests commit or branch
+  CGO_ENABLED:
+    required: false
+    description: Whether to have cgo enabled, defaults to disabled
+    default: "0"
+
+runs:
+  using: composite
+  steps:
+    # Setup Tools and libraries
+    - name: Setup Go
+      uses: smartcontractkit/.github/actions/ctf-setup-go@b0d756c57fcdbcff187e74166562a029fdd5d1b9 # ctf-setup-go@0.0.0
+      with:
+        test_download_vendor_packages_command:
+          ${{ inputs.test_download_vendor_packages_command }}
+        go_version: ${{ inputs.go_version }}
+        go_mod_path: ${{ inputs.go_mod_path }}
+        cache_restore_only: ${{ inputs.cache_restore_only }}
+        cache_key_id: ${{ inputs.cache_key_id }}
+        should_tidy: "true"
+
+    - name: Replace chainlink/integration-tests deps
+      if: ${{ inputs.dep_chainlink_integration_tests }}
+      shell: bash
+      run: |
+        # find test go root by using the go_mod_path and change to that directory
+        TEST_LIB_PATH="${{ inputs.go_mod_path }}"
+        if [ "${#TEST_LIB_PATH}" -gt "6" ]; then
+            TEST_LIB_PATH=${TEST_LIB_PATH%go.mod}
+            cd "${TEST_LIB_PATH}"
+        fi
+
+        go version
+        # update the integration-tests lib to the branch or commit
+        go get github.com/smartcontractkit/chainlink/integration-tests@${{ inputs.dep_chainlink_integration_tests }}
+        go mod tidy
+
+    - name: Build Tests
+      shell: bash
+      env:
+        CGO_ENABLED: ${{ inputs.CGO_ENABLED }}
+      run: |
+        PATH=$PATH:$(go env GOPATH)/bin
+        export PATH
+        TAGS="${{ inputs.go_tags }}"
+        if [ -n "$TAGS" ]; then
+            echo "Using build tags: $TAGS"
+            TAGS="-tags ${TAGS} "
+        fi
+        cd ./integration-tests && go test -c $TAGS-ldflags="-s -w" -o ./tests ./${{ inputs.test_type }}
+        echo "Built binary at ./integration-tests/tests"
+
+    - name: Publish Binary
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+      with:
+        name: ${{ inputs.binary_name }}
+        path: ./integration-tests/tests

--- a/actions/ctf-build-tests/package.json
+++ b/actions/ctf-build-tests/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ctf-build-tests",
+  "version": "0.0.0",
+  "description": "",
+  "private": true,
+  "scripts": {},
+  "author": "@smartcontractkit",
+  "license": "MIT",
+  "dependencies": {},
+  "repository": "https://github.com/smartcontractkit/.github"
+}

--- a/actions/ctf-build-tests/project.json
+++ b/actions/ctf-build-tests/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "ctf-build-tests",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "actions/ctf-build-tests",
+  "targets": {}
+}


### PR DESCRIPTION
This migrates ctf-build-tests from [smartcontractkit/chainlink-github-actions](https://github.com/smartcontractkit/chainlink-github-actions/tree/main/chainlink-testing-framework) repository to this repo. Once merged, I will proceed to update all workflows that utilize these actions and subsequently remove the actions from the original smartcontractkit/chainlink-github-actions repository.