### PR TITLE
Add ctf-run-tests-binary action

### DIFF
--- a/.changeset/ninety-suits-suffer.md
+++ b/.changeset/ninety-suits-suffer.md
@@ -1,0 +1,5 @@
+---
+"ctf-run-tests-binary": minor
+---
+
+Add ctf-run-tests-binary action

--- a/actions/ctf-run-tests-binary/README.md
+++ b/actions/ctf-run-tests-binary/README.md
@@ -1,0 +1,3 @@
+# ctf-run-tests-binary
+
+> Run CTF test binary

--- a/actions/ctf-run-tests-binary/action.yml
+++ b/actions/ctf-run-tests-binary/action.yml
@@ -1,0 +1,154 @@
+name: ctf-run-tests-binary
+description: "Run CTF test binary"
+
+inputs:
+  artifacts_location:
+    required: false
+    description: Location of where error logs are written
+    default: ./logs
+  artifacts_name:
+    required: false
+    description: Name of the artifact to upload
+    default: test-logs
+  test_command_to_run:
+    required: true
+    description:
+      The command to run the tests by calling your binary (note that -test.json
+      is not supported)
+    # https://github.com/golang/go/issues/22996
+  cl_repo:
+    required: false
+    description: The Chainlink ecr repository to use
+    default: public.ecr.aws/z0b1w9r9/chainlink
+  cl_image_tag:
+    required: false
+    description: The chainlink image to use
+    default: develop
+  build_gauntlet_command:
+    required: false
+    description: How to build gauntlet if necessary
+    default: "false"
+  download_contract_artifacts_path:
+    required: false
+    description: Path where the contract artifacts need to be placed
+    default: "none"
+  token:
+    required: false
+    description: The GITHUB_TOKEN for the workflow
+    default: ${{ github.token }}
+  triggered_by:
+    required: true
+    description:
+      The triggered-by label for the k8s namespace, required for cleanup
+    default: ci
+  cache_restore_only:
+    required: false
+    description:
+      Only restore the cache, set to true if you want to restore and save on
+      cache hit miss
+    default: "false"
+  cache_key_id:
+    required: false
+    description: Cache go vendors unique id
+    default: go
+  aws_registries:
+    required: false
+    description: AWS registries to log into for the test if needed
+  aws_role_duration_seconds:
+    required: false
+    default: "3600"
+    description: The duration to be logged into the aws role for
+  dockerhub_username:
+    description:
+      Username for Docker Hub to avoid rate limits when pulling public images
+    required: false
+  dockerhub_password:
+    description:
+      Password for Docker Hub to avoid rate limits when pulling public images
+    required: false
+  QA_AWS_REGION:
+    required: true
+    description: The AWS region to use
+  QA_AWS_ROLE_TO_ASSUME:
+    required: true
+    description: The AWS role to assume
+  QA_KUBECONFIG:
+    required: false
+    description: The kubernetes configuration to use
+  should_cleanup:
+    required: false
+    description:
+      Whether to run the cleanup at the end, soak tests and such would not want
+      to automatically cleanup
+    default: "false"
+  binary_name:
+    required: true
+    description: Name of the binary artifact to run
+    default: tests
+  should_tidy:
+    required: false
+    description: Should we check go mod tidy
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Environment
+      uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@49cb1613e96c9ce17f7290e4dabd38f43aa9bd4d # ctf-setup-run-tests-environment@0.0.0
+      with:
+        go_necessary: "false"
+        cache_restore_only: ${{ inputs.cache_restore_only }}
+        cache_key_id: ${{ inputs.cache_key_id }}
+        aws_registries: ${{ inputs.aws_registries }}
+        aws_role_duration_seconds: ${{ inputs.aws_role_duration_seconds }}
+        dockerhub_username: ${{ inputs.dockerhub_username }}
+        dockerhub_password: ${{ inputs.dockerhub_password }}
+        QA_AWS_REGION: ${{ inputs.QA_AWS_REGION }}
+        QA_AWS_ROLE_TO_ASSUME: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}
+        QA_KUBECONFIG: ${{ inputs.QA_KUBECONFIG }}
+        should_tidy: ${{ inputs.should_tidy }}
+
+    # Download any external artifacts
+    - name: Download Artifacts
+      if: inputs.download_contract_artifacts_path != 'none'
+      uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+      with:
+        name: artifacts
+        path: ${{ inputs.download_contract_artifacts_path }}
+
+    # Generate any excutables needed to run tests
+    - name: Generate gauntlet executable
+      if: inputs.build_gauntlet_command != 'false'
+      shell: bash
+      run: ${{ inputs.build_gauntlet_command }}
+
+    # Run the tests
+    - name: Run Tests
+      shell: bash
+      env:
+        CHAINLINK_IMAGE: ${{ inputs.cl_repo }}
+        CHAINLINK_VERSION: ${{ inputs.cl_image_tag }}
+        CHAINLINK_ENV_USER: ${{ github.actor }}
+        CGO_ENABLED: ${{ inputs.CGO_ENABLED }}
+      run: |
+        export TEST_TRIGGERED_BY=${{ inputs.triggered_by }}-${{ github.event.pull_request.number || github.run_id }}
+        # Handle bots as users
+        export CHAINLINK_ENV_USER=${CHAINLINK_ENV_USER//"[bot]"/-bot}
+
+        chmod +x ./${{ inputs.binary_name }}
+
+        ${{ inputs.test_command_to_run }}
+
+    - name: Publish Artifacts
+      if: failure()
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+      with:
+        name: ${{ inputs.artifacts_name }}
+        path: ${{ inputs.artifacts_location }}
+
+    - name: cleanup
+      if: always()
+      uses: smartcontractkit/.github/actions/ctf-cleanup@d7bff995d180bd94443e68d5a54496e674232836 # ctf-cleanup@0.0.0
+      with:
+        triggered_by: ${{ inputs.triggered_by }}
+        should_cleanup: ${{ inputs.should_cleanup }}

--- a/actions/ctf-run-tests-binary/package.json
+++ b/actions/ctf-run-tests-binary/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ctf-run-tests-binary",
+  "version": "0.0.0",
+  "description": "",
+  "private": true,
+  "scripts": {},
+  "author": "@smartcontractkit",
+  "license": "MIT",
+  "dependencies": {},
+  "repository": "https://github.com/smartcontractkit/.github"
+}

--- a/actions/ctf-run-tests-binary/project.json
+++ b/actions/ctf-run-tests-binary/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "ctf-run-tests-binary",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "actions/ctf-run-tests-binary",
+  "targets": {}
+}


### PR DESCRIPTION
This migrates ctf-run-tests-binary from [smartcontractkit/chainlink-github-actions](https://github.com/smartcontractkit/chainlink-github-actions/tree/main/chainlink-testing-framework) repository to this repo. Once merged, I will proceed to update all workflows that utilize these actions and subsequently remove the actions from the original smartcontractkit/chainlink-github-actions repository.