### PR TITLE
Add ctf-run-tests action

### DIFF
--- a/.changeset/itchy-drinks-suffer.md
+++ b/.changeset/itchy-drinks-suffer.md
@@ -1,0 +1,5 @@
+---
+"ctf-run-tests": minor
+---
+
+Add ctf-run-tests action

--- a/actions/ctf-run-tests/README.md
+++ b/actions/ctf-run-tests/README.md
@@ -1,0 +1,3 @@
+# ctf-run-tests
+
+> Common runner for chainlink-testing-framework based tests

--- a/actions/ctf-run-tests/action.yml
+++ b/actions/ctf-run-tests/action.yml
@@ -1,0 +1,317 @@
+name: ctf-run-tests
+description: "Common runner for chainlink-testing-framework based tests"
+
+inputs:
+  artifacts_location:
+    required: false
+    description: Location of where error logs are written
+    default: ./integration-tests/smoke/logs
+  artifacts_name:
+    required: false
+    description: Name of the artifact to upload
+    default: test-logs
+  test_command_to_run:
+    required: true
+    description: The command to run the tests
+  test_download_vendor_packages_command:
+    required: false
+    description: The command to download the go modules
+    default: make download
+  test_secrets_defaults_base64:
+    required: false
+    description:
+      The base64-encoded .env file with key=value with secrets to use as
+      defaults
+  test_secrets_override_base64:
+    required: false
+    description:
+      The base64-encoded .env file with key=value with secrets to override
+      defaults
+  test_config_override_path:
+    required: false
+    description:
+      The path to the test config file used to override the default test config
+  test_config_override_base64:
+    required: false
+    description: The base64-encoded test config override
+  test_type:
+    required: false
+    description:
+      The type of test to run. Used by some tests to select test configuration
+  test_suite:
+    required: false
+    description: The test suite to run. Used by k8s remote runner tests
+  default_e2e_test_chainlink_image:
+    required: false
+    description: The default chainlink image to use if override not set
+  default_e2e_test_chainlink_upgrade_image:
+    required: false
+    description:
+      The default chainlink image to use for upgrade tests if override not set
+  cl_repo:
+    required: false
+    description: The Chainlink ecr repository to use
+    default: public.ecr.aws/z0b1w9r9/chainlink
+  cl_image_tag:
+    required: false
+    description: The chainlink image to use
+    default: develop
+  build_gauntlet_command:
+    required: false
+    description: How to build gauntlet if necessary
+    default: "false"
+  download_contract_artifacts_path:
+    required: false
+    description: Path where the contract artifacts need to be placed
+    default: "none"
+  publish_report_paths:
+    required: false
+    description: The path of the output report
+    default: "./tests-smoke-report.xml"
+  publish_check_name:
+    required: false
+    description: The check name for publishing the reports
+    default: Smoke Test Results
+  token:
+    required: false
+    description: The GITHUB_TOKEN for the workflow
+    default: ${{ github.token }}
+  publish_test_results_comment_mode:
+    required: false
+    description:
+      comment_mode value for EnricoMi/publish-unit-test-result-action@v1
+    default: always
+  publish_test_results_commit:
+    required: false
+    description:
+      Commit SHA to which test results are published. Only needed if the value
+      of GITHUB_SHA does not work for you.
+  triggered_by:
+    required: true
+    description:
+      The triggered-by label for the k8s namespace, required for cleanup
+    default: ci
+  go_version:
+    required: false
+    description: Go version to install
+  go_mod_path:
+    required: false
+    description: The go.mod file path
+  go_coverage_src_dir:
+    required: false
+    description: The source directory for go coverage files
+  go_coverage_dest_dir:
+    required: false
+    description: The destination directory to store go coverage files
+  cache_restore_only:
+    required: false
+    description:
+      Only restore the cache, set to true if you want to restore and save on
+      cache hit miss
+    default: "false"
+  cache_key_id:
+    required: false
+    description: Cache go vendors unique id
+    default: go
+  aws_registries:
+    required: false
+    description: AWS registries to log into for the test if needed
+  aws_role_duration_seconds:
+    required: false
+    default: "3600"
+    description: The duration to be logged into the aws role for
+  dockerhub_username:
+    description:
+      Username for Docker Hub to avoid rate limits when pulling public images
+    required: false
+  dockerhub_password:
+    description:
+      Password for Docker Hub to avoid rate limits when pulling public images
+    required: false
+  dep_chainlink_integration_tests:
+    required: false
+    description: chainlink/integration-tests commit or branch
+  QA_AWS_REGION:
+    required: true
+    description: The AWS region to use
+  QA_AWS_ROLE_TO_ASSUME:
+    required: true
+    description: The AWS role to assume
+  QA_KUBECONFIG:
+    required: false
+    description: The kubernetes configuration to use
+  CGO_ENABLED:
+    required: false
+    description: Whether to have cgo enabled, defaults to enabled
+    default: "1"
+  run_setup:
+    required: false
+    description: Should we run the setup before running the tests
+    default: "true"
+  should_cleanup:
+    required: false
+    description:
+      Whether to run the cleanup at the end, soak tests and such would not want
+      to automatically cleanup
+    default: "false"
+  should_tidy:
+    required: false
+    description: Should we check go mod tidy
+    default: "true"
+  no_cache:
+    required: false
+    description: Do not use a go cache
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    # Setup Tools and libraries
+    - name: Setup environment
+      if: inputs.run_setup == 'true'
+      uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@49cb1613e96c9ce17f7290e4dabd38f43aa9bd4d # ctf-setup-run-tests-environment@0.0.0
+      with:
+        test_download_vendor_packages_command:
+          ${{ inputs.test_download_vendor_packages_command }}
+        go_version: ${{ inputs.go_version }}
+        go_mod_path: ${{ inputs.go_mod_path }}
+        cache_restore_only: ${{ inputs.cache_restore_only }}
+        cache_key_id: ${{ inputs.cache_key_id }}
+        aws_registries: ${{ inputs.aws_registries }}
+        aws_role_duration_seconds: ${{ inputs.aws_role_duration_seconds }}
+        dockerhub_username: ${{ inputs.dockerhub_username }}
+        dockerhub_password: ${{ inputs.dockerhub_password }}
+        QA_AWS_REGION: ${{ inputs.QA_AWS_REGION }}
+        QA_AWS_ROLE_TO_ASSUME: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}
+        QA_KUBECONFIG: ${{ inputs.QA_KUBECONFIG }}
+        should_tidy: ${{ inputs.should_tidy }}
+        no_cache: ${{ inputs.no_cache }}
+
+    - name: Replace chainlink/integration-tests deps
+      if: ${{ inputs.dep_chainlink_integration_tests }}
+      shell: bash
+      run: |
+        # find test go root by using the go_mod_path and change to that directory
+        TEST_LIB_PATH="${{ inputs.go_mod_path }}"
+        if [ "${#TEST_LIB_PATH}" -gt "6" ]; then
+            TEST_LIB_PATH=${TEST_LIB_PATH%go.mod}
+            cd "${TEST_LIB_PATH}"
+        fi
+
+        # update the integration-tests lib to the branch or commit
+        go get github.com/smartcontractkit/chainlink/integration-tests@${{ inputs.dep_chainlink_integration_tests }}
+        go mod tidy
+
+    # Download any external artifacts
+    - name: Download Artifacts
+      if: inputs.download_contract_artifacts_path != 'none'
+      uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+      with:
+        name: artifacts
+        path: ${{ inputs.download_contract_artifacts_path }}
+
+    # Generate any excutables needed to run tests
+    - name: Generate gauntlet executable
+      if: inputs.build_gauntlet_command != 'false'
+      shell: bash
+      run: ${{ inputs.build_gauntlet_command }}
+
+    # TODO: Remove this once gotestloghelper has replaced all usages of gotestfmt
+    - name: Set Up gotestfmt
+      uses: GoTestTools/gotestfmt-action@8b4478c7019be847373babde9300210e7de34bfb # v2.2.0
+      with:
+        token: ${{ inputs.token }} # Avoids rate-limiting
+
+    # gotestfmt gives us pretty test output
+    - name: Set Up gotestloghelper
+      shell: bash
+      run:
+        go install
+        github.com/smartcontractkit/chainlink-testing-framework/tools/gotestloghelper@v1.1.1
+
+    - name: Set default enironment variables
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.test_type }}" ]; then
+          echo "TEST_TYPE=${{ inputs.test_type }}" >> $GITHUB_ENV
+          echo "TEST_TEST_TYPE=${{ inputs.test_type }}" >> $GITHUB_ENV
+        fi
+        if [ -n "${{ inputs.test_suite }}" ]; then
+          echo "TEST_SUITE=${{ inputs.test_suite }}" >> $GITHUB_ENV
+          echo "TEST_TEST_SUITE=${{ inputs.test_suite }}" >> $GITHUB_ENV
+        fi
+
+    # If default and/or custom secrets provided, decode them, mask them and set them as env vars to override the default secrets
+    - name: Set default test secrets from dotenv file
+      if: inputs.test_secrets_defaults_base64 != ''
+      shell: bash
+      run:
+        go run ${{ github.action_path }}/mask-testsecrets/main.go "${{
+        inputs.test_secrets_defaults_base64 }}"
+
+    # Custom secrets override the default secrets
+    - name: Set custom test secrets from dotenv file
+      if: inputs.test_secrets_override_base64 != ''
+      shell: bash
+      run:
+        go run ${{ github.action_path }}/mask-testsecrets/main.go "${{
+        inputs.test_secrets_override_base64 }}"
+
+    - name: Set default E2E_TEST_* env vars if they are not set already
+      shell: bash
+      run: |
+        if [[ -z "${{ env.E2E_TEST_CHAINLINK_IMAGE }}" ]]; then
+          echo "E2E_TEST_CHAINLINK_IMAGE=${{ inputs.default_e2e_test_chainlink_image }}" >> $GITHUB_ENV
+        fi
+        if [[ -z "${{ env.E2E_TEST_CHAINLINK_UPGRADE_IMAGE }}" ]]; then
+          echo "E2E_TEST_CHAINLINK_UPGRADE_IMAGE=${{ inputs.default_e2e_test_chainlink_upgrade_image }}" >> $GITHUB_ENV
+        fi
+
+    - name: Set test config override from config file
+      if: inputs.test_config_override_path != ''
+      shell: bash
+      run: |
+        BASE64_CONFIG_OVERRIDE=$(base64 -w 0 -i ${{ inputs.test_config_override_path }})
+        echo ::add-mask::$BASE64_CONFIG_OVERRIDE
+        echo "BASE64_CONFIG_OVERRIDE=$BASE64_CONFIG_OVERRIDE" >> $GITHUB_ENV
+
+    # Override the default test config if a custom one is provided
+    - name: Use test config override
+      if: inputs.test_config_override_base64 != ''
+      shell: bash
+      run: |
+        BASE64_CONFIG_OVERRIDE=${{ inputs.test_config_override_base64 }}
+        echo ::add-mask::$BASE64_CONFIG_OVERRIDE
+        echo "BASE64_CONFIG_OVERRIDE=$BASE64_CONFIG_OVERRIDE" >> $GITHUB_ENV
+
+    # Run the tests
+    - name: Run Tests
+      shell: bash
+      env:
+        CHAINLINK_IMAGE: ${{ inputs.cl_repo }} # TODO: to remove
+        CHAINLINK_VERSION: ${{ inputs.cl_image_tag }} # TODO: to remove
+        CHAINLINK_ENV_USER: ${{ github.actor }}
+        CGO_ENABLED: ${{ inputs.CGO_ENABLED }}
+        GO_COVERAGE_SRC_DIR: ${{ inputs.go_coverage_src_dir }}
+        GO_COVERAGE_DEST_DIR: ${{ inputs.go_coverage_dest_dir }}
+      run: |
+        PATH=$PATH:$(go env GOPATH)/bin
+        export PATH
+        export TEST_TRIGGERED_BY=${{ inputs.triggered_by }}-${{ github.event.pull_request.number || github.run_id }}
+        # Handle bots as users
+        export CHAINLINK_ENV_USER=${CHAINLINK_ENV_USER//"[bot]"/-bot}
+        ${{ inputs.test_command_to_run }}
+
+    - name: Publish Artifacts
+      if: failure()
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+      with:
+        name: ${{ inputs.artifacts_name }}
+        path: ${{ inputs.artifacts_location }}
+
+    - name: cleanup
+      if: always()
+      uses: smartcontractkit/.github/actions/ctf-cleanup@d7bff995d180bd94443e68d5a54496e674232836 # ctf-cleanup@0.0.0
+      with:
+        triggered_by: ${{ inputs.triggered_by }}
+        should_cleanup: ${{ inputs.should_cleanup }}

--- a/actions/ctf-run-tests/mask-testsecrets/go.mod
+++ b/actions/ctf-run-tests/mask-testsecrets/go.mod
@@ -1,0 +1,3 @@
+module github.com/smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests/mask-testsecrets
+
+go 1.21.3

--- a/actions/ctf-run-tests/mask-testsecrets/main.go
+++ b/actions/ctf-run-tests/mask-testsecrets/main.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+type DotenvParseError struct {
+	Line int // Line where the error occurred
+}
+
+// Error implements the error interface for DotenvParseError.
+func (e *DotenvParseError) Error() string {
+	return fmt.Sprintf("could not parse dotenv due to invalid KEY=\"VALUE\" in line: %d. Only KEY=VALUE or KEY=\"VALUE\" are supported. To include special characters such as an apostrophe in the VALUE, enclose the VALUE in double quotes (e.g., KEY=\"'VALUE'\")", e.Line)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run main.go <base64_dot_env_string>")
+		return
+	}
+
+	decodedBytes, err := base64.StdEncoding.DecodeString(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Could not decode provided base64 string")
+		os.Exit(1)
+	}
+
+	envVars, err := parseEnvVars(string(decodedBytes))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	for key, value := range envVars {
+		mustMaskSecret(key, value)
+		mustAddToGithubEnv(key, value)
+	}
+}
+
+func parseEnvVars(envStr string) (map[string]string, error) {
+	envVars := make(map[string]string)
+	// Regular expression to match configurations in the form of KEY=VALUE or KEY="VALUE".
+	// To include special characters such as an apostrophe in the VALUE, enclose the VALUE in double quotes (e.g., KEY="'VALUE'").
+	// Restrictions:
+	// - KEY must not be enclosed in any type of quotes.
+	// - VALUE can be unquoted or enclosed in double quotes, but not single quotes.
+	re := regexp.MustCompile(`^[^" '=]+=".*"$|^[^" '=]+=[^" ']+$`)
+
+	lines := strings.Split(envStr, "\n")
+	for i, line := range lines {
+		line = strings.TrimSpace(line) // Trim space from start and end
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue // Skip empty lines and comments
+		}
+		if strings.HasPrefix(line, "export ") {
+			line = strings.TrimSpace(strings.TrimPrefix(line, "export"))
+		}
+
+		// Validate the line with regex before processing
+		if re.MatchString(line) {
+			parts := strings.SplitN(line, "=", 2)
+			if len(parts) == 2 {
+				key := strings.TrimSpace(parts[0])
+				value := removeSurroundingQuotes(strings.TrimSpace(parts[1]))
+				envVars[key] = value
+			}
+		} else {
+			return nil, &DotenvParseError{Line: i + 1}
+		}
+	}
+	return envVars, nil
+}
+
+func removeSurroundingQuotes(s string) string {
+	if len(s) >= 2 {
+		if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}
+
+func mustAddToGithubEnv(key, value string) {
+	command := fmt.Sprintf("echo \"%s=%s\" >> $GITHUB_ENV", key, value)
+	cmd := exec.Command("bash", "-c", command)
+	err := cmd.Run()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to add '%s' to GITHUB_ENV", key)
+		os.Exit(1)
+	}
+}
+
+func mustMaskSecret(description string, secret string) {
+	if secret != "" {
+		fmt.Printf("Mask '%s'\n", description)
+		fmt.Printf("::add-mask::%s\n", secret)
+		cmd := exec.Command("bash", "-c", "echo ::add-mask::$0", "_", secret)
+		err := cmd.Run()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to mask secret '%s'", description)
+			os.Exit(1)
+		}
+	}
+}

--- a/actions/ctf-run-tests/mask-testsecrets/main_test.go
+++ b/actions/ctf-run-tests/mask-testsecrets/main_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestParseEnvVars checks various scenarios for parsing environment variables.
+func TestParseEnvVars(t *testing.T) {
+	tests := []struct {
+		name     string
+		envStr   string
+		expected map[string]string
+		err      error
+	}{
+		{
+			name: "Simple Key-Value",
+			envStr: `KEY=VALUE
+ANOTHER_KEY=VALUE2
+KEY3="VALUE1 VALUE2"`,
+			expected: map[string]string{"KEY": "VALUE", "ANOTHER_KEY": "VALUE2", "KEY3": "VALUE1 VALUE2"},
+		},
+		{
+			name:     "Export Prefix",
+			envStr:   "export KEY=VALUE\nexport ANOTHER_KEY=VALUE",
+			expected: map[string]string{"KEY": "VALUE", "ANOTHER_KEY": "VALUE"},
+		},
+		{
+			name: "Values with Quotes",
+			envStr: `KEY="some value"
+ANOTHER_KEY="another value"
+KEY3="'value3'"
+KEY4="'value4',"`,
+			expected: map[string]string{"KEY": "some value", "ANOTHER_KEY": "another value", "KEY3": "'value3'", "KEY4": "'value4',"},
+		},
+		{
+			name: "With Comments",
+			envStr: `# This is a comment
+export VAR1="Value 1"
+#VAR2='Value2'
+VAR3=Value3
+# export VAR4="Value4"`,
+			expected: map[string]string{"VAR1": "Value 1", "VAR3": "Value3"},
+		},
+		{
+			name: "Comma after Value",
+			envStr: `KEY=VALUE,
+KEY2="VALUE2",`,
+			err: &DotenvParseError{Line: 2},
+		},
+		{
+			name: "Fail on Single Quotes",
+			envStr: `KEY1=VALUE1
+KEY2="VALUE2"
+ANOTHER_KEY='VALUE'
+		`,
+			err: &DotenvParseError{Line: 3},
+		},
+		{
+			name: "Key with Double Quotes",
+			envStr: `KEY="VALUE"
+"ANOTHER_KEY"=VALUE`,
+			err: &DotenvParseError{Line: 2},
+		},
+		{
+			name: "Key with Single Quotes",
+			envStr: `KEY="VALUE"
+'ANOTHER_KEY'=VALUE`,
+			err: &DotenvParseError{Line: 2},
+		},
+		{
+			name: "Value with Spaces",
+			envStr: `KEY="VALUE"
+KEY2=VALUE 2`,
+			err: &DotenvParseError{Line: 2},
+		},
+		{
+			name: "Empty Line",
+			envStr: `KEY="VALUE"
+
+KEY2=VALUE2`,
+			expected: map[string]string{"KEY": "VALUE", "KEY2": "VALUE2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseEnvVars(tt.envStr)
+			// Check for error type and line number
+			if err != nil && tt.err == nil {
+				t.Errorf("parseEnvVars(%q) error = %v, want nil", tt.envStr, err)
+			}
+			if err != nil && tt.err != nil {
+				if err.Error() != tt.err.Error() {
+					t.Errorf("parseEnvVars(%q) error = %v, want %v", tt.envStr, err, tt.err)
+				}
+			}
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("parseEnvVars(%q) = %v, want %v", tt.envStr, result, tt.expected)
+			}
+		})
+	}
+}

--- a/actions/ctf-run-tests/package.json
+++ b/actions/ctf-run-tests/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ctf-run-tests",
+  "version": "0.0.0",
+  "description": "",
+  "private": true,
+  "scripts": {},
+  "author": "@smartcontractkit",
+  "license": "MIT",
+  "dependencies": {},
+  "repository": "https://github.com/smartcontractkit/.github"
+}

--- a/actions/ctf-run-tests/project.json
+++ b/actions/ctf-run-tests/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "ctf-run-tests",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "actions/ctf-run-tests",
+  "targets": {}
+}


### PR DESCRIPTION
This migrates ctf-run-tests from [smartcontractkit/chainlink-github-actions](https://github.com/smartcontractkit/chainlink-github-actions/tree/main/chainlink-testing-framework) repository to this repo. Once merged, I will proceed to update all workflows that utilize these actions and subsequently remove the actions from the original smartcontractkit/chainlink-github-actions repository.