### PR TITLE
fix: dont validate workflow references

### DIFF
--- a/.changeset/spicy-pears-yell.md
+++ b/.changeset/spicy-pears-yell.md
@@ -1,0 +1,5 @@
+---
+"gha-workflow-validator": patch
+---
+
+fix: don't treat workflow references as action references

--- a/actions/gha-workflow-validator/dist/index.js
+++ b/actions/gha-workflow-validator/dist/index.js
@@ -24116,6 +24116,12 @@ function validateVersionCommentExists(actionReference) {
   };
 }
 async function validateNodeActionVersion(octokit, actionRef) {
+  if (actionRef.isWorkflowFile) {
+    core3.debug(
+      `Skipping node version validation for ${actionRef.owner}/${actionRef.repo}/${actionRef.repoPath}`
+    );
+    return;
+  }
   const actionFile = await getActionFileFromGithub(
     octokit,
     actionRef.owner,
@@ -24145,6 +24151,9 @@ function extractActionReference(fileLine) {
   if (!actionReference) {
     return;
   }
+  if (actionReference.isWorkflowFile) {
+    core3.debug(`Found workflow file reference: ${fileLine.content}`);
+  }
   return {
     ...fileLine,
     actionReference
@@ -24173,7 +24182,8 @@ function extractActionReferenceFromLine(line) {
     repo,
     repoPath,
     ref: gitRef,
-    comment: comment.join().trim()
+    comment: comment.join().trim(),
+    isWorkflowFile: repoPath.endsWith(".yml") || repoPath.endsWith(".yaml")
   };
 }
 

--- a/actions/gha-workflow-validator/src/__tests__/action-reference-validation.test.ts
+++ b/actions/gha-workflow-validator/src/__tests__/action-reference-validation.test.ts
@@ -256,6 +256,7 @@ describe(extractActionReferenceFromLine.name, () => {
       repoPath: "/actions/foo",
       ref: "bar",
       comment: "foo@1.0.0",
+      isWorkflowFile: false,
     });
   });
 
@@ -269,6 +270,22 @@ describe(extractActionReferenceFromLine.name, () => {
       repoPath: "/actions/foo",
       ref: "bar",
       comment: "",
+      isWorkflowFile: false,
+    });
+  });
+
+  it("it parses workflow reference with isWorkflowFile=true", () => {
+    const line =
+      "        - uses: smartcontractkit/.github/.github/workflows/worfklow.yml@bar";
+    const actionReference = extractActionReferenceFromLine(line);
+
+    expect(actionReference).toEqual({
+      owner: "smartcontractkit",
+      repo: ".github",
+      repoPath: "/.github/workflows/worfklow.yml",
+      ref: "bar",
+      comment: "",
+      isWorkflowFile: true,
     });
   });
 


### PR DESCRIPTION
### Changes

- Add `isWorkflowFile` to the `ActionReference` type for conditional validations for reusable workflows, and reusable actions
- Don't validate node action version for workflow file references

Found during rollout of action - https://github.com/smartcontractkit/chainlink/actions/runs/10943604627/job/30383456630?pr=14436
```
Warning: Encountered Github Request Error while getting file - smartcontractkit/.github/.github/workflows/solidity-review-artifacts.yml/action.yml@6a46410e2f2cd9efd99fd7930977931adb9153b7
```


---

https://smartcontract-it.atlassian.net/browse/RE-2963