### PR TITLE
[TT-1624] add jira solidity review issue enforcement code

### DIFF
--- a/libs/jira-tracing/axios.ts
+++ b/libs/jira-tracing/axios.ts
@@ -18,7 +18,7 @@ interface AxiosErrorFormatError<Data = any>
     AxiosErrorFormat<Data> {}
 
 export function formatAxiosError<Data = any>(
-  origErr: AxiosError<Data>
+  origErr: AxiosError<Data>,
 ): AxiosErrorFormatError<Data> {
   const { message, name, stack, code, config, response, isAxiosError } =
     origErr;
@@ -81,7 +81,7 @@ const RESPONSE_KEYS: (keyof AxiosResponse)[] = [
 
 function formatValue(
   value: any,
-  key: (typeof CONFIG_KEYS)[number] | (typeof RESPONSE_KEYS)[number]
+  key: (typeof CONFIG_KEYS)[number] | (typeof RESPONSE_KEYS)[number],
 ): any {
   if (key !== "data") {
     return value;

--- a/libs/jira-tracing/axios.ts
+++ b/libs/jira-tracing/axios.ts
@@ -18,7 +18,7 @@ interface AxiosErrorFormatError<Data = any>
     AxiosErrorFormat<Data> {}
 
 export function formatAxiosError<Data = any>(
-  origErr: AxiosError<Data>,
+  origErr: AxiosError<Data>
 ): AxiosErrorFormatError<Data> {
   const { message, name, stack, code, config, response, isAxiosError } =
     origErr;
@@ -81,7 +81,7 @@ const RESPONSE_KEYS: (keyof AxiosResponse)[] = [
 
 function formatValue(
   value: any,
-  key: (typeof CONFIG_KEYS)[number] | (typeof RESPONSE_KEYS)[number],
+  key: (typeof CONFIG_KEYS)[number] | (typeof RESPONSE_KEYS)[number]
 ): any {
   if (key !== "data") {
     return value;

--- a/libs/jira-tracing/changeset-lib.ts
+++ b/libs/jira-tracing/changeset-lib.ts
@@ -4,22 +4,22 @@ import { getGitTopLevel } from "./lib";
 import { promises as fs } from "fs";
 
 export async function appendIssueNumberToChangesetFile(
-    prefix: string,
-    changesetFile: string,
-    issueNumber: string
-  ) {
-    const gitTopLevel = await getGitTopLevel();
-    const fullChangesetPath = join(gitTopLevel, changesetFile);
-    const changesetContents = await fs.readFile(fullChangesetPath, "utf-8");
-    // Check if the issue number is already in the changeset file
-    if (changesetContents.includes(issueNumber)) {
-      core.info("Issue number already exists in changeset file, skipping...");
-      return;
-    }
-
-    const updatedChangesetContents = `${changesetContents}\n\n${prefix}${issueNumber}`;
-    await fs.writeFile(fullChangesetPath, updatedChangesetContents);
+  prefix: string,
+  changesetFile: string,
+  issueNumber: string,
+) {
+  const gitTopLevel = await getGitTopLevel();
+  const fullChangesetPath = join(gitTopLevel, changesetFile);
+  const changesetContents = await fs.readFile(fullChangesetPath, "utf-8");
+  // Check if the issue number is already in the changeset file
+  if (changesetContents.includes(issueNumber)) {
+    core.info("Issue number already exists in changeset file, skipping...");
+    return;
   }
+
+  const updatedChangesetContents = `${changesetContents}\n\n${prefix}${issueNumber}`;
+  await fs.writeFile(fullChangesetPath, updatedChangesetContents);
+}
 
 /**
  * Extracts the list of changeset files. Intended to be used with https://github.com/dorny/paths-filter with
@@ -40,7 +40,7 @@ export function extractChangesetFiles(): string[] {
   }
 
   core.info(
-    `Changeset to extract issues from: ${parsedChangesetFiles.join(", ")}`
+    `Changeset to extract issues from: ${parsedChangesetFiles.join(", ")}`,
   );
   return parsedChangesetFiles;
 }
@@ -55,10 +55,12 @@ export function extractChangesetFiles(): string[] {
  * @throws {Error} If more than one changeset file exists.
  */
 export function extractChangesetFile(): string {
-  const changesetFiles = extractChangesetFiles()
+  const changesetFiles = extractChangesetFiles();
   if (changesetFiles.length > 1) {
-    throw new Error(`Found ${changesetFiles.length} changeset files, but only 1 was expected.`)
+    throw new Error(
+      `Found ${changesetFiles.length} changeset files, but only 1 was expected.`,
+    );
   }
 
-  return changesetFiles[0]
+  return changesetFiles[0];
 }

--- a/libs/jira-tracing/changeset-lib.ts
+++ b/libs/jira-tracing/changeset-lib.ts
@@ -1,0 +1,64 @@
+import * as core from "@actions/core";
+import { join } from "path";
+import { getGitTopLevel } from "./lib";
+import { promises as fs } from "fs";
+
+export async function appendIssueNumberToChangesetFile(
+    prefix: string,
+    changesetFile: string,
+    issueNumber: string
+  ) {
+    const gitTopLevel = await getGitTopLevel();
+    const fullChangesetPath = join(gitTopLevel, changesetFile);
+    const changesetContents = await fs.readFile(fullChangesetPath, "utf-8");
+    // Check if the issue number is already in the changeset file
+    if (changesetContents.includes(issueNumber)) {
+      core.info("Issue number already exists in changeset file, skipping...");
+      return;
+    }
+
+    const updatedChangesetContents = `${changesetContents}\n\n${prefix}${issueNumber}`;
+    await fs.writeFile(fullChangesetPath, updatedChangesetContents);
+  }
+
+/**
+ * Extracts the list of changeset files. Intended to be used with https://github.com/dorny/paths-filter with
+ * the 'csv' output format.
+ *
+ * @returns An array of strings representing the changeset files.
+ * @throws {Error} If the required environment variable CHANGESET_FILES is missing.
+ * @throws {Error} If no changeset file exists.
+ */
+export function extractChangesetFiles(): string[] {
+  const changesetFiles = process.env.CHANGESET_FILES;
+  if (!changesetFiles) {
+    throw Error("Missing required environment variable CHANGESET_FILES");
+  }
+  const parsedChangesetFiles = changesetFiles.split(",");
+  if (parsedChangesetFiles.length === 0) {
+    throw Error("At least one changeset file must exist");
+  }
+
+  core.info(
+    `Changeset to extract issues from: ${parsedChangesetFiles.join(", ")}`
+  );
+  return parsedChangesetFiles;
+}
+
+/**
+ * Extracts a single changeset file. Intended to be used with https://github.com/dorny/paths-filter with
+ * the 'csv' output format.
+ *
+ * @returns A single changeset file path.
+ * @throws {Error} If the required environment variable CHANGESET_FILES is missing.
+ * @throws {Error} If no changeset file exists.
+ * @throws {Error} If more than one changeset file exists.
+ */
+export function extractChangesetFile(): string {
+  const changesetFiles = extractChangesetFiles()
+  if (changesetFiles.length > 1) {
+    throw new Error(`Found ${changesetFiles.length} changeset files, but only 1 was expected.`)
+  }
+
+  return changesetFiles[0]
+}

--- a/libs/jira-tracing/create-jira-traceability.ts
+++ b/libs/jira-tracing/create-jira-traceability.ts
@@ -9,7 +9,7 @@ import {
   PR_PREFIX,
 } from "./lib";
 import * as core from "@actions/core";
-import { extractChangesetFiles } from './changeset-lib'
+import { extractChangesetFiles } from "./changeset-lib";
 
 /**
  * Adds traceability to JIRA issues by commenting on each issue with a link to the artifact payload
@@ -24,7 +24,7 @@ async function addTraceabillityToJiraIssues(
   client: jira.Version3Client,
   issues: string[],
   label: string,
-  artifactUrl: string
+  artifactUrl: string,
 ) {
   for (const issue of issues) {
     await checkAndAddArtifactPayloadComment(client, issue, artifactUrl);
@@ -46,7 +46,7 @@ async function addTraceabillityToJiraIssues(
 async function checkAndAddArtifactPayloadComment(
   client: jira.Version3.Version3Client,
   issue: string,
-  artifactUrl: string
+  artifactUrl: string,
 ) {
   const maxResults = 5000;
   const getCommentsResponse = await client.issueComments.getComments({
@@ -56,7 +56,7 @@ async function checkAndAddArtifactPayloadComment(
   core.debug(JSON.stringify(getCommentsResponse.comments));
   if ((getCommentsResponse.total ?? 0) > maxResults) {
     throw Error(
-      `Too many (${getCommentsResponse.total}) comments on issue ${issue}, please increase maxResults (${maxResults})`
+      `Too many (${getCommentsResponse.total}) comments on issue ${issue}, please increase maxResults (${maxResults})`,
     );
   }
 
@@ -93,9 +93,9 @@ async function checkAndAddArtifactPayloadComment(
   const commentExists = getCommentsResponse.comments?.some((c) =>
     c?.body?.content?.some((innerContent) =>
       innerContent?.content?.some((c) =>
-        c.marks?.some((m) => m.attrs?.href === artifactUrl)
-      )
-    )
+        c.marks?.some((m) => m.attrs?.href === artifactUrl),
+      ),
+    ),
   );
 
   if (commentExists) {
@@ -163,10 +163,13 @@ async function main() {
   const changesetFiles = extractChangesetFiles();
   core.info(
     `Extracting Jira issue numbers from changeset files: ${changesetFiles.join(
-      ", "
-    )}`
+      ", ",
+    )}`,
   );
-  const jiraIssueNumbers = await extractJiraIssueNumbersFrom(PR_PREFIX, changesetFiles);
+  const jiraIssueNumbers = await extractJiraIssueNumbersFrom(
+    PR_PREFIX,
+    changesetFiles,
+  );
 
   const client = createJiraClient();
   const label = generateIssueLabel(product, baseRef, headRef);
@@ -175,7 +178,7 @@ async function main() {
       client,
       jiraIssueNumbers,
       label,
-      artifactUrl
+      artifactUrl,
     );
   } catch (e) {
     handleError(e);
@@ -186,7 +189,7 @@ async function main() {
   const { jiraHost } = getJiraEnvVars();
   core.summary.addLink(
     "Jira Issues",
-    generateJiraIssuesLink(`${jiraHost}/issues/`, label)
+    generateJiraIssuesLink(`${jiraHost}/issues/`, label),
   );
   core.summary.write();
 }

--- a/libs/jira-tracing/enforce-jira-issue.ts
+++ b/libs/jira-tracing/enforce-jira-issue.ts
@@ -1,62 +1,17 @@
 import * as core from "@actions/core";
-import jira from "jira.js";
-import {
-  createJiraClient,
-  getGitTopLevel,
-  handleError,
-  parseIssueNumberFrom,
-} from "./lib";
-import { promises as fs } from "fs";
-import { join } from "path";
-
-async function doesIssueExist(
-  client: jira.Version3Client,
-  issueNumber: string,
-  dryRun: boolean,
-) {
-  const payload = {
-    issueIdOrKey: issueNumber,
-  };
-
-  if (dryRun) {
-    core.info("Dry run enabled, skipping JIRA issue enforcement");
-    return true;
-  }
-
-  try {
-    /**
-     * The issue is identified by its ID or key, however, if the identifier doesn't match an issue, a case-insensitive search and check for moved issues is performed.
-     * If a matching issue is found its details are returned, a 302 or other redirect is not returned. The issue key returned in the response is the key of the issue found.
-     */
-    const issue = await client.issues.getIssue(payload);
-    core.debug(
-      `JIRA issue id:${issue.id} key: ${issue.key} found while querying for ${issueNumber}`,
-    );
-    if (issue.key !== issueNumber) {
-      core.error(
-        `JIRA issue key ${issueNumber} not found, but found issue key ${issue.key} instead. This can happen if the identifier doesn't match an issue, in which case a case-insensitive search and check for moved issues is performed. Make sure the issue key is correct.`,
-      );
-      return false;
-    }
-
-    return true;
-  } catch (e) {
-    handleError(e);
-    return false;
-  }
-}
+import { createJiraClient, EMPTY_PREFIX, parseIssueNumberFrom, doesIssueExist, PR_PREFIX } from "./lib";
+import { appendIssueNumberToChangesetFile, extractChangesetFile } from "./changeset-lib";
 
 async function main() {
   const prTitle = process.env.PR_TITLE;
   const commitMessage = process.env.COMMIT_MESSAGE;
   const branchName = process.env.BRANCH_NAME;
   const dryRun = !!process.env.DRY_RUN;
-  const { changesetFile } = extractChangesetFile();
-
+  const changesetFile = extractChangesetFile();
   const client = createJiraClient();
 
   // Checks for the Jira issue number and exit if it can't find it
-  const issueNumber = parseIssueNumberFrom(prTitle, commitMessage, branchName);
+  const issueNumber = parseIssueNumberFrom(EMPTY_PREFIX, prTitle, commitMessage, branchName);
   if (!issueNumber) {
     const msg =
       "No JIRA issue number found in PR title, commit message, or branch name. This pull request must be associated with a JIRA issue.";
@@ -68,46 +23,13 @@ async function main() {
   const exists = await doesIssueExist(client, issueNumber, dryRun);
   if (!exists) {
     core.setFailed(
-      `JIRA issue ${issueNumber} not found, this pull request must be associated with a JIRA issue.`,
+      `JIRA issue ${issueNumber} not found, this pull request must be associated with a JIRA issue.`
     );
     return;
   }
 
   core.info(`Appending JIRA issue ${issueNumber} to changeset file`);
-  await appendIssueNumberToChangesetFile(changesetFile, issueNumber);
-}
-
-async function appendIssueNumberToChangesetFile(
-  changesetFile: string,
-  issueNumber: string,
-) {
-  const gitTopLevel = await getGitTopLevel();
-  const fullChangesetPath = join(gitTopLevel, changesetFile);
-  const changesetContents = await fs.readFile(fullChangesetPath, "utf-8");
-  // Check if the issue number is already in the changeset file
-  if (changesetContents.includes(issueNumber)) {
-    core.info("Issue number already exists in changeset file, skipping...");
-    return;
-  }
-
-  const updatedChangesetContents = `${changesetContents}\n\n${issueNumber}`;
-  await fs.writeFile(fullChangesetPath, updatedChangesetContents);
-}
-
-function extractChangesetFile() {
-  const changesetFiles = process.env.CHANGESET_FILES;
-  if (!changesetFiles) {
-    throw Error("Missing required environment variable CHANGESET_FILES");
-  }
-  const parsedChangesetFiles = JSON.parse(changesetFiles);
-  if (parsedChangesetFiles.length !== 1) {
-    throw Error(
-      "This action only supports one changeset file per pull request.",
-    );
-  }
-  const [changesetFile] = parsedChangesetFiles;
-
-  return { changesetFile };
+  await appendIssueNumberToChangesetFile(PR_PREFIX, changesetFile, issueNumber);
 }
 
 async function run() {

--- a/libs/jira-tracing/enforce-jira-issue.ts
+++ b/libs/jira-tracing/enforce-jira-issue.ts
@@ -1,6 +1,15 @@
 import * as core from "@actions/core";
-import { createJiraClient, EMPTY_PREFIX, parseIssueNumberFrom, doesIssueExist, PR_PREFIX } from "./lib";
-import { appendIssueNumberToChangesetFile, extractChangesetFile } from "./changeset-lib";
+import {
+  createJiraClient,
+  EMPTY_PREFIX,
+  parseIssueNumberFrom,
+  doesIssueExist,
+  PR_PREFIX,
+} from "./lib";
+import {
+  appendIssueNumberToChangesetFile,
+  extractChangesetFile,
+} from "./changeset-lib";
 
 async function main() {
   const prTitle = process.env.PR_TITLE;
@@ -11,7 +20,12 @@ async function main() {
   const client = createJiraClient();
 
   // Checks for the Jira issue number and exit if it can't find it
-  const issueNumber = parseIssueNumberFrom(EMPTY_PREFIX, prTitle, commitMessage, branchName);
+  const issueNumber = parseIssueNumberFrom(
+    EMPTY_PREFIX,
+    prTitle,
+    commitMessage,
+    branchName,
+  );
   if (!issueNumber) {
     const msg =
       "No JIRA issue number found in PR title, commit message, or branch name. This pull request must be associated with a JIRA issue.";
@@ -23,7 +37,7 @@ async function main() {
   const exists = await doesIssueExist(client, issueNumber, dryRun);
   if (!exists) {
     core.setFailed(
-      `JIRA issue ${issueNumber} not found, this pull request must be associated with a JIRA issue.`
+      `JIRA issue ${issueNumber} not found, this pull request must be associated with a JIRA issue.`,
     );
     return;
   }

--- a/libs/jira-tracing/enforce-jira-solidity-review.test.ts
+++ b/libs/jira-tracing/enforce-jira-solidity-review.test.ts
@@ -1,0 +1,680 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import {
+    addChecklistsToIssue, assertChecklistCount,
+    cloneIssue, cloneLinkedIssues, copyAllChecklists,
+    getChecklistJSONFromIssue,
+    getIssueKeys,
+    linkIssues,
+    transitionIssueWithComment
+} from "./enforce-jira-solidity-review";
+import * as core from "@actions/core";
+import jira from "jira.js";
+import axios from "axios";
+
+vi.mock("jira.js");
+vi.mock("@actions/core");
+vi.mock("axios");
+
+beforeAll(() => {
+    process.env.JIRA_HOST = "https://your-jira-host/";
+    process.env.JIRA_USERNAME = "your-jira-username";
+    process.env.JIRA_API_TOKEN = "your-jira-api-token";
+});
+
+describe("getIssueKeys", () => {
+    const mockClient = {
+        issueSearch: {
+            searchForIssuesUsingJql: vi.fn(),
+        },
+    };
+
+    it("should return issue keys when issues are found", async () => {
+        const mockIssues = [{ key: "ISSUE-1" }, { key: "ISSUE-2" }];
+        mockClient.issueSearch.searchForIssuesUsingJql.mockResolvedValueOnce({
+            issues: mockIssues,
+        });
+
+        const result = await getIssueKeys(
+            mockClient as unknown as jira.Version3Client,
+            "TEST",
+            "Bug",
+            "summary",
+            "Open",
+            [],
+            10
+        );
+
+        expect(result).toEqual(["ISSUE-1", "ISSUE-2"]);
+        expect(mockClient.issueSearch.searchForIssuesUsingJql).toHaveBeenCalledWith({
+            jql: 'project = TEST AND issuetype = "Bug" AND summary ~ "summary" AND status = "Open"',
+            maxResults: 10,
+            fields: ["key"],
+        });
+    });
+
+    it("should return an empty array when no issues are found", async () => {
+        mockClient.issueSearch.searchForIssuesUsingJql.mockResolvedValueOnce({
+            issues: undefined,
+        });
+
+        const result = await getIssueKeys(
+            mockClient as unknown as jira.Version3Client,
+            "TEST",
+            "Bug",
+            "summary",
+            "Open",
+            [],
+            10
+        );
+
+        expect(result).toEqual([]);
+        expect(mockClient.issueSearch.searchForIssuesUsingJql).toHaveBeenCalledWith({
+            jql: 'project = TEST AND issuetype = "Bug" AND summary ~ "summary" AND status = "Open"',
+            maxResults: 10,
+            fields: ["key"],
+        });
+    });
+
+    it("should handle JQL with issue keys to ignore", async () => {
+        const mockIssues = [{ key: "ISSUE-3" }];
+        mockClient.issueSearch.searchForIssuesUsingJql.mockResolvedValueOnce({
+            issues: mockIssues,
+        });
+
+        const result = await getIssueKeys(
+            mockClient as unknown as jira.Version3Client,
+            "TEST",
+            "Bug",
+            "summary",
+            "Open",
+            ["ISSUE-1", "ISSUE-2"],
+            10
+        );
+
+        expect(result).toEqual(["ISSUE-3"]);
+        expect(mockClient.issueSearch.searchForIssuesUsingJql).toHaveBeenCalledWith({
+            jql: 'project = TEST AND issuetype = "Bug" AND summary ~ "summary" AND status = "Open" AND issuekey NOT IN (ISSUE-1,ISSUE-2)',
+            maxResults: 10,
+            fields: ["key"],
+        });
+    });
+
+    it("should throw an error when the search fails", async () => {
+        mockClient.issueSearch.searchForIssuesUsingJql.mockRejectedValueOnce(
+            new Error("Search failed")
+        );
+
+        await expect(
+            getIssueKeys(
+                mockClient as unknown as jira.Version3Client,
+                "TEST",
+                "Bug",
+                "summary",
+                "Open",
+                [],
+                10
+            )
+        ).rejects.toThrow("Search failed");
+        expect(mockClient.issueSearch.searchForIssuesUsingJql).toHaveBeenCalledWith({
+            jql: 'project = TEST AND issuetype = "Bug" AND summary ~ "summary" AND status = "Open"',
+            maxResults: 10,
+            fields: ["key"],
+        });
+    });
+});
+
+describe("linkIssues", () => {
+    const mockClient = {
+        issueLinks: {
+            linkIssues: vi.fn(),
+        },
+    };
+
+    it("should link issues successfully", async () => {
+        mockClient.issueLinks.linkIssues.mockResolvedValueOnce(undefined);
+
+        await linkIssues(
+            mockClient as unknown as jira.Version3Client,
+            "ISSUE-1",
+            "ISSUE-2",
+            "Blocks"
+        );
+
+        expect(mockClient.issueLinks.linkIssues).toHaveBeenCalledWith({
+            type: { name: "Blocks" },
+            inwardIssue: { key: "ISSUE-1" },
+            outwardIssue: { key: "ISSUE-2" },
+        });
+        expect(core.debug).toHaveBeenCalledWith(
+            "Successfully linked issues: ISSUE-1 now 'Blocks' ISSUE-2"
+        );
+    });
+
+    it("should handle errors when linking issues", async () => {
+        const errorMessage = "Linking failed";
+        mockClient.issueLinks.linkIssues.mockRejectedValueOnce(new Error(errorMessage));
+
+        await expect(
+            linkIssues(
+                mockClient as unknown as jira.Version3Client,
+                "ISSUE-1",
+                "ISSUE-2",
+                "Blocks"
+            )
+        ).rejects.toThrow(errorMessage);
+
+        expect(mockClient.issueLinks.linkIssues).toHaveBeenCalledWith({
+            type: { name: "Blocks" },
+            inwardIssue: { key: "ISSUE-1" },
+            outwardIssue: { key: "ISSUE-2" },
+        });
+        expect(core.error).toHaveBeenCalledWith(
+            `Error linking issues ISSUE-1 and ISSUE-2: Error: ${errorMessage}`
+        );
+    });
+});
+
+describe("cloneIssue", () => {
+    const mockClient = {
+        issues: {
+            getIssue: vi.fn(),
+            createIssue: vi.fn(),
+        },
+    };
+
+    it("should clone an issue successfully", async () => {
+        const originalIssue = {
+            fields: {
+                issuetype: { id: "10001" },
+                priority: { id: "2" },
+                summary: "Original Issue Summary",
+                description: "Original Issue Description",
+            },
+        };
+        const newIssue = { key: "NEW-1" };
+
+        mockClient.issues.getIssue.mockResolvedValueOnce(originalIssue);
+        mockClient.issues.createIssue.mockResolvedValueOnce(newIssue);
+
+        const result = await cloneIssue(
+            mockClient as unknown as jira.Version3Client,
+            "ORIG-1",
+            "TEST"
+        );
+
+        expect(result).toBe("NEW-1");
+        expect(mockClient.issues.getIssue).toHaveBeenCalledWith({
+            issueIdOrKey: "ORIG-1",
+        });
+        expect(mockClient.issues.createIssue).toHaveBeenCalledWith({
+            fields: {
+                project: { key: "TEST" },
+                priority: originalIssue.fields.priority,
+                summary: originalIssue.fields.summary,
+                description: originalIssue.fields.description,
+                issuetype: { id: originalIssue.fields.issuetype.id },
+            },
+        });
+        expect(core.debug).toHaveBeenCalledWith("Cloned issue key: NEW-1");
+    });
+
+    it("should throw an error if the original issue is missing issue type id", async () => {
+        const originalIssue = {
+            fields: {
+                issuetype: undefined,
+            },
+        };
+
+        mockClient.issues.getIssue.mockResolvedValueOnce(originalIssue);
+
+        await expect(
+            cloneIssue(
+                mockClient as unknown as jira.Version3Client,
+                "ORIG-1",
+                "TEST"
+            )
+        ).rejects.toThrow("Issue ORIG-1 is missing issue type id. This should not happen.");
+
+        expect(mockClient.issues.getIssue).toHaveBeenCalledWith({
+            issueIdOrKey: "ORIG-1",
+        });
+        expect(core.error).toHaveBeenCalledWith(
+            "Error cloning issue ORIG-1: Error: Issue ORIG-1 is missing issue type id. This should not happen."
+        );
+    });
+
+    it("should handle errors during cloning", async () => {
+        const errorMessage = "Cloning failed";
+
+        mockClient.issues.getIssue.mockRejectedValueOnce(new Error(errorMessage));
+
+        await expect(
+            cloneIssue(
+                mockClient as unknown as jira.Version3Client,
+                "ORIG-1",
+                "TEST"
+            )
+        ).rejects.toThrow(errorMessage);
+
+        expect(mockClient.issues.getIssue).toHaveBeenCalledWith({
+            issueIdOrKey: "ORIG-1",
+        });
+        expect(core.error).toHaveBeenCalledWith(
+            `Error cloning issue ORIG-1: Error: ${errorMessage}`
+        );
+    });
+});
+
+describe("transitionIssueWithComment", () => {
+    const mockClient = {
+        issues: {
+            doTransition: vi.fn(),
+        },
+    };
+
+    it("should transition the issue with the given resolution and comment", async () => {
+        mockClient.issues.doTransition.mockResolvedValueOnce(undefined);
+
+        await transitionIssueWithComment(
+            mockClient as unknown as jira.Version3Client,
+            "ISSUE-1",
+            "81",
+            "Declined",
+            "Closing issue due to an error"
+        );
+
+        expect(mockClient.issues.doTransition).toHaveBeenCalledWith({
+            issueIdOrKey: "ISSUE-1",
+            transition: {
+                id: "81",
+            },
+            fields: {
+                resolution: {
+                    name: "Declined",
+                },
+            },
+            update: {
+                comment: [
+                    {
+                        add: {
+                            body: {
+                                type: "doc",
+                                version: 1,
+                                content: [
+                                    {
+                                        type: "paragraph",
+                                        content: [
+                                            {
+                                                type: "text",
+                                                text: "Closing issue due to an error",
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                ],
+            },
+        });
+        expect(core.debug).toHaveBeenCalledWith("Issue ISSUE-1 successfully closed with comment.");
+    });
+
+    it("should handle errors during the transition", async () => {
+        const errorMessage = "Transition failed";
+        mockClient.issues.doTransition.mockRejectedValueOnce(new Error(errorMessage));
+
+        await expect(
+            transitionIssueWithComment(
+                mockClient as unknown as jira.Version3Client,
+                "ISSUE-1",
+                "81",
+                "Declined",
+                "Closing issue due to an error"
+            )
+        ).rejects.toThrow(errorMessage);
+
+        expect(mockClient.issues.doTransition).toHaveBeenCalledWith({
+            issueIdOrKey: "ISSUE-1",
+            transition: {
+                id: "81",
+            },
+            fields: {
+                resolution: {
+                    name: "Declined",
+                },
+            },
+            update: {
+                comment: [
+                    {
+                        add: {
+                            body: {
+                                type: "doc",
+                                version: 1,
+                                content: [
+                                    {
+                                        type: "paragraph",
+                                        content: [
+                                            {
+                                                type: "text",
+                                                text: "Closing issue due to an error",
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                ],
+            },
+        });
+        expect(core.error).toHaveBeenCalledWith("Failed to update issue ISSUE-1: Error: Transition failed");
+    });
+});
+
+describe("getChecklistJSONFromIssue", () => {
+    const mockChecklist = {
+        value: {
+            version: "1.0.0",
+            checklists: [
+                {
+                    id: 0,
+                    name: "Example to do",
+                    items: [
+                        {
+                            name: "<p>task 1</p>",
+                            required: true,
+                            completed: true,
+                            status: 0,
+                            user: "{ user id }",
+                            date: "2019-08-13T13:18:24.046Z",
+                        },
+                        {
+                            name: "<p>task 2</p>",
+                            required: false,
+                            completed: true,
+                            status: 0,
+                            user: "{ user id }",
+                            date: "2019-08-13T13:18:44.988Z",
+                        },
+                        {
+                            name: "<p>task 3</p>",
+                            required: false,
+                            completed: false,
+                            status: 0,
+                            user: "{ user id }",
+                            date: "2019-08-08T13:30:29.643Z",
+                        },
+                    ],
+                },
+            ],
+        },
+    };
+
+    it("should fetch the checklist JSON from the issue", async () => {
+        axios.get.mockResolvedValueOnce({ data: mockChecklist });
+
+        const result = await getChecklistJSONFromIssue("ISSUE-1", "sd-checklists-0");
+
+        expect(result).toEqual(mockChecklist.value);
+        expect(axios.get).toHaveBeenCalledWith(
+            `https://your-jira-host/rest/api/3/issue/ISSUE-1/properties/sd-checklists-0`,
+            {
+                auth: {
+                    username: process.env.JIRA_USERNAME,
+                    password: process.env.JIRA_API_TOKEN,
+                },
+            }
+        );
+        expect(core.debug).toHaveBeenCalledWith("Fetching all checklists from issue ISSUE-1");
+    });
+
+    it("should handle errors when fetching the checklist JSON", async () => {
+        const errorMessage = "Checklist response had unexpected content: {\"some\":\"data\"}";
+        axios.get.mockResolvedValueOnce( { data: { some: "data" } });
+
+        await expect(getChecklistJSONFromIssue("ISSUE-1", "sd-checklists-0")).rejects.toThrow(errorMessage);
+
+        expect(axios.get).toHaveBeenCalledWith(
+            `https://your-jira-host/rest/api/3/issue/ISSUE-1/properties/sd-checklists-0`,
+            {
+                auth: {
+                    username: process.env.JIRA_USERNAME,
+                    password: process.env.JIRA_API_TOKEN,
+                },
+            }
+        );
+        expect(core.error).toHaveBeenCalledWith(`Error reading checklists from issue ISSUE-1: Error: ${errorMessage}`);
+    });
+});
+
+describe("addChecklistsToIssue", () => {
+    const issueId = "10001";
+    const checklistProperty = "sd-checklists-0";
+    const checklistsJson = {
+        version: "1.0.0",
+        checklists: [
+            {
+                id: 0,
+                name: "Example to do",
+                items: [
+                    {
+                        name: "<p>task 1</p>",
+                        required: true,
+                        completed: true,
+                        status: 0,
+                        user: "{ user id }",
+                        date: "2019-08-13T13:18:24.046Z",
+                    },
+                ],
+            },
+        ],
+    };
+
+    it("should add checklists to the issue successfully", async () => {
+        axios.put.mockResolvedValueOnce({});
+
+        await addChecklistsToIssue(issueId, checklistProperty, checklistsJson);
+
+        expect(axios.put).toHaveBeenCalledWith(
+            `https://your-jira-host/rest/api/3/issue/${issueId}/properties/${checklistProperty}`,
+            checklistsJson,
+            {
+                auth: {
+                    username: process.env.JIRA_USERNAME,
+                    password: process.env.JIRA_API_TOKEN,
+                },
+            }
+        );
+        expect(core.debug).toHaveBeenCalledWith("Added checklists successfully");
+    });
+
+    it("should handle errors when adding checklists to the issue", async () => {
+        const errorMessage = "Failed to add checklists";
+        axios.put.mockRejectedValueOnce(new Error(errorMessage));
+
+        await expect(addChecklistsToIssue(issueId, checklistProperty, checklistsJson)).rejects.toThrow(errorMessage);
+
+        expect(axios.put).toHaveBeenCalledWith(
+            `https://your-jira-host/rest/api/3/issue/${issueId}/properties/${checklistProperty}`,
+            checklistsJson,
+            {
+                auth: {
+                    username: process.env.JIRA_USERNAME,
+                    password: process.env.JIRA_API_TOKEN,
+                },
+            }
+        );
+        expect(core.error).toHaveBeenCalledWith(`Failed to add checklists to issue ${issueId}: Error: ${errorMessage}`);
+    });
+});
+
+describe("assertChecklistCount", () => {
+    it("should pass when checklist count is sufficient", () => {
+        const checklistJSON = {
+            checklists: [
+                { id: 0, name: "Checklist 1", items: [] },
+                { id: 1, name: "Checklist 2", items: [] },
+            ],
+        };
+        expect(() => assertChecklistCount(checklistJSON, 2)).not.toThrow();
+    });
+
+    it("should throw an error when checklist count is insufficient", () => {
+        const checklistJSON = {
+            checklists: [
+                { id: 0, name: "Checklist 1", items: [] },
+            ],
+        };
+        expect(() => assertChecklistCount(checklistJSON, 2)).toThrow("Checklist JSON either did not contain \"checklists\" array or it's lenght was smaller than 2");
+    });
+
+    it("should throw an error when checklists key is missing", () => {
+        const checklistJSON = {};
+        expect(() => assertChecklistCount(checklistJSON, 1)).toThrow("Checklist JSON did not contain any checklists.");
+    });
+});
+
+const mockChecklistJSON = {
+    value: {
+        version: "1.0.0",
+        checklists: [
+            {
+                id: 0,
+                name: "Example to do",
+                items: [
+                    {
+                        name: "<p>task 1</p>",
+                        required: true,
+                        completed: true,
+                        status: 0,
+                        user: "{ user id }",
+                        date: "2019-08-13T13:18:24.046Z",
+                    },
+                ],
+            },
+        ],
+    },
+};
+
+describe("copyAllChecklists", () => {
+    const sourceIssueId = "10001";
+    const targetIssueId = "10002";
+    const expectedMinChecklists = 1;
+
+
+    it("should copy all checklists successfully", async () => {
+        axios.get.mockResolvedValueOnce({ data: mockChecklistJSON });
+        axios.put.mockResolvedValueOnce({});
+
+        await copyAllChecklists(sourceIssueId, targetIssueId, expectedMinChecklists);
+
+        expect(axios.get).toHaveBeenCalledWith(
+            `https://your-jira-host/rest/api/3/issue/${sourceIssueId}/properties/sd-checklists-0`,
+            {
+                auth: {
+                    username: process.env.JIRA_USERNAME,
+                    password: process.env.JIRA_API_TOKEN,
+                },
+            }
+        );
+        expect(axios.put).toHaveBeenCalledWith(
+            `https://your-jira-host/rest/api/3/issue/${targetIssueId}/properties/sd-checklists-0`,
+            mockChecklistJSON.value,
+            {
+                auth: {
+                    username: process.env.JIRA_USERNAME,
+                    password: process.env.JIRA_API_TOKEN,
+                },
+            }
+        );
+        expect(core.debug).toHaveBeenCalledWith(`Copying all checklists from ${sourceIssueId} to ${targetIssueId}`);
+    });
+
+    it("should handle errors when copying checklists", async () => {
+        axios.get.mockRejectedValueOnce(new Error("Failed to fetch checklists"));
+
+        await expect(copyAllChecklists(sourceIssueId, targetIssueId, expectedMinChecklists)).rejects.toThrow("Failed to fetch checklists");
+
+        expect(core.error).toHaveBeenCalledWith(`Error reading checklists from issue ${sourceIssueId}: Error: Failed to fetch checklists`);
+    });
+});
+
+const mockJiraClient = {
+    issues: {
+        getIssue: vi.fn(),
+        createIssue: vi.fn(),
+    },
+    issueLinks: {
+        linkIssues: vi.fn(),
+    },
+};
+
+describe("cloneLinkedIssues", () => {
+    const projectKey = "PROJ";
+    const sourceIssueKey = "PROJ-1";
+    const targetIssueKey = "PROJ-2";
+    const issueTypes = ["Task"];
+    const expectedLinkedIssues = 1;
+    const expectedMinChecklists = 1;
+
+    it("should clone linked issues successfully", async () => {
+        const mockLinkedIssue = {
+            id: "10001",
+            key: "PROJ-3",
+            fields: {
+                issuetype: { id: "10000", name: "Task" },
+                priority: "High",
+                summary: "Linked issue summary",
+                description: "Linked issue description",
+            },
+        };
+        const mockNewLinkedIssue = {
+            key: "PROJ-4",
+        };
+
+        mockJiraClient.issues.getIssue.mockResolvedValueOnce({
+            fields: {
+                issuelinks: [
+                    {
+                        id: "10001",
+                        inwardIssue: mockLinkedIssue,
+                    },
+                ],
+            },
+        });
+        mockJiraClient.issues.getIssue.mockResolvedValueOnce(mockLinkedIssue);
+        mockJiraClient.issues.createIssue.mockResolvedValueOnce(mockNewLinkedIssue);
+        mockJiraClient.issueLinks.linkIssues.mockResolvedValueOnce(undefined);
+
+        axios.get.mockResolvedValueOnce({ data: mockChecklistJSON });
+        axios.put.mockResolvedValueOnce({});
+
+        await cloneLinkedIssues(mockJiraClient as unknown as jira.Version3Client, projectKey, sourceIssueKey, targetIssueKey, issueTypes, expectedLinkedIssues, expectedMinChecklists);
+
+        expect(mockJiraClient.issues.getIssue).toHaveBeenCalledWith({ issueIdOrKey: sourceIssueKey });
+        expect(mockJiraClient.issues.getIssue).toHaveBeenCalledWith({ issueIdOrKey: mockLinkedIssue.key });
+        expect(mockJiraClient.issues.createIssue).toHaveBeenCalledWith({
+            fields: {
+                project: { key: projectKey },
+                priority: mockLinkedIssue.fields.priority,
+                summary: mockLinkedIssue.fields.summary,
+                description: mockLinkedIssue.fields.description,
+                issuetype: { id: mockLinkedIssue.fields.issuetype.id },
+            },
+        });
+        expect(mockJiraClient.issueLinks.linkIssues).toHaveBeenCalledWith({
+            type: { name: "Blocks" },
+            inwardIssue: { key: mockNewLinkedIssue.key },
+            outwardIssue: { key: targetIssueKey },
+        });
+    });
+
+    it("should handle errors when cloning linked issues", async () => {
+        mockJiraClient.issues.getIssue.mockRejectedValueOnce(new Error("Failed to fetch issue"));
+
+        await expect(cloneLinkedIssues(mockJiraClient as unknown as jira.Version3Client, projectKey, sourceIssueKey, targetIssueKey, issueTypes, expectedLinkedIssues, expectedMinChecklists)).rejects.toThrow("Failed to fetch issue");
+
+        expect(core.error).toHaveBeenCalledWith(`Error cloning linked issues from ${sourceIssueKey} to ${targetIssueKey}:  Error: Failed to fetch issue`);
+    });
+});

--- a/libs/jira-tracing/enforce-jira-solidity-review.test.ts
+++ b/libs/jira-tracing/enforce-jira-solidity-review.test.ts
@@ -1,11 +1,14 @@
 import { describe, it, expect, vi, beforeAll } from "vitest";
 import {
-    addChecklistsToIssue, assertChecklistCount,
-    cloneIssue, cloneLinkedIssues, copyAllChecklists,
-    getChecklistJSONFromIssue,
-    getIssueKeys,
-    linkIssues,
-    transitionIssueWithComment
+  addChecklistsToIssue,
+  assertChecklistCount,
+  cloneIssue,
+  cloneLinkedIssues,
+  copyAllChecklists,
+  getChecklistJSONFromIssue,
+  getIssueKeys,
+  linkIssues,
+  transitionIssueWithComment,
 } from "./enforce-jira-solidity-review";
 import * as core from "@actions/core";
 import jira from "jira.js";
@@ -16,665 +19,734 @@ vi.mock("@actions/core");
 vi.mock("axios");
 
 beforeAll(() => {
-    process.env.JIRA_HOST = "https://your-jira-host/";
-    process.env.JIRA_USERNAME = "your-jira-username";
-    process.env.JIRA_API_TOKEN = "your-jira-api-token";
+  process.env.JIRA_HOST = "https://your-jira-host/";
+  process.env.JIRA_USERNAME = "your-jira-username";
+  process.env.JIRA_API_TOKEN = "your-jira-api-token";
 });
 
 describe("getIssueKeys", () => {
-    const mockClient = {
-        issueSearch: {
-            searchForIssuesUsingJql: vi.fn(),
-        },
-    };
+  const mockClient = {
+    issueSearch: {
+      searchForIssuesUsingJql: vi.fn(),
+    },
+  };
 
-    it("should return issue keys when issues are found", async () => {
-        const mockIssues = [{ key: "ISSUE-1" }, { key: "ISSUE-2" }];
-        mockClient.issueSearch.searchForIssuesUsingJql.mockResolvedValueOnce({
-            issues: mockIssues,
-        });
-
-        const result = await getIssueKeys(
-            mockClient as unknown as jira.Version3Client,
-            "TEST",
-            "Bug",
-            "summary",
-            "Open",
-            [],
-            10
-        );
-
-        expect(result).toEqual(["ISSUE-1", "ISSUE-2"]);
-        expect(mockClient.issueSearch.searchForIssuesUsingJql).toHaveBeenCalledWith({
-            jql: 'project = TEST AND issuetype = "Bug" AND summary ~ "summary" AND status = "Open"',
-            maxResults: 10,
-            fields: ["key"],
-        });
+  it("should return issue keys when issues are found", async () => {
+    const mockIssues = [{ key: "ISSUE-1" }, { key: "ISSUE-2" }];
+    mockClient.issueSearch.searchForIssuesUsingJql.mockResolvedValueOnce({
+      issues: mockIssues,
     });
 
-    it("should return an empty array when no issues are found", async () => {
-        mockClient.issueSearch.searchForIssuesUsingJql.mockResolvedValueOnce({
-            issues: undefined,
-        });
+    const result = await getIssueKeys(
+      mockClient as unknown as jira.Version3Client,
+      "TEST",
+      "Bug",
+      "summary",
+      "Open",
+      [],
+      10,
+    );
 
-        const result = await getIssueKeys(
-            mockClient as unknown as jira.Version3Client,
-            "TEST",
-            "Bug",
-            "summary",
-            "Open",
-            [],
-            10
-        );
+    expect(result).toEqual(["ISSUE-1", "ISSUE-2"]);
+    expect(mockClient.issueSearch.searchForIssuesUsingJql).toHaveBeenCalledWith(
+      {
+        jql: 'project = TEST AND issuetype = "Bug" AND summary ~ "summary" AND status = "Open"',
+        maxResults: 10,
+        fields: ["key"],
+      },
+    );
+  });
 
-        expect(result).toEqual([]);
-        expect(mockClient.issueSearch.searchForIssuesUsingJql).toHaveBeenCalledWith({
-            jql: 'project = TEST AND issuetype = "Bug" AND summary ~ "summary" AND status = "Open"',
-            maxResults: 10,
-            fields: ["key"],
-        });
+  it("should return an empty array when no issues are found", async () => {
+    mockClient.issueSearch.searchForIssuesUsingJql.mockResolvedValueOnce({
+      issues: undefined,
     });
 
-    it("should handle JQL with issue keys to ignore", async () => {
-        const mockIssues = [{ key: "ISSUE-3" }];
-        mockClient.issueSearch.searchForIssuesUsingJql.mockResolvedValueOnce({
-            issues: mockIssues,
-        });
+    const result = await getIssueKeys(
+      mockClient as unknown as jira.Version3Client,
+      "TEST",
+      "Bug",
+      "summary",
+      "Open",
+      [],
+      10,
+    );
 
-        const result = await getIssueKeys(
-            mockClient as unknown as jira.Version3Client,
-            "TEST",
-            "Bug",
-            "summary",
-            "Open",
-            ["ISSUE-1", "ISSUE-2"],
-            10
-        );
+    expect(result).toEqual([]);
+    expect(mockClient.issueSearch.searchForIssuesUsingJql).toHaveBeenCalledWith(
+      {
+        jql: 'project = TEST AND issuetype = "Bug" AND summary ~ "summary" AND status = "Open"',
+        maxResults: 10,
+        fields: ["key"],
+      },
+    );
+  });
 
-        expect(result).toEqual(["ISSUE-3"]);
-        expect(mockClient.issueSearch.searchForIssuesUsingJql).toHaveBeenCalledWith({
-            jql: 'project = TEST AND issuetype = "Bug" AND summary ~ "summary" AND status = "Open" AND issuekey NOT IN (ISSUE-1,ISSUE-2)',
-            maxResults: 10,
-            fields: ["key"],
-        });
+  it("should handle JQL with issue keys to ignore", async () => {
+    const mockIssues = [{ key: "ISSUE-3" }];
+    mockClient.issueSearch.searchForIssuesUsingJql.mockResolvedValueOnce({
+      issues: mockIssues,
     });
 
-    it("should throw an error when the search fails", async () => {
-        mockClient.issueSearch.searchForIssuesUsingJql.mockRejectedValueOnce(
-            new Error("Search failed")
-        );
+    const result = await getIssueKeys(
+      mockClient as unknown as jira.Version3Client,
+      "TEST",
+      "Bug",
+      "summary",
+      "Open",
+      ["ISSUE-1", "ISSUE-2"],
+      10,
+    );
 
-        await expect(
-            getIssueKeys(
-                mockClient as unknown as jira.Version3Client,
-                "TEST",
-                "Bug",
-                "summary",
-                "Open",
-                [],
-                10
-            )
-        ).rejects.toThrow("Search failed");
-        expect(mockClient.issueSearch.searchForIssuesUsingJql).toHaveBeenCalledWith({
-            jql: 'project = TEST AND issuetype = "Bug" AND summary ~ "summary" AND status = "Open"',
-            maxResults: 10,
-            fields: ["key"],
-        });
-    });
+    expect(result).toEqual(["ISSUE-3"]);
+    expect(mockClient.issueSearch.searchForIssuesUsingJql).toHaveBeenCalledWith(
+      {
+        jql: 'project = TEST AND issuetype = "Bug" AND summary ~ "summary" AND status = "Open" AND issuekey NOT IN (ISSUE-1,ISSUE-2)',
+        maxResults: 10,
+        fields: ["key"],
+      },
+    );
+  });
+
+  it("should throw an error when the search fails", async () => {
+    mockClient.issueSearch.searchForIssuesUsingJql.mockRejectedValueOnce(
+      new Error("Search failed"),
+    );
+
+    await expect(
+      getIssueKeys(
+        mockClient as unknown as jira.Version3Client,
+        "TEST",
+        "Bug",
+        "summary",
+        "Open",
+        [],
+        10,
+      ),
+    ).rejects.toThrow("Search failed");
+    expect(mockClient.issueSearch.searchForIssuesUsingJql).toHaveBeenCalledWith(
+      {
+        jql: 'project = TEST AND issuetype = "Bug" AND summary ~ "summary" AND status = "Open"',
+        maxResults: 10,
+        fields: ["key"],
+      },
+    );
+  });
 });
 
 describe("linkIssues", () => {
-    const mockClient = {
-        issueLinks: {
-            linkIssues: vi.fn(),
-        },
-    };
+  const mockClient = {
+    issueLinks: {
+      linkIssues: vi.fn(),
+    },
+  };
 
-    it("should link issues successfully", async () => {
-        mockClient.issueLinks.linkIssues.mockResolvedValueOnce(undefined);
+  it("should link issues successfully", async () => {
+    mockClient.issueLinks.linkIssues.mockResolvedValueOnce(undefined);
 
-        await linkIssues(
-            mockClient as unknown as jira.Version3Client,
-            "ISSUE-1",
-            "ISSUE-2",
-            "Blocks"
-        );
+    await linkIssues(
+      mockClient as unknown as jira.Version3Client,
+      "ISSUE-1",
+      "ISSUE-2",
+      "Blocks",
+    );
 
-        expect(mockClient.issueLinks.linkIssues).toHaveBeenCalledWith({
-            type: { name: "Blocks" },
-            inwardIssue: { key: "ISSUE-1" },
-            outwardIssue: { key: "ISSUE-2" },
-        });
-        expect(core.debug).toHaveBeenCalledWith(
-            "Successfully linked issues: ISSUE-1 now 'Blocks' ISSUE-2"
-        );
+    expect(mockClient.issueLinks.linkIssues).toHaveBeenCalledWith({
+      type: { name: "Blocks" },
+      inwardIssue: { key: "ISSUE-1" },
+      outwardIssue: { key: "ISSUE-2" },
     });
+    expect(core.debug).toHaveBeenCalledWith(
+      "Successfully linked issues: ISSUE-1 now 'Blocks' ISSUE-2",
+    );
+  });
 
-    it("should handle errors when linking issues", async () => {
-        const errorMessage = "Linking failed";
-        mockClient.issueLinks.linkIssues.mockRejectedValueOnce(new Error(errorMessage));
+  it("should handle errors when linking issues", async () => {
+    const errorMessage = "Linking failed";
+    mockClient.issueLinks.linkIssues.mockRejectedValueOnce(
+      new Error(errorMessage),
+    );
 
-        await expect(
-            linkIssues(
-                mockClient as unknown as jira.Version3Client,
-                "ISSUE-1",
-                "ISSUE-2",
-                "Blocks"
-            )
-        ).rejects.toThrow(errorMessage);
+    await expect(
+      linkIssues(
+        mockClient as unknown as jira.Version3Client,
+        "ISSUE-1",
+        "ISSUE-2",
+        "Blocks",
+      ),
+    ).rejects.toThrow(errorMessage);
 
-        expect(mockClient.issueLinks.linkIssues).toHaveBeenCalledWith({
-            type: { name: "Blocks" },
-            inwardIssue: { key: "ISSUE-1" },
-            outwardIssue: { key: "ISSUE-2" },
-        });
-        expect(core.error).toHaveBeenCalledWith(
-            `Error linking issues ISSUE-1 and ISSUE-2: Error: ${errorMessage}`
-        );
+    expect(mockClient.issueLinks.linkIssues).toHaveBeenCalledWith({
+      type: { name: "Blocks" },
+      inwardIssue: { key: "ISSUE-1" },
+      outwardIssue: { key: "ISSUE-2" },
     });
+    expect(core.error).toHaveBeenCalledWith(
+      `Error linking issues ISSUE-1 and ISSUE-2: Error: ${errorMessage}`,
+    );
+  });
 });
 
 describe("cloneIssue", () => {
-    const mockClient = {
-        issues: {
-            getIssue: vi.fn(),
-            createIssue: vi.fn(),
-        },
+  const mockClient = {
+    issues: {
+      getIssue: vi.fn(),
+      createIssue: vi.fn(),
+    },
+  };
+
+  it("should clone an issue successfully", async () => {
+    const originalIssue = {
+      fields: {
+        issuetype: { id: "10001" },
+        priority: { id: "2" },
+        summary: "Original Issue Summary",
+        description: "Original Issue Description",
+      },
+    };
+    const newIssue = { key: "NEW-1" };
+
+    mockClient.issues.getIssue.mockResolvedValueOnce(originalIssue);
+    mockClient.issues.createIssue.mockResolvedValueOnce(newIssue);
+
+    const result = await cloneIssue(
+      mockClient as unknown as jira.Version3Client,
+      "ORIG-1",
+      "TEST",
+    );
+
+    expect(result).toBe("NEW-1");
+    expect(mockClient.issues.getIssue).toHaveBeenCalledWith({
+      issueIdOrKey: "ORIG-1",
+    });
+    expect(mockClient.issues.createIssue).toHaveBeenCalledWith({
+      fields: {
+        project: { key: "TEST" },
+        priority: originalIssue.fields.priority,
+        summary: originalIssue.fields.summary,
+        description: originalIssue.fields.description,
+        issuetype: { id: originalIssue.fields.issuetype.id },
+      },
+    });
+    expect(core.debug).toHaveBeenCalledWith("Cloned issue key: NEW-1");
+  });
+
+  it("should throw an error if the original issue is missing issue type id", async () => {
+    const originalIssue = {
+      fields: {
+        issuetype: undefined,
+      },
     };
 
-    it("should clone an issue successfully", async () => {
-        const originalIssue = {
-            fields: {
-                issuetype: { id: "10001" },
-                priority: { id: "2" },
-                summary: "Original Issue Summary",
-                description: "Original Issue Description",
-            },
-        };
-        const newIssue = { key: "NEW-1" };
+    mockClient.issues.getIssue.mockResolvedValueOnce(originalIssue);
 
-        mockClient.issues.getIssue.mockResolvedValueOnce(originalIssue);
-        mockClient.issues.createIssue.mockResolvedValueOnce(newIssue);
+    await expect(
+      cloneIssue(
+        mockClient as unknown as jira.Version3Client,
+        "ORIG-1",
+        "TEST",
+      ),
+    ).rejects.toThrow(
+      "Issue ORIG-1 is missing issue type id. This should not happen.",
+    );
 
-        const result = await cloneIssue(
-            mockClient as unknown as jira.Version3Client,
-            "ORIG-1",
-            "TEST"
-        );
-
-        expect(result).toBe("NEW-1");
-        expect(mockClient.issues.getIssue).toHaveBeenCalledWith({
-            issueIdOrKey: "ORIG-1",
-        });
-        expect(mockClient.issues.createIssue).toHaveBeenCalledWith({
-            fields: {
-                project: { key: "TEST" },
-                priority: originalIssue.fields.priority,
-                summary: originalIssue.fields.summary,
-                description: originalIssue.fields.description,
-                issuetype: { id: originalIssue.fields.issuetype.id },
-            },
-        });
-        expect(core.debug).toHaveBeenCalledWith("Cloned issue key: NEW-1");
+    expect(mockClient.issues.getIssue).toHaveBeenCalledWith({
+      issueIdOrKey: "ORIG-1",
     });
+    expect(core.error).toHaveBeenCalledWith(
+      "Error cloning issue ORIG-1: Error: Issue ORIG-1 is missing issue type id. This should not happen.",
+    );
+  });
 
-    it("should throw an error if the original issue is missing issue type id", async () => {
-        const originalIssue = {
-            fields: {
-                issuetype: undefined,
-            },
-        };
+  it("should handle errors during cloning", async () => {
+    const errorMessage = "Cloning failed";
 
-        mockClient.issues.getIssue.mockResolvedValueOnce(originalIssue);
+    mockClient.issues.getIssue.mockRejectedValueOnce(new Error(errorMessage));
 
-        await expect(
-            cloneIssue(
-                mockClient as unknown as jira.Version3Client,
-                "ORIG-1",
-                "TEST"
-            )
-        ).rejects.toThrow("Issue ORIG-1 is missing issue type id. This should not happen.");
+    await expect(
+      cloneIssue(
+        mockClient as unknown as jira.Version3Client,
+        "ORIG-1",
+        "TEST",
+      ),
+    ).rejects.toThrow(errorMessage);
 
-        expect(mockClient.issues.getIssue).toHaveBeenCalledWith({
-            issueIdOrKey: "ORIG-1",
-        });
-        expect(core.error).toHaveBeenCalledWith(
-            "Error cloning issue ORIG-1: Error: Issue ORIG-1 is missing issue type id. This should not happen."
-        );
+    expect(mockClient.issues.getIssue).toHaveBeenCalledWith({
+      issueIdOrKey: "ORIG-1",
     });
-
-    it("should handle errors during cloning", async () => {
-        const errorMessage = "Cloning failed";
-
-        mockClient.issues.getIssue.mockRejectedValueOnce(new Error(errorMessage));
-
-        await expect(
-            cloneIssue(
-                mockClient as unknown as jira.Version3Client,
-                "ORIG-1",
-                "TEST"
-            )
-        ).rejects.toThrow(errorMessage);
-
-        expect(mockClient.issues.getIssue).toHaveBeenCalledWith({
-            issueIdOrKey: "ORIG-1",
-        });
-        expect(core.error).toHaveBeenCalledWith(
-            `Error cloning issue ORIG-1: Error: ${errorMessage}`
-        );
-    });
+    expect(core.error).toHaveBeenCalledWith(
+      `Error cloning issue ORIG-1: Error: ${errorMessage}`,
+    );
+  });
 });
 
 describe("transitionIssueWithComment", () => {
-    const mockClient = {
-        issues: {
-            doTransition: vi.fn(),
+  const mockClient = {
+    issues: {
+      doTransition: vi.fn(),
+    },
+  };
+
+  it("should transition the issue with the given resolution and comment", async () => {
+    mockClient.issues.doTransition.mockResolvedValueOnce(undefined);
+
+    await transitionIssueWithComment(
+      mockClient as unknown as jira.Version3Client,
+      "ISSUE-1",
+      "81",
+      "Declined",
+      "Closing issue due to an error",
+    );
+
+    expect(mockClient.issues.doTransition).toHaveBeenCalledWith({
+      issueIdOrKey: "ISSUE-1",
+      transition: {
+        id: "81",
+      },
+      fields: {
+        resolution: {
+          name: "Declined",
         },
-    };
-
-    it("should transition the issue with the given resolution and comment", async () => {
-        mockClient.issues.doTransition.mockResolvedValueOnce(undefined);
-
-        await transitionIssueWithComment(
-            mockClient as unknown as jira.Version3Client,
-            "ISSUE-1",
-            "81",
-            "Declined",
-            "Closing issue due to an error"
-        );
-
-        expect(mockClient.issues.doTransition).toHaveBeenCalledWith({
-            issueIdOrKey: "ISSUE-1",
-            transition: {
-                id: "81",
-            },
-            fields: {
-                resolution: {
-                    name: "Declined",
-                },
-            },
-            update: {
-                comment: [
-                    {
-                        add: {
-                            body: {
-                                type: "doc",
-                                version: 1,
-                                content: [
-                                    {
-                                        type: "paragraph",
-                                        content: [
-                                            {
-                                                type: "text",
-                                                text: "Closing issue due to an error",
-                                            },
-                                        ],
-                                    },
-                                ],
-                            },
-                        },
-                    },
+      },
+      update: {
+        comment: [
+          {
+            add: {
+              body: {
+                type: "doc",
+                version: 1,
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [
+                      {
+                        type: "text",
+                        text: "Closing issue due to an error",
+                      },
+                    ],
+                  },
                 ],
+              },
             },
-        });
-        expect(core.debug).toHaveBeenCalledWith("Issue ISSUE-1 successfully closed with comment.");
+          },
+        ],
+      },
     });
+    expect(core.debug).toHaveBeenCalledWith(
+      "Issue ISSUE-1 successfully closed with comment.",
+    );
+  });
 
-    it("should handle errors during the transition", async () => {
-        const errorMessage = "Transition failed";
-        mockClient.issues.doTransition.mockRejectedValueOnce(new Error(errorMessage));
+  it("should handle errors during the transition", async () => {
+    const errorMessage = "Transition failed";
+    mockClient.issues.doTransition.mockRejectedValueOnce(
+      new Error(errorMessage),
+    );
 
-        await expect(
-            transitionIssueWithComment(
-                mockClient as unknown as jira.Version3Client,
-                "ISSUE-1",
-                "81",
-                "Declined",
-                "Closing issue due to an error"
-            )
-        ).rejects.toThrow(errorMessage);
+    await expect(
+      transitionIssueWithComment(
+        mockClient as unknown as jira.Version3Client,
+        "ISSUE-1",
+        "81",
+        "Declined",
+        "Closing issue due to an error",
+      ),
+    ).rejects.toThrow(errorMessage);
 
-        expect(mockClient.issues.doTransition).toHaveBeenCalledWith({
-            issueIdOrKey: "ISSUE-1",
-            transition: {
-                id: "81",
-            },
-            fields: {
-                resolution: {
-                    name: "Declined",
-                },
-            },
-            update: {
-                comment: [
-                    {
-                        add: {
-                            body: {
-                                type: "doc",
-                                version: 1,
-                                content: [
-                                    {
-                                        type: "paragraph",
-                                        content: [
-                                            {
-                                                type: "text",
-                                                text: "Closing issue due to an error",
-                                            },
-                                        ],
-                                    },
-                                ],
-                            },
-                        },
-                    },
+    expect(mockClient.issues.doTransition).toHaveBeenCalledWith({
+      issueIdOrKey: "ISSUE-1",
+      transition: {
+        id: "81",
+      },
+      fields: {
+        resolution: {
+          name: "Declined",
+        },
+      },
+      update: {
+        comment: [
+          {
+            add: {
+              body: {
+                type: "doc",
+                version: 1,
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [
+                      {
+                        type: "text",
+                        text: "Closing issue due to an error",
+                      },
+                    ],
+                  },
                 ],
+              },
             },
-        });
-        expect(core.error).toHaveBeenCalledWith("Failed to update issue ISSUE-1: Error: Transition failed");
+          },
+        ],
+      },
     });
+    expect(core.error).toHaveBeenCalledWith(
+      "Failed to update issue ISSUE-1: Error: Transition failed",
+    );
+  });
 });
 
 describe("getChecklistJSONFromIssue", () => {
-    const mockChecklist = {
-        value: {
-            version: "1.0.0",
-            checklists: [
-                {
-                    id: 0,
-                    name: "Example to do",
-                    items: [
-                        {
-                            name: "<p>task 1</p>",
-                            required: true,
-                            completed: true,
-                            status: 0,
-                            user: "{ user id }",
-                            date: "2019-08-13T13:18:24.046Z",
-                        },
-                        {
-                            name: "<p>task 2</p>",
-                            required: false,
-                            completed: true,
-                            status: 0,
-                            user: "{ user id }",
-                            date: "2019-08-13T13:18:44.988Z",
-                        },
-                        {
-                            name: "<p>task 3</p>",
-                            required: false,
-                            completed: false,
-                            status: 0,
-                            user: "{ user id }",
-                            date: "2019-08-08T13:30:29.643Z",
-                        },
-                    ],
-                },
-            ],
+  const mockChecklist = {
+    value: {
+      version: "1.0.0",
+      checklists: [
+        {
+          id: 0,
+          name: "Example to do",
+          items: [
+            {
+              name: "<p>task 1</p>",
+              required: true,
+              completed: true,
+              status: 0,
+              user: "{ user id }",
+              date: "2019-08-13T13:18:24.046Z",
+            },
+            {
+              name: "<p>task 2</p>",
+              required: false,
+              completed: true,
+              status: 0,
+              user: "{ user id }",
+              date: "2019-08-13T13:18:44.988Z",
+            },
+            {
+              name: "<p>task 3</p>",
+              required: false,
+              completed: false,
+              status: 0,
+              user: "{ user id }",
+              date: "2019-08-08T13:30:29.643Z",
+            },
+          ],
         },
-    };
+      ],
+    },
+  };
 
-    it("should fetch the checklist JSON from the issue", async () => {
-        axios.get.mockResolvedValueOnce({ data: mockChecklist });
+  it("should fetch the checklist JSON from the issue", async () => {
+    axios.get.mockResolvedValueOnce({ data: mockChecklist });
 
-        const result = await getChecklistJSONFromIssue("ISSUE-1", "sd-checklists-0");
+    const result = await getChecklistJSONFromIssue(
+      "ISSUE-1",
+      "sd-checklists-0",
+    );
 
-        expect(result).toEqual(mockChecklist.value);
-        expect(axios.get).toHaveBeenCalledWith(
-            `https://your-jira-host/rest/api/3/issue/ISSUE-1/properties/sd-checklists-0`,
-            {
-                auth: {
-                    username: process.env.JIRA_USERNAME,
-                    password: process.env.JIRA_API_TOKEN,
-                },
-            }
-        );
-        expect(core.debug).toHaveBeenCalledWith("Fetching all checklists from issue ISSUE-1");
-    });
+    expect(result).toEqual(mockChecklist.value);
+    expect(axios.get).toHaveBeenCalledWith(
+      `https://your-jira-host/rest/api/3/issue/ISSUE-1/properties/sd-checklists-0`,
+      {
+        auth: {
+          username: process.env.JIRA_USERNAME,
+          password: process.env.JIRA_API_TOKEN,
+        },
+      },
+    );
+    expect(core.debug).toHaveBeenCalledWith(
+      "Fetching all checklists from issue ISSUE-1",
+    );
+  });
 
-    it("should handle errors when fetching the checklist JSON", async () => {
-        const errorMessage = "Checklist response had unexpected content: {\"some\":\"data\"}";
-        axios.get.mockResolvedValueOnce( { data: { some: "data" } });
+  it("should handle errors when fetching the checklist JSON", async () => {
+    const errorMessage =
+      'Checklist response had unexpected content: {"some":"data"}';
+    axios.get.mockResolvedValueOnce({ data: { some: "data" } });
 
-        await expect(getChecklistJSONFromIssue("ISSUE-1", "sd-checklists-0")).rejects.toThrow(errorMessage);
+    await expect(
+      getChecklistJSONFromIssue("ISSUE-1", "sd-checklists-0"),
+    ).rejects.toThrow(errorMessage);
 
-        expect(axios.get).toHaveBeenCalledWith(
-            `https://your-jira-host/rest/api/3/issue/ISSUE-1/properties/sd-checklists-0`,
-            {
-                auth: {
-                    username: process.env.JIRA_USERNAME,
-                    password: process.env.JIRA_API_TOKEN,
-                },
-            }
-        );
-        expect(core.error).toHaveBeenCalledWith(`Error reading checklists from issue ISSUE-1: Error: ${errorMessage}`);
-    });
+    expect(axios.get).toHaveBeenCalledWith(
+      `https://your-jira-host/rest/api/3/issue/ISSUE-1/properties/sd-checklists-0`,
+      {
+        auth: {
+          username: process.env.JIRA_USERNAME,
+          password: process.env.JIRA_API_TOKEN,
+        },
+      },
+    );
+    expect(core.error).toHaveBeenCalledWith(
+      `Error reading checklists from issue ISSUE-1: Error: ${errorMessage}`,
+    );
+  });
 });
 
 describe("addChecklistsToIssue", () => {
-    const issueId = "10001";
-    const checklistProperty = "sd-checklists-0";
-    const checklistsJson = {
-        version: "1.0.0",
-        checklists: [
-            {
-                id: 0,
-                name: "Example to do",
-                items: [
-                    {
-                        name: "<p>task 1</p>",
-                        required: true,
-                        completed: true,
-                        status: 0,
-                        user: "{ user id }",
-                        date: "2019-08-13T13:18:24.046Z",
-                    },
-                ],
-            },
+  const issueId = "10001";
+  const checklistProperty = "sd-checklists-0";
+  const checklistsJson = {
+    version: "1.0.0",
+    checklists: [
+      {
+        id: 0,
+        name: "Example to do",
+        items: [
+          {
+            name: "<p>task 1</p>",
+            required: true,
+            completed: true,
+            status: 0,
+            user: "{ user id }",
+            date: "2019-08-13T13:18:24.046Z",
+          },
         ],
-    };
+      },
+    ],
+  };
 
-    it("should add checklists to the issue successfully", async () => {
-        axios.put.mockResolvedValueOnce({});
+  it("should add checklists to the issue successfully", async () => {
+    axios.put.mockResolvedValueOnce({});
 
-        await addChecklistsToIssue(issueId, checklistProperty, checklistsJson);
+    await addChecklistsToIssue(issueId, checklistProperty, checklistsJson);
 
-        expect(axios.put).toHaveBeenCalledWith(
-            `https://your-jira-host/rest/api/3/issue/${issueId}/properties/${checklistProperty}`,
-            checklistsJson,
-            {
-                auth: {
-                    username: process.env.JIRA_USERNAME,
-                    password: process.env.JIRA_API_TOKEN,
-                },
-            }
-        );
-        expect(core.debug).toHaveBeenCalledWith("Added checklists successfully");
-    });
+    expect(axios.put).toHaveBeenCalledWith(
+      `https://your-jira-host/rest/api/3/issue/${issueId}/properties/${checklistProperty}`,
+      checklistsJson,
+      {
+        auth: {
+          username: process.env.JIRA_USERNAME,
+          password: process.env.JIRA_API_TOKEN,
+        },
+      },
+    );
+    expect(core.debug).toHaveBeenCalledWith("Added checklists successfully");
+  });
 
-    it("should handle errors when adding checklists to the issue", async () => {
-        const errorMessage = "Failed to add checklists";
-        axios.put.mockRejectedValueOnce(new Error(errorMessage));
+  it("should handle errors when adding checklists to the issue", async () => {
+    const errorMessage = "Failed to add checklists";
+    axios.put.mockRejectedValueOnce(new Error(errorMessage));
 
-        await expect(addChecklistsToIssue(issueId, checklistProperty, checklistsJson)).rejects.toThrow(errorMessage);
+    await expect(
+      addChecklistsToIssue(issueId, checklistProperty, checklistsJson),
+    ).rejects.toThrow(errorMessage);
 
-        expect(axios.put).toHaveBeenCalledWith(
-            `https://your-jira-host/rest/api/3/issue/${issueId}/properties/${checklistProperty}`,
-            checklistsJson,
-            {
-                auth: {
-                    username: process.env.JIRA_USERNAME,
-                    password: process.env.JIRA_API_TOKEN,
-                },
-            }
-        );
-        expect(core.error).toHaveBeenCalledWith(`Failed to add checklists to issue ${issueId}: Error: ${errorMessage}`);
-    });
+    expect(axios.put).toHaveBeenCalledWith(
+      `https://your-jira-host/rest/api/3/issue/${issueId}/properties/${checklistProperty}`,
+      checklistsJson,
+      {
+        auth: {
+          username: process.env.JIRA_USERNAME,
+          password: process.env.JIRA_API_TOKEN,
+        },
+      },
+    );
+    expect(core.error).toHaveBeenCalledWith(
+      `Failed to add checklists to issue ${issueId}: Error: ${errorMessage}`,
+    );
+  });
 });
 
 describe("assertChecklistCount", () => {
-    it("should pass when checklist count is sufficient", () => {
-        const checklistJSON = {
-            checklists: [
-                { id: 0, name: "Checklist 1", items: [] },
-                { id: 1, name: "Checklist 2", items: [] },
-            ],
-        };
-        expect(() => assertChecklistCount(checklistJSON, 2)).not.toThrow();
-    });
+  it("should pass when checklist count is sufficient", () => {
+    const checklistJSON = {
+      checklists: [
+        { id: 0, name: "Checklist 1", items: [] },
+        { id: 1, name: "Checklist 2", items: [] },
+      ],
+    };
+    expect(() => assertChecklistCount(checklistJSON, 2)).not.toThrow();
+  });
 
-    it("should throw an error when checklist count is insufficient", () => {
-        const checklistJSON = {
-            checklists: [
-                { id: 0, name: "Checklist 1", items: [] },
-            ],
-        };
-        expect(() => assertChecklistCount(checklistJSON, 2)).toThrow("Checklist JSON either did not contain \"checklists\" array or it's lenght was smaller than 2");
-    });
+  it("should throw an error when checklist count is insufficient", () => {
+    const checklistJSON = {
+      checklists: [{ id: 0, name: "Checklist 1", items: [] }],
+    };
+    expect(() => assertChecklistCount(checklistJSON, 2)).toThrow(
+      'Checklist JSON either did not contain "checklists" array or it\'s lenght was smaller than 2',
+    );
+  });
 
-    it("should throw an error when checklists key is missing", () => {
-        const checklistJSON = {};
-        expect(() => assertChecklistCount(checklistJSON, 1)).toThrow("Checklist JSON did not contain any checklists.");
-    });
+  it("should throw an error when checklists key is missing", () => {
+    const checklistJSON = {};
+    expect(() => assertChecklistCount(checklistJSON, 1)).toThrow(
+      "Checklist JSON did not contain any checklists.",
+    );
+  });
 });
 
 const mockChecklistJSON = {
-    value: {
-        version: "1.0.0",
-        checklists: [
-            {
-                id: 0,
-                name: "Example to do",
-                items: [
-                    {
-                        name: "<p>task 1</p>",
-                        required: true,
-                        completed: true,
-                        status: 0,
-                        user: "{ user id }",
-                        date: "2019-08-13T13:18:24.046Z",
-                    },
-                ],
-            },
+  value: {
+    version: "1.0.0",
+    checklists: [
+      {
+        id: 0,
+        name: "Example to do",
+        items: [
+          {
+            name: "<p>task 1</p>",
+            required: true,
+            completed: true,
+            status: 0,
+            user: "{ user id }",
+            date: "2019-08-13T13:18:24.046Z",
+          },
         ],
-    },
+      },
+    ],
+  },
 };
 
 describe("copyAllChecklists", () => {
-    const sourceIssueId = "10001";
-    const targetIssueId = "10002";
-    const expectedMinChecklists = 1;
+  const sourceIssueId = "10001";
+  const targetIssueId = "10002";
+  const expectedMinChecklists = 1;
 
+  it("should copy all checklists successfully", async () => {
+    axios.get.mockResolvedValueOnce({ data: mockChecklistJSON });
+    axios.put.mockResolvedValueOnce({});
 
-    it("should copy all checklists successfully", async () => {
-        axios.get.mockResolvedValueOnce({ data: mockChecklistJSON });
-        axios.put.mockResolvedValueOnce({});
+    await copyAllChecklists(
+      sourceIssueId,
+      targetIssueId,
+      expectedMinChecklists,
+    );
 
-        await copyAllChecklists(sourceIssueId, targetIssueId, expectedMinChecklists);
+    expect(axios.get).toHaveBeenCalledWith(
+      `https://your-jira-host/rest/api/3/issue/${sourceIssueId}/properties/sd-checklists-0`,
+      {
+        auth: {
+          username: process.env.JIRA_USERNAME,
+          password: process.env.JIRA_API_TOKEN,
+        },
+      },
+    );
+    expect(axios.put).toHaveBeenCalledWith(
+      `https://your-jira-host/rest/api/3/issue/${targetIssueId}/properties/sd-checklists-0`,
+      mockChecklistJSON.value,
+      {
+        auth: {
+          username: process.env.JIRA_USERNAME,
+          password: process.env.JIRA_API_TOKEN,
+        },
+      },
+    );
+    expect(core.debug).toHaveBeenCalledWith(
+      `Copying all checklists from ${sourceIssueId} to ${targetIssueId}`,
+    );
+  });
 
-        expect(axios.get).toHaveBeenCalledWith(
-            `https://your-jira-host/rest/api/3/issue/${sourceIssueId}/properties/sd-checklists-0`,
-            {
-                auth: {
-                    username: process.env.JIRA_USERNAME,
-                    password: process.env.JIRA_API_TOKEN,
-                },
-            }
-        );
-        expect(axios.put).toHaveBeenCalledWith(
-            `https://your-jira-host/rest/api/3/issue/${targetIssueId}/properties/sd-checklists-0`,
-            mockChecklistJSON.value,
-            {
-                auth: {
-                    username: process.env.JIRA_USERNAME,
-                    password: process.env.JIRA_API_TOKEN,
-                },
-            }
-        );
-        expect(core.debug).toHaveBeenCalledWith(`Copying all checklists from ${sourceIssueId} to ${targetIssueId}`);
-    });
+  it("should handle errors when copying checklists", async () => {
+    axios.get.mockRejectedValueOnce(new Error("Failed to fetch checklists"));
 
-    it("should handle errors when copying checklists", async () => {
-        axios.get.mockRejectedValueOnce(new Error("Failed to fetch checklists"));
+    await expect(
+      copyAllChecklists(sourceIssueId, targetIssueId, expectedMinChecklists),
+    ).rejects.toThrow("Failed to fetch checklists");
 
-        await expect(copyAllChecklists(sourceIssueId, targetIssueId, expectedMinChecklists)).rejects.toThrow("Failed to fetch checklists");
-
-        expect(core.error).toHaveBeenCalledWith(`Error reading checklists from issue ${sourceIssueId}: Error: Failed to fetch checklists`);
-    });
+    expect(core.error).toHaveBeenCalledWith(
+      `Error reading checklists from issue ${sourceIssueId}: Error: Failed to fetch checklists`,
+    );
+  });
 });
 
 const mockJiraClient = {
-    issues: {
-        getIssue: vi.fn(),
-        createIssue: vi.fn(),
-    },
-    issueLinks: {
-        linkIssues: vi.fn(),
-    },
+  issues: {
+    getIssue: vi.fn(),
+    createIssue: vi.fn(),
+  },
+  issueLinks: {
+    linkIssues: vi.fn(),
+  },
 };
 
 describe("cloneLinkedIssues", () => {
-    const projectKey = "PROJ";
-    const sourceIssueKey = "PROJ-1";
-    const targetIssueKey = "PROJ-2";
-    const issueTypes = ["Task"];
-    const expectedLinkedIssues = 1;
-    const expectedMinChecklists = 1;
+  const projectKey = "PROJ";
+  const sourceIssueKey = "PROJ-1";
+  const targetIssueKey = "PROJ-2";
+  const issueTypes = ["Task"];
+  const expectedLinkedIssues = 1;
+  const expectedMinChecklists = 1;
 
-    it("should clone linked issues successfully", async () => {
-        const mockLinkedIssue = {
+  it("should clone linked issues successfully", async () => {
+    const mockLinkedIssue = {
+      id: "10001",
+      key: "PROJ-3",
+      fields: {
+        issuetype: { id: "10000", name: "Task" },
+        priority: "High",
+        summary: "Linked issue summary",
+        description: "Linked issue description",
+      },
+    };
+    const mockNewLinkedIssue = {
+      key: "PROJ-4",
+    };
+
+    mockJiraClient.issues.getIssue.mockResolvedValueOnce({
+      fields: {
+        issuelinks: [
+          {
             id: "10001",
-            key: "PROJ-3",
-            fields: {
-                issuetype: { id: "10000", name: "Task" },
-                priority: "High",
-                summary: "Linked issue summary",
-                description: "Linked issue description",
-            },
-        };
-        const mockNewLinkedIssue = {
-            key: "PROJ-4",
-        };
-
-        mockJiraClient.issues.getIssue.mockResolvedValueOnce({
-            fields: {
-                issuelinks: [
-                    {
-                        id: "10001",
-                        inwardIssue: mockLinkedIssue,
-                    },
-                ],
-            },
-        });
-        mockJiraClient.issues.getIssue.mockResolvedValueOnce(mockLinkedIssue);
-        mockJiraClient.issues.createIssue.mockResolvedValueOnce(mockNewLinkedIssue);
-        mockJiraClient.issueLinks.linkIssues.mockResolvedValueOnce(undefined);
-
-        axios.get.mockResolvedValueOnce({ data: mockChecklistJSON });
-        axios.put.mockResolvedValueOnce({});
-
-        await cloneLinkedIssues(mockJiraClient as unknown as jira.Version3Client, projectKey, sourceIssueKey, targetIssueKey, issueTypes, expectedLinkedIssues, expectedMinChecklists);
-
-        expect(mockJiraClient.issues.getIssue).toHaveBeenCalledWith({ issueIdOrKey: sourceIssueKey });
-        expect(mockJiraClient.issues.getIssue).toHaveBeenCalledWith({ issueIdOrKey: mockLinkedIssue.key });
-        expect(mockJiraClient.issues.createIssue).toHaveBeenCalledWith({
-            fields: {
-                project: { key: projectKey },
-                priority: mockLinkedIssue.fields.priority,
-                summary: mockLinkedIssue.fields.summary,
-                description: mockLinkedIssue.fields.description,
-                issuetype: { id: mockLinkedIssue.fields.issuetype.id },
-            },
-        });
-        expect(mockJiraClient.issueLinks.linkIssues).toHaveBeenCalledWith({
-            type: { name: "Blocks" },
-            inwardIssue: { key: mockNewLinkedIssue.key },
-            outwardIssue: { key: targetIssueKey },
-        });
+            inwardIssue: mockLinkedIssue,
+          },
+        ],
+      },
     });
+    mockJiraClient.issues.getIssue.mockResolvedValueOnce(mockLinkedIssue);
+    mockJiraClient.issues.createIssue.mockResolvedValueOnce(mockNewLinkedIssue);
+    mockJiraClient.issueLinks.linkIssues.mockResolvedValueOnce(undefined);
 
-    it("should handle errors when cloning linked issues", async () => {
-        mockJiraClient.issues.getIssue.mockRejectedValueOnce(new Error("Failed to fetch issue"));
+    axios.get.mockResolvedValueOnce({ data: mockChecklistJSON });
+    axios.put.mockResolvedValueOnce({});
 
-        await expect(cloneLinkedIssues(mockJiraClient as unknown as jira.Version3Client, projectKey, sourceIssueKey, targetIssueKey, issueTypes, expectedLinkedIssues, expectedMinChecklists)).rejects.toThrow("Failed to fetch issue");
+    await cloneLinkedIssues(
+      mockJiraClient as unknown as jira.Version3Client,
+      projectKey,
+      sourceIssueKey,
+      targetIssueKey,
+      issueTypes,
+      expectedLinkedIssues,
+      expectedMinChecklists,
+    );
 
-        expect(core.error).toHaveBeenCalledWith(`Error cloning linked issues from ${sourceIssueKey} to ${targetIssueKey}:  Error: Failed to fetch issue`);
+    expect(mockJiraClient.issues.getIssue).toHaveBeenCalledWith({
+      issueIdOrKey: sourceIssueKey,
     });
+    expect(mockJiraClient.issues.getIssue).toHaveBeenCalledWith({
+      issueIdOrKey: mockLinkedIssue.key,
+    });
+    expect(mockJiraClient.issues.createIssue).toHaveBeenCalledWith({
+      fields: {
+        project: { key: projectKey },
+        priority: mockLinkedIssue.fields.priority,
+        summary: mockLinkedIssue.fields.summary,
+        description: mockLinkedIssue.fields.description,
+        issuetype: { id: mockLinkedIssue.fields.issuetype.id },
+      },
+    });
+    expect(mockJiraClient.issueLinks.linkIssues).toHaveBeenCalledWith({
+      type: { name: "Blocks" },
+      inwardIssue: { key: mockNewLinkedIssue.key },
+      outwardIssue: { key: targetIssueKey },
+    });
+  });
+
+  it("should handle errors when cloning linked issues", async () => {
+    mockJiraClient.issues.getIssue.mockRejectedValueOnce(
+      new Error("Failed to fetch issue"),
+    );
+
+    await expect(
+      cloneLinkedIssues(
+        mockJiraClient as unknown as jira.Version3Client,
+        projectKey,
+        sourceIssueKey,
+        targetIssueKey,
+        issueTypes,
+        expectedLinkedIssues,
+        expectedMinChecklists,
+      ),
+    ).rejects.toThrow("Failed to fetch issue");
+
+    expect(core.error).toHaveBeenCalledWith(
+      `Error cloning linked issues from ${sourceIssueKey} to ${targetIssueKey}:  Error: Failed to fetch issue`,
+    );
+  });
 });

--- a/libs/jira-tracing/enforce-jira-solidity-review.ts
+++ b/libs/jira-tracing/enforce-jira-solidity-review.ts
@@ -1,0 +1,644 @@
+import * as core from "@actions/core";
+import jira from "jira.js";
+import axios from "axios";
+import { join } from "path";
+import { createJiraClient, extractJiraIssueNumbersFrom, getJiraEnvVars, doesIssueExist, PR_PREFIX, SOLIDITY_REVIEW_PREFIX } from "./lib";
+import { appendIssueNumberToChangesetFile, extractChangesetFile } from "./changeset-lib";
+import fs from "fs";
+
+async function main() {
+    core.info('Started linking PR to a Solidity Review issue')
+    const solidityReviewTemplateKey = readSolidityReviewTemplateKey()
+    const changesetFile = extractChangesetFile();
+
+    const jiraPRIssueKeys = await extractJiraIssueNumbersFrom(PR_PREFIX, [changesetFile])
+    if (jiraPRIssueKeys.length !== 1) {
+        core.setFailed(
+            `Solidity Review enforcement only works with 1 JIRA issue per PR, but found ${jiraPRIssueKeys.length} issues in changeset file ${changesetFile}`
+          );
+
+          return
+    }
+
+    const jiraPRIssueKey = jiraPRIssueKeys[0]
+    const client = createJiraClient();
+
+    const jiraSolidityIssues = await extractJiraIssueNumbersFrom(SOLIDITY_REVIEW_PREFIX, [changesetFile])
+    if (jiraSolidityIssues.length > 0) {
+        for (const jiraIssue of jiraSolidityIssues) {
+          const exists = await doesIssueExist(client, jiraIssue, false);
+          if (!exists) {
+            core.setFailed(
+              `JIRA issue ${jiraIssue} not found, Solidity Review issue must exist in JIRA.`
+            );
+
+            return;
+          }
+        }
+
+        core.info(`Found linked Solidity Review issue(s): ${join(...jiraSolidityIssues)}. Nothing more needs to be done.`)
+
+        return
+    }
+
+    const jiraProject = extracProjectFromIssueKey(jiraPRIssueKey)
+    if (!jiraProject) {
+        core.setFailed(`Could not extract project key from issue: ${jiraPRIssueKey}`)
+
+        return
+    }
+
+    core.info(`Checking if project ${jiraProject} has any open Solidity Review issues`)
+    let solidityReviewIssueKey: string
+    const openSolidityReviewIssues = await getOpenSolidityReviewIssuesForProject(client, jiraProject, [solidityReviewTemplateKey])
+    if (openSolidityReviewIssues.length === 0) {
+        solidityReviewIssueKey = await createSolidityReviewIssue(client, jiraProject, solidityReviewTemplateKey)
+    } else if (openSolidityReviewIssues.length === 1) {
+        solidityReviewIssueKey = openSolidityReviewIssues[0]
+    } else {
+        core.setFailed(`Found following open Solidity Review issues for project ${jiraProject}: ${join(...openSolidityReviewIssues)}.
+Since we are unable to automatically determine, which one to use, please manualy add it to changeset file: ${changesetFile}. Use this exact format:
+${SOLIDITY_REVIEW_PREFIX}<issue-key>
+Exmaple with issue key 'PROJ-1234':
+${SOLIDITY_REVIEW_PREFIX}PROJ-1234`)
+
+      return
+    }
+
+    core.info(`Will use Solidity Review issue: ${solidityReviewIssueKey}`)
+    await linkIssues(client, solidityReviewIssueKey, jiraPRIssueKey, 'Blocks')
+
+    core.info(`Appending JIRA Solidity Review issue ${solidityReviewIssueKey} to changeset file`);
+    await appendIssueNumberToChangesetFile(SOLIDITY_REVIEW_PREFIX, changesetFile, solidityReviewIssueKey);
+    exportIssueKeysToGithubEnv(jiraPRIssueKey, solidityReviewIssueKey)
+
+    core.info('Finished linking PR to a Solidity Review issue')
+  }
+
+  /**
+   * Retrieves issue keys from Jira based on the specified criteria.
+   *
+   * This function searches for issues within a given project that match the specified issue type, summary, and status.
+   * It can also exclude certain issue keys from the search results and limit the number of results returned.
+   *
+   * @param client - The Jira client instance used to perform the search.
+   * @param projectKey - The key of the project to search within.
+   * @param issueType - The type of issues to search for (e.g., 'Bug', 'Task').
+   * @param summary - A substring to match within the issue summaries (aka title).
+   * @param status - The status of the issues to search for (e.g., 'Open', 'Closed').
+   * @param issueKeysToIgnore - An array of issue keys to exclude from the search results.
+   * @param maxResults - The maximum number of issue keys to return.
+   * @returns A promise that resolves to an array of issue keys that match the search criteria.
+   * @throws Will throw an error if the search operation fails.
+   */
+  export async function getIssueKeys(client: jira.Version3Client, projectKey: string, issueType: string, summary: string, status: string, issueKeysToIgnore: string[], maxResults: number): Promise<string[]> {
+    try {
+      let jql = `project = ${projectKey} AND issuetype = "${issueType}" AND summary ~ "${summary}" AND status = "${status}"`;
+      if (issueKeysToIgnore.length > 0) {
+        jql = `${jql} AND issuekey NOT IN (${issueKeysToIgnore.join(',')})`
+      }
+      core.debug(`Searching for issue using jql: '${jql}'`)
+      const result = await client.issueSearch.searchForIssuesUsingJql({
+        jql: jql,
+        maxResults: maxResults,
+        fields: ['key']
+      });
+
+      if (result.issues === undefined) {
+        core.debug('Found no matching issues.')
+        return [];
+      }
+
+      return result.issues.map(issue => issue.key);
+    } catch (error) {
+      core.error(`Error searching for issues: ${error}`);
+      throw error
+    }
+  }
+
+  /**
+   * Links two Jira issues with a specified link type.
+   *
+   * This function creates a link between an inward issue and an outward issue using the provided link type.
+   * It logs the linking process and handles any errors that may occur during the operation.
+   *
+   * @param client - The Jira client instance used to perform the linking.
+   * @param inwardIssueKey - The key of the inward issue to be linked.
+   * @param outwardIssueKey - The key of the outward issue to be linked.
+   * @param linkType - The type of link to create between the issues (e.g., 'Blocks', 'Relates').
+   * @throws Will throw an error if the linking operation fails.
+   */
+  export async function linkIssues(client: jira.Version3Client, inwardIssueKey: string, outwardIssueKey: string, linkType: string) {
+    core.debug(`Linking issue ${inwardIssueKey} to ${outwardIssueKey} with link type of '${linkType}'`)
+    try {
+      await client.issueLinks.linkIssues({
+        type: {
+          name: linkType,
+        },
+        inwardIssue: {
+          key: inwardIssueKey,
+        },
+        outwardIssue: {
+          key: outwardIssueKey,
+        }
+      });
+
+      core.debug(`Successfully linked issues: ${inwardIssueKey} now '${linkType}' ${outwardIssueKey}`);
+    } catch (error) {
+        core.error(`Error linking issues ${inwardIssueKey} and ${outwardIssueKey}: ` + error);
+        throw error
+    }
+  }
+
+  /**
+   * Creates a new Solidity Review issue in the specified Jira project.
+   *
+   * This function clones an existing issue to create a new Solidity Review issue in the given project.
+   * It also clones all linked issues and their checklists. If any error occurs during the process,
+   * it attempts to clean up any partially created issues.
+   *
+   * @param client - The Jira client instance used to perform the operations.
+   * @param projectKey - The key of the project where the new issue will be created.
+   * @param sourceIssueKey - The key of the issue to be cloned as the new Solidity Review issue.
+   * @returns A promise that resolves to the key of the newly created Solidity Review issue.
+   * @throws Will throw an error if the creation or cloning process fails.
+   */
+  export async function createSolidityReviewIssue(client: jira.Version3Client, projectKey: string, sourceIssueKey: string) {
+    let solidityReviewKey = ""
+    try {
+      core.info(`Creating new Solidity Review issue in project ${projectKey}`)
+      solidityReviewKey = await cloneIssue(client, sourceIssueKey, projectKey)
+      await cloneLinkedIssues(client, projectKey, sourceIssueKey, solidityReviewKey, ['Epic'], 2, 1)
+      core.info(`Created new Solidity Review issue in project ${projectKey}. Issue key: ${solidityReviewKey}`)
+
+      return solidityReviewKey
+    } catch (error) {
+      core.setFailed('Failed to create new Solidity Review issue: ' + error)
+      if (solidityReviewKey !== '') {
+        await cleanUpUnfinishedIssues(client, [solidityReviewKey])
+      }
+      throw error
+    }
+  }
+
+  /**
+   * Clones an existing Jira issue into a specified project.
+   *
+   * This function retrieves the details of an existing issue and creates a new issue in the specified project
+   * with the same details (priority, summary, description, and issue type). It's a shallow clone and linked issues
+   * or custom fields are not copied.
+   *
+   * @param client - The Jira client instance used to perform the operations.
+   * @param originalIssueKey - The key of the issue to be cloned.
+   * @param projectKey - The key of the project where the new issue will be created.
+   * @returns A promise that resolves to the key of the newly created issue.
+   * @throws Will throw an error if the cloning process fails.
+   */
+  export async function cloneIssue(client: jira.Version3Client, originalIssueKey: string, projectKey: string): Promise<string> {
+    try {
+      core.debug(`Trying to clone ${originalIssueKey}`)
+      const originalIssue = await client.issues.getIssue({ issueIdOrKey: originalIssueKey });
+
+      if (originalIssue.fields.issuetype === undefined) {
+        throw new Error(`Issue ${originalIssueKey} is missing issue type id. This should not happen.`)
+      }
+
+      const newIssue = await client.issues.createIssue({
+        fields: {
+          project: {
+            key: projectKey,
+          },
+          priority: originalIssue.fields.priority,
+          summary: originalIssue.fields.summary,
+          description: originalIssue.fields.description,
+          issuetype: { id: originalIssue.fields.issuetype.id },
+        },
+      });
+      core.debug(`Cloned issue key: ${newIssue.key}`)
+      return newIssue.key;
+    } catch (error) {
+      core.error(`Error cloning issue ${originalIssueKey}: ` + error)
+      throw error
+    }
+  }
+
+  /**
+   * Clones all linked issues of specified types from a source issue to a target issue within a given project.
+   *
+   * This function retrieves all linked issues of the specified types from the source issue, clones them into the target project,
+   * copies their checklists, and links them to the target issue. If any error occurs during the process, it attempts to clean up
+   * any partially created issues. If issue types are not provided, all linked issues are cloned.
+   *
+   * @param client - The Jira client instance used to perform the operations.
+   * @param projectKey - The key of the project where the new issues will be created.
+   * @param sourceIssueKey - The key of the source issue whose linked issues will be cloned.
+   * @param targetIssueKey - The key of the target issue to which the cloned issues will be linked.
+   * @param issueTypes - An array of issue types to filter the linked issues (e.g., 'Task', 'Bug').
+   * @param expectedLinkedIssues - The expected number of linked issues to be cloned.
+   * @param expectedMinChecklists - The minimum number of checklists each issue should have.
+   * @throws Will throw an error if the cloning process fails or if the number of linked issues does not match the expected count.
+   */
+  export async function cloneLinkedIssues(client: jira.Version3Client, projectKey: string, sourceIssueKey: string, targetIssueKey: string, issueTypes: string[], expectedLinkedIssues: number, expectedMinChecklists: number) {
+    const linkedIssuesKeys: string[] = []
+    try {
+        core.debug(`Cloning to ${targetIssueKey} all issues with type '${join(...issueTypes)}' linked to ${sourceIssueKey}`)
+      const originalIssue = await client.issues.getIssue({ issueIdOrKey: sourceIssueKey });
+
+      const linkedIssues = originalIssue.fields.issuelinks.filter(link => {
+        const issueTypeName = link.inwardIssue?.fields?.issuetype?.name
+        if (!issueTypeName) {
+          return false
+        }
+        return issueTypes.length === 0 || issueTypes.includes(issueTypeName)
+      });
+
+      if (linkedIssues.length !== expectedLinkedIssues) {
+        throw new Error(`Expected exactly ${expectedLinkedIssues} linked issues of type ${join(...issueTypes)}, but got ${linkedIssues.length}`)
+      }
+
+      for (const issueLink of linkedIssues) {
+        if (!issueLink.inwardIssue?.key) {
+          throw new Error(`Issue link ${issueLink.id} was missing inward issue or inward issue key`)
+        }
+
+        const linkedIssue = await client.issues.getIssue({ issueIdOrKey: issueLink.inwardIssue?.key });
+
+        if (linkedIssue.fields.issuetype === undefined) {
+            throw new Error(`Issue ${linkedIssue.key} is missing issue type id. This should not happen.`)
+          }
+
+        const newLinkedIssue = await client.issues.createIssue({
+          fields: {
+            project: {
+              key: projectKey,
+            },
+            priority: linkedIssue.fields.priority,
+            summary: linkedIssue.fields.summary,
+            description: linkedIssue.fields.description,
+            issuetype: { id: linkedIssue.fields.issuetype.id },
+          },
+        });
+        linkedIssuesKeys.push(newLinkedIssue.key)
+
+        core.debug(`Cloned linked issue key: ${newLinkedIssue.key}`);
+
+        await copyAllChecklists(linkedIssue.id, newLinkedIssue.id, expectedMinChecklists)
+
+        await client.issueLinks.linkIssues({
+          type: { name: 'Blocks' },
+          inwardIssue: { key: newLinkedIssue.key },
+          outwardIssue: { key: targetIssueKey },
+        });
+
+        core.debug(`Linked ${newLinkedIssue.key} to issue ${targetIssueKey}`);
+      }
+    } catch (error) {
+        core.error(`Error cloning linked issues from ${sourceIssueKey} to ${targetIssueKey}:  ${error}`);
+        core.info('issues so far: ' + linkedIssuesKeys)
+        await cleanUpUnfinishedIssues(client, linkedIssuesKeys)
+        throw error
+    }
+  }
+
+  /**
+   * Cleans up unfinished Jira issues by closing them with a 'Declined' resolution.
+   *
+   * This function iterates over the provided issue keys and attempts to close each issue with a 'Declined' resolution.
+   * If any error occurs during the process, it logs the error and returns it.
+   *
+   * @param client - The Jira client instance used to perform the operations.
+   * @param issueKeys - An array of issue keys to be closed.
+   * @returns A promise that resolves to `undefined` if all issues are closed successfully, or an error if any issue fails to close.
+   * @throws Will throw an error if closing any of the issues fails.
+   */
+  async function cleanUpUnfinishedIssues(client: jira.Version3Client, issueKeys: string[]): Promise<unknown> {
+    try {
+      for (const key of issueKeys) {
+        await declineIssue(client, key, 'Closing issue due to an error in automatic creation of Solidity Review')
+      }
+      return
+    } catch (error) {
+      core.error(`Failed to close at least one of issues: ${join(...issueKeys)} due to: ${error}. Please close them manually`)
+      return error
+    }
+  }
+
+  /**
+   * Declines a Jira issue by transitioning it to a 'Closed' status with a 'Declined' resolution and adding a comment.
+   *
+   * This function transitions the specified Jira issue to the 'Closed' status using the provided transition ID and resolution.
+   * It also adds a comment to the issue explaining the reason for the decline.
+   *
+   * @param client - The Jira client instance used to perform the operations.
+   * @param issueKey - The key of the issue to be declined.
+   * @param commentText - The text of the comment to be added to the issue.
+   * @throws Will throw an error if the transition or comment operation fails.
+   */
+  async function declineIssue(client: jira.Version3Client, issueKey: string, commentText: string) {
+    // in our JIRA '81' is transitionId of `Closed` status, using transition name did not work
+    await transitionIssueWithComment(client,issueKey, '81', 'Declined', commentText)
+  }
+
+  /**
+   * Transitions a Jira issue to a specified status with a given resolution and adds a comment.
+   *
+   * This function transitions the specified Jira issue to the status identified by the provided transition ID.
+   * It also sets the resolution of the issue and adds a comment explaining the reason for the transition.
+   *
+   * @param client - The Jira client instance used to perform the operations.
+   * @param issueKey - The key of the issue to be transitioned.
+   * @param transitionId - The ID of the transition to be applied to the issue.
+   * @param resolution - The resolution to be set for the issue (e.g., 'Fixed', 'Declined').
+   * @param commentText - The text of the comment to be added to the issue.
+   * @throws Will throw an error if the transition or comment operation fails.
+   */
+  export async function transitionIssueWithComment(client: jira.Version3Client, issueKey: string, transitionId: string, resolution: string, commentText: string) {
+    try {
+      await client.issues.doTransition({
+        issueIdOrKey: issueKey,
+        transition: {
+          id: transitionId
+        },
+        fields: {
+          resolution: {
+            name: resolution
+          }
+        },
+        update: {
+          comment: [
+            {
+              add: {
+                body: {
+                  type: 'doc',
+                  version: 1,
+                  content: [
+                    {
+                      type: 'paragraph',
+                      content: [
+                        {
+                          type: 'text',
+                          text: commentText
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      });
+
+      core.debug(`Issue ${issueKey} successfully closed with comment.`);
+    } catch (error) {
+      core.error(`Failed to update issue ${issueKey}: ${error}`);
+      throw error
+    }
+  }
+
+  /**
+   * Copies all checklists from a source Jira issue to a target Jira issue. Works only with checklists created with the plugin "Multiple checklists for Jira".
+   *
+   * This function retrieves the checklists from the source issue, verifies that the number of checklists meets the expected minimum,
+   * and then adds the checklists to the target issue.
+   *
+   * @param sourceIssueId - The ID of the source issue from which checklists will be copied.
+   * @param targetIssueId - The ID of the target issue to which checklists will be added.
+   * @param expectedMinChecklists - The minimum number of checklists expected in the source issue.
+   * @throws Will throw an error if the number of checklists in the source issue is less than the expected minimum or if any operation fails.
+   */
+  export async function copyAllChecklists(sourceIssueId: string, targetIssueId: string, expectedMinChecklists: number) {
+    core.debug(`Copying all checklists from ${sourceIssueId} to ${targetIssueId}`)
+    const checklistProperty = 'sd-checklists-0'
+    const checklistJson = await getChecklistJSONFromIssue(sourceIssueId, checklistProperty)
+    assertChecklistCount(checklistJson, expectedMinChecklists)
+    addChecklistsToIssue(targetIssueId, checklistProperty, checklistJson)
+    core.debug(`Copied all checklists from ${sourceIssueId} to ${targetIssueId}`)
+  }
+
+  /**
+   * Asserts whether there are at least a specified number of checklists in the provided checklist JSON. Works only with checklists created with the plugin "Multiple checklists for Jira".
+   *
+   * This function checks if the `checklists` array in the provided JSON contains at least the specified minimum number of checklists.
+   * If the array is missing or contains fewer checklists than expected, it throws an error.
+   *
+   * Sample checklist:
+   * {
+       "version":"1.0.0",
+       "checklists":[
+          {
+            "id":0,
+            "name":"Example to do",
+            "items":[
+                {
+                  "name":"<p>task 1</p>",
+                  "required":true,
+                  "completed":true,
+                  "status":0,
+                  "user":"{ user id }",
+                  "date":"2019-08-13T13:18:24.046Z"
+                },
+                {
+                  "name":"<p>task 2</p>",
+                  "required":false,
+                  "completed":true,
+                  "status":0,
+                  "user":"{ user id }",
+                  "date":"2019-08-13T13:18:44.988Z"
+                },
+                {
+                  "name":"<p>task 3</p>",
+                  "required":false,
+                  "completed":false,
+                  "status":0,
+                  "user":"{ user id }",
+                  "date":"2019-08-08T13:30:29.643Z"
+                }
+            ]
+          }
+       ]
+    }
+   * @param checklistJSON - The JSON object containing the checklists to be validated.
+   * @param minChecklistCount - The minimum number of checklists expected in the `checklists` array.
+   * @throws Will throw an error if the `checklists` array is missing, not an array, or contains fewer checklists than `minChecklistCount`.
+   */
+  export function assertChecklistCount(checklistJSON: any, minChecklistCount: number) {
+    if (checklistJSON.checklists) {
+      if (!(checklistJSON.checklists instanceof Array) || (checklistJSON.checklists as Array<any>).length < minChecklistCount) {
+        core.debug('Checklist JSON:')
+        core.debug(JSON.stringify(checklistJSON))
+        throw new Error(`Checklist JSON either did not contain "checklists" array or it's lenght was smaller than ${minChecklistCount}`)
+      }
+
+      return
+    }
+
+    core.debug('Checklist JSON:')
+    core.debug(JSON.stringify(checklistJSON))
+    throw new Error('Checklist JSON did not contain any checklists.')
+  }
+
+  /**
+   * Adds provided checklists to a Jira issue. Works only with checklists created with the plugin "Multiple checklists for Jira".
+   * It's designed to work with the output of the `getChecklistJSONFromIssue()` function.
+   *
+   * This function sends a PUT request to the Jira API to add the checklists to the specified issue.
+   * It logs the process and handles any errors that may occur during the operation.
+   *
+   * @param issueId - The Jira issue ID (not key) of the issue to which checklists will be added.
+   * @param checklistProperty - The name of the checklist property, usually in the format `sd-checklists-{N}`.
+   * @param checklistsJson - The JSON object containing the checklists to be added, conforming to the "Multiple checklists for Jira" format.
+   * @throws Will throw an error if the operation to add checklists fails.
+   */
+  export async function addChecklistsToIssue(issueId: string, checklistProperty: string, checklistsJson: object) {
+    core.debug(`Adding checklists to issue ${issueId}`)
+    const { jiraHost, jiraUserName, jiraApiToken } = getJiraEnvVars();
+
+    try {
+    await axios.put(
+        `${jiraHost}rest/api/3/issue/${issueId}/properties/${checklistProperty}`,
+        checklistsJson,
+        {
+        auth: {
+            username: jiraUserName,
+            password: jiraApiToken,
+        }
+    },
+    );
+    core.debug(`Added checklists successfully`)
+    } catch (error) {
+        core.error(`Failed to add checklists to issue ${issueId}: ${error}`)
+        throw error
+    }
+  }
+
+  /**
+   * Reads all checklists created with the plugin "Multiple checklists for Jira" and returns them as JSON.
+   * This JSON can be used as-is to add these checklists to another issue. It's meant to be used in tandem
+   * with `addChecklistsToIssue()`.
+   *
+   * This function sends a GET request to the Jira API to fetch the checklists from the specified issue.
+   * It logs the process and handles any errors that may occur during the operation.
+   *
+   * @param issueId - The Jira issue ID (not key) of the issue to check.
+   * @param checklistProperty - The name of the checklist property, usually in the format `sd-checklists-{N}`.
+   * @returns A promise that resolves to a JSON object containing the checklists.
+   * @throws Will throw an error if the operation to fetch checklists fails or if the response has unexpected content.
+   */
+  export async function getChecklistJSONFromIssue(issueId: string, checklistProperty: string): Promise<object> {
+    core.debug(`Fetching all checklists from issue ${issueId}`)
+    const { jiraHost, jiraUserName, jiraApiToken } = getJiraEnvVars();
+
+    try {
+        const response = await axios.get(
+          `${jiraHost}rest/api/3/issue/${issueId}/properties/${checklistProperty}`,
+          {
+            auth: {
+              username: jiraUserName,
+              password: jiraApiToken,
+            },
+          }
+        );
+
+        if (response.data.value?.checklists && response.data.value?.checklists instanceof Array) {
+            core.debug(`Found ${(response.data.value?.checklists as Array<unknown>).length} checklists`)
+
+            return response.data.value
+        }
+
+        throw new Error('Checklist response had unexpected content: ' + JSON.stringify(response.data))
+
+      } catch (error) {
+        core.error(`Error reading checklists from issue ${issueId}: ${error}`);
+
+        throw error
+      }
+  }
+
+  /**
+   * Queries Jira for open Solidity Review issues within a specified project.
+   *
+   * This function searches for issues within the given project that match the 'Initiative' issue type,
+   * contain 'Solidity Review' in their summary, and have an 'Open' status. It excludes any issue keys
+   * provided in the `issueKeysToIgnore` array and limits the number of results to 10.
+   *
+   * @param client - The Jira client instance used to perform the search.
+   * @param projectKey - The key of the project to search within.
+   * @param issueKeysToIgnore - An array of issue keys to exclude from the search results.
+   * @returns A promise that resolves to an array of issue keys that match the search criteria.
+   * @throws Will throw an error if the search operation fails.
+   */
+  async function getOpenSolidityReviewIssuesForProject(client: jira.Version3Client, projectKey: string, issueKeysToIgnore: string[]): Promise<string[]> {
+    //TODO: change 'Initiative' to 'Solidity Review' once it has been created
+    const issueKeys = await getIssueKeys(client, projectKey, 'Initiative', 'Solidity Review', 'Open', issueKeysToIgnore, 10)
+    core.info(`Found ${issueKeys.length} open Solidity Review issues for project ${projectKey}`)
+    return issueKeys
+  }
+
+  function extracProjectFromIssueKey(issueKey: string): string | undefined {
+    const pattern = /([A-Z]{2,})-\d+/
+
+    const match = issueKey.toUpperCase().match(pattern);
+    const projectExtracted = match ? match[1] : undefined
+
+    core.debug(`Extracted following project '${projectExtracted}' from issue '${issueKey}'`)
+
+    return projectExtracted
+  }
+
+  /**
+   * Reads Jira issue key of Solidity Review blueprint.
+   *
+   * This function retrieves the issue key from the environment variable `SOLIDITY_REVIEW_TEMPLATE_KEY`.
+   * The issue key is used as a blueprint for creating new Solidity Review issues.
+   *
+   * @returns {string} The key of the issue that will be used as a blueprint for creating new Solidity Review issues.
+   * @throws {Error} If the `SOLIDITY_REVIEW_TEMPLATE_KEY` environment variable is not set or is empty.
+   */
+  function readSolidityReviewTemplateKey(): string {
+    const issueKey = process.env.SOLIDITY_REVIEW_TEMPLATE_KEY;
+    if (!issueKey) {
+      throw Error("Missing required environment variable SOLIDITY_REVIEW_TEMPLATE_KEY");
+    }
+
+    return issueKey
+  }
+
+  /**
+   * Exports Jira issue keys to GitHub environment variables if the `EXPORT_JIRA_ISSUE_KEYS` environment variable is set to 'true'.
+   *
+   * This function checks if the `EXPORT_JIRA_ISSUE_KEYS` environment variable is set to 'true'. If it is, it exports the provided
+   * Jira issue keys to the GitHub environment by appending them to the `GITHUB_ENV` file. The environment variables used are
+   * `PR_JIRA_ISSUE_KEY` for the pull request issue key and `SOLIDITY_REVIEW_ISSUE_KEY` for the Solidity review issue key.
+   *
+   * @param prIssueKey - The Jira issue key representing the pull request.
+   * @param solidityReviewIssueKey - The Jira issue key representing the Solidity review.
+   */
+  function exportIssueKeysToGithubEnv(prIssueKey: string, solidityReviewIssueKey: string) {
+    const shouldExport = process.env.EXPORT_JIRA_ISSUE_KEYS;
+    if (!shouldExport || shouldExport !== 'true' ) {
+      return
+    }
+
+    const prIssueKeyEnvVar = 'PR_JIRA_ISSUE_KEY'
+    const solidityReviewIssueKeyEnvVar = 'SOLIDITY_REVIEW_JIRA_ISSUE_KEY'
+
+    fs.appendFileSync(process.env.GITHUB_ENV ?? '', `${prIssueKeyEnvVar}=${prIssueKey}\n`);
+    fs.appendFileSync(process.env.GITHUB_ENV ?? '', `${solidityReviewIssueKeyEnvVar}=${solidityReviewIssueKey}\n`);
+
+    core.info(`Exported Jira issue key representing the PR as ${prIssueKeyEnvVar} env var`)
+    core.info(`Exported Jira issue key representing the Solidity Review as ${solidityReviewIssueKeyEnvVar} env var`)
+  }
+
+  async function run() {
+    try {
+      await main();
+    } catch (error) {
+      if (error instanceof Error) {
+        return core.setFailed(error.message);
+      }
+      core.setFailed(error as any);
+    }
+  }
+
+  run();

--- a/libs/jira-tracing/enforce-jira-solidity-review.ts
+++ b/libs/jira-tracing/enforce-jira-solidity-review.ts
@@ -55,6 +55,13 @@ async function main() {
       `Found linked Solidity Review issue(s): ${join(...jiraSolidityIssues)}. Nothing more needs to be done.`,
     );
 
+    exportIssueKeysToGithubEnv(jiraPRIssueKey, jiraSolidityIssues[0]);
+    if (jiraSolidityIssues.length > 1) {
+      core.warning(
+        `Found more than one Solidity Review issue linked to PR. Only the first one will be exported to GitHub environment.`,
+      );
+    }
+
     return;
   }
 

--- a/libs/jira-tracing/enforce-jira-solidity-review.ts
+++ b/libs/jira-tracing/enforce-jira-solidity-review.ts
@@ -2,421 +2,557 @@ import * as core from "@actions/core";
 import jira from "jira.js";
 import axios from "axios";
 import { join } from "path";
-import { createJiraClient, extractJiraIssueNumbersFrom, getJiraEnvVars, doesIssueExist, PR_PREFIX, SOLIDITY_REVIEW_PREFIX } from "./lib";
-import { appendIssueNumberToChangesetFile, extractChangesetFile } from "./changeset-lib";
+import {
+  createJiraClient,
+  extractJiraIssueNumbersFrom,
+  getJiraEnvVars,
+  doesIssueExist,
+  PR_PREFIX,
+  SOLIDITY_REVIEW_PREFIX,
+} from "./lib";
+import {
+  appendIssueNumberToChangesetFile,
+  extractChangesetFile,
+} from "./changeset-lib";
 import fs from "fs";
 
 async function main() {
-    core.info('Started linking PR to a Solidity Review issue')
-    const solidityReviewTemplateKey = readSolidityReviewTemplateKey()
-    const changesetFile = extractChangesetFile();
+  core.info("Started linking PR to a Solidity Review issue");
+  const solidityReviewTemplateKey = readSolidityReviewTemplateKey();
+  const changesetFile = extractChangesetFile();
 
-    const jiraPRIssueKeys = await extractJiraIssueNumbersFrom(PR_PREFIX, [changesetFile])
-    if (jiraPRIssueKeys.length !== 1) {
+  const jiraPRIssueKeys = await extractJiraIssueNumbersFrom(PR_PREFIX, [
+    changesetFile,
+  ]);
+  if (jiraPRIssueKeys.length !== 1) {
+    core.setFailed(
+      `Solidity Review enforcement only works with 1 JIRA issue per PR, but found ${jiraPRIssueKeys.length} issues in changeset file ${changesetFile}`,
+    );
+
+    return;
+  }
+
+  const jiraPRIssueKey = jiraPRIssueKeys[0];
+  const client = createJiraClient();
+
+  const jiraSolidityIssues = await extractJiraIssueNumbersFrom(
+    SOLIDITY_REVIEW_PREFIX,
+    [changesetFile],
+  );
+  if (jiraSolidityIssues.length > 0) {
+    for (const jiraIssue of jiraSolidityIssues) {
+      const exists = await doesIssueExist(client, jiraIssue, false);
+      if (!exists) {
         core.setFailed(
-            `Solidity Review enforcement only works with 1 JIRA issue per PR, but found ${jiraPRIssueKeys.length} issues in changeset file ${changesetFile}`
-          );
+          `JIRA issue ${jiraIssue} not found, Solidity Review issue must exist in JIRA.`,
+        );
 
-          return
+        return;
+      }
     }
 
-    const jiraPRIssueKey = jiraPRIssueKeys[0]
-    const client = createJiraClient();
+    core.info(
+      `Found linked Solidity Review issue(s): ${join(...jiraSolidityIssues)}. Nothing more needs to be done.`,
+    );
 
-    const jiraSolidityIssues = await extractJiraIssueNumbersFrom(SOLIDITY_REVIEW_PREFIX, [changesetFile])
-    if (jiraSolidityIssues.length > 0) {
-        for (const jiraIssue of jiraSolidityIssues) {
-          const exists = await doesIssueExist(client, jiraIssue, false);
-          if (!exists) {
-            core.setFailed(
-              `JIRA issue ${jiraIssue} not found, Solidity Review issue must exist in JIRA.`
-            );
+    return;
+  }
 
-            return;
-          }
-        }
+  const jiraProject = extracProjectFromIssueKey(jiraPRIssueKey);
+  if (!jiraProject) {
+    core.setFailed(
+      `Could not extract project key from issue: ${jiraPRIssueKey}`,
+    );
 
-        core.info(`Found linked Solidity Review issue(s): ${join(...jiraSolidityIssues)}. Nothing more needs to be done.`)
+    return;
+  }
 
-        return
-    }
-
-    const jiraProject = extracProjectFromIssueKey(jiraPRIssueKey)
-    if (!jiraProject) {
-        core.setFailed(`Could not extract project key from issue: ${jiraPRIssueKey}`)
-
-        return
-    }
-
-    core.info(`Checking if project ${jiraProject} has any open Solidity Review issues`)
-    let solidityReviewIssueKey: string
-    const openSolidityReviewIssues = await getOpenSolidityReviewIssuesForProject(client, jiraProject, [solidityReviewTemplateKey])
-    if (openSolidityReviewIssues.length === 0) {
-        solidityReviewIssueKey = await createSolidityReviewIssue(client, jiraProject, solidityReviewTemplateKey)
-    } else if (openSolidityReviewIssues.length === 1) {
-        solidityReviewIssueKey = openSolidityReviewIssues[0]
-    } else {
-        core.setFailed(`Found following open Solidity Review issues for project ${jiraProject}: ${join(...openSolidityReviewIssues)}.
+  core.info(
+    `Checking if project ${jiraProject} has any open Solidity Review issues`,
+  );
+  let solidityReviewIssueKey: string;
+  const openSolidityReviewIssues = await getOpenSolidityReviewIssuesForProject(
+    client,
+    jiraProject,
+    [solidityReviewTemplateKey],
+  );
+  if (openSolidityReviewIssues.length === 0) {
+    solidityReviewIssueKey = await createSolidityReviewIssue(
+      client,
+      jiraProject,
+      solidityReviewTemplateKey,
+    );
+  } else if (openSolidityReviewIssues.length === 1) {
+    solidityReviewIssueKey = openSolidityReviewIssues[0];
+  } else {
+    core.setFailed(`Found following open Solidity Review issues for project ${jiraProject}: ${join(...openSolidityReviewIssues)}.
 Since we are unable to automatically determine, which one to use, please manualy add it to changeset file: ${changesetFile}. Use this exact format:
 ${SOLIDITY_REVIEW_PREFIX}<issue-key>
 Exmaple with issue key 'PROJ-1234':
-${SOLIDITY_REVIEW_PREFIX}PROJ-1234`)
+${SOLIDITY_REVIEW_PREFIX}PROJ-1234`);
 
-      return
-    }
-
-    core.info(`Will use Solidity Review issue: ${solidityReviewIssueKey}`)
-    await linkIssues(client, solidityReviewIssueKey, jiraPRIssueKey, 'Blocks')
-
-    core.info(`Appending JIRA Solidity Review issue ${solidityReviewIssueKey} to changeset file`);
-    await appendIssueNumberToChangesetFile(SOLIDITY_REVIEW_PREFIX, changesetFile, solidityReviewIssueKey);
-    exportIssueKeysToGithubEnv(jiraPRIssueKey, solidityReviewIssueKey)
-
-    core.info('Finished linking PR to a Solidity Review issue')
+    return;
   }
 
-  /**
-   * Retrieves issue keys from Jira based on the specified criteria.
-   *
-   * This function searches for issues within a given project that match the specified issue type, summary, and status.
-   * It can also exclude certain issue keys from the search results and limit the number of results returned.
-   *
-   * @param client - The Jira client instance used to perform the search.
-   * @param projectKey - The key of the project to search within.
-   * @param issueType - The type of issues to search for (e.g., 'Bug', 'Task').
-   * @param summary - A substring to match within the issue summaries (aka title).
-   * @param status - The status of the issues to search for (e.g., 'Open', 'Closed').
-   * @param issueKeysToIgnore - An array of issue keys to exclude from the search results.
-   * @param maxResults - The maximum number of issue keys to return.
-   * @returns A promise that resolves to an array of issue keys that match the search criteria.
-   * @throws Will throw an error if the search operation fails.
-   */
-  export async function getIssueKeys(client: jira.Version3Client, projectKey: string, issueType: string, summary: string, status: string, issueKeysToIgnore: string[], maxResults: number): Promise<string[]> {
-    try {
-      let jql = `project = ${projectKey} AND issuetype = "${issueType}" AND summary ~ "${summary}" AND status = "${status}"`;
-      if (issueKeysToIgnore.length > 0) {
-        jql = `${jql} AND issuekey NOT IN (${issueKeysToIgnore.join(',')})`
+  core.info(`Will use Solidity Review issue: ${solidityReviewIssueKey}`);
+  await linkIssues(client, solidityReviewIssueKey, jiraPRIssueKey, "Blocks");
+
+  core.info(
+    `Appending JIRA Solidity Review issue ${solidityReviewIssueKey} to changeset file`,
+  );
+  await appendIssueNumberToChangesetFile(
+    SOLIDITY_REVIEW_PREFIX,
+    changesetFile,
+    solidityReviewIssueKey,
+  );
+  exportIssueKeysToGithubEnv(jiraPRIssueKey, solidityReviewIssueKey);
+
+  core.info("Finished linking PR to a Solidity Review issue");
+}
+
+/**
+ * Retrieves issue keys from Jira based on the specified criteria.
+ *
+ * This function searches for issues within a given project that match the specified issue type, summary, and status.
+ * It can also exclude certain issue keys from the search results and limit the number of results returned.
+ *
+ * @param client - The Jira client instance used to perform the search.
+ * @param projectKey - The key of the project to search within.
+ * @param issueType - The type of issues to search for (e.g., 'Bug', 'Task').
+ * @param summary - A substring to match within the issue summaries (aka title).
+ * @param status - The status of the issues to search for (e.g., 'Open', 'Closed').
+ * @param issueKeysToIgnore - An array of issue keys to exclude from the search results.
+ * @param maxResults - The maximum number of issue keys to return.
+ * @returns A promise that resolves to an array of issue keys that match the search criteria.
+ * @throws Will throw an error if the search operation fails.
+ */
+export async function getIssueKeys(
+  client: jira.Version3Client,
+  projectKey: string,
+  issueType: string,
+  summary: string,
+  status: string,
+  issueKeysToIgnore: string[],
+  maxResults: number,
+): Promise<string[]> {
+  try {
+    let jql = `project = ${projectKey} AND issuetype = "${issueType}" AND summary ~ "${summary}" AND status = "${status}"`;
+    if (issueKeysToIgnore.length > 0) {
+      jql = `${jql} AND issuekey NOT IN (${issueKeysToIgnore.join(",")})`;
+    }
+    core.debug(`Searching for issue using jql: '${jql}'`);
+    const result = await client.issueSearch.searchForIssuesUsingJql({
+      jql: jql,
+      maxResults: maxResults,
+      fields: ["key"],
+    });
+
+    if (result.issues === undefined) {
+      core.debug("Found no matching issues.");
+      return [];
+    }
+
+    return result.issues.map((issue) => issue.key);
+  } catch (error) {
+    core.error(`Error searching for issues: ${error}`);
+    throw error;
+  }
+}
+
+/**
+ * Links two Jira issues with a specified link type.
+ *
+ * This function creates a link between an inward issue and an outward issue using the provided link type.
+ * It logs the linking process and handles any errors that may occur during the operation.
+ *
+ * @param client - The Jira client instance used to perform the linking.
+ * @param inwardIssueKey - The key of the inward issue to be linked.
+ * @param outwardIssueKey - The key of the outward issue to be linked.
+ * @param linkType - The type of link to create between the issues (e.g., 'Blocks', 'Relates').
+ * @throws Will throw an error if the linking operation fails.
+ */
+export async function linkIssues(
+  client: jira.Version3Client,
+  inwardIssueKey: string,
+  outwardIssueKey: string,
+  linkType: string,
+) {
+  core.debug(
+    `Linking issue ${inwardIssueKey} to ${outwardIssueKey} with link type of '${linkType}'`,
+  );
+  try {
+    await client.issueLinks.linkIssues({
+      type: {
+        name: linkType,
+      },
+      inwardIssue: {
+        key: inwardIssueKey,
+      },
+      outwardIssue: {
+        key: outwardIssueKey,
+      },
+    });
+
+    core.debug(
+      `Successfully linked issues: ${inwardIssueKey} now '${linkType}' ${outwardIssueKey}`,
+    );
+  } catch (error) {
+    core.error(
+      `Error linking issues ${inwardIssueKey} and ${outwardIssueKey}: ` + error,
+    );
+    throw error;
+  }
+}
+
+/**
+ * Creates a new Solidity Review issue in the specified Jira project.
+ *
+ * This function clones an existing issue to create a new Solidity Review issue in the given project.
+ * It also clones all linked issues and their checklists. If any error occurs during the process,
+ * it attempts to clean up any partially created issues.
+ *
+ * @param client - The Jira client instance used to perform the operations.
+ * @param projectKey - The key of the project where the new issue will be created.
+ * @param sourceIssueKey - The key of the issue to be cloned as the new Solidity Review issue.
+ * @returns A promise that resolves to the key of the newly created Solidity Review issue.
+ * @throws Will throw an error if the creation or cloning process fails.
+ */
+export async function createSolidityReviewIssue(
+  client: jira.Version3Client,
+  projectKey: string,
+  sourceIssueKey: string,
+) {
+  let solidityReviewKey = "";
+  try {
+    core.info(`Creating new Solidity Review issue in project ${projectKey}`);
+    solidityReviewKey = await cloneIssue(client, sourceIssueKey, projectKey);
+    await cloneLinkedIssues(
+      client,
+      projectKey,
+      sourceIssueKey,
+      solidityReviewKey,
+      ["Epic"],
+      2,
+      1,
+    );
+    core.info(
+      `Created new Solidity Review issue in project ${projectKey}. Issue key: ${solidityReviewKey}`,
+    );
+
+    return solidityReviewKey;
+  } catch (error) {
+    core.setFailed("Failed to create new Solidity Review issue: " + error);
+    if (solidityReviewKey !== "") {
+      await cleanUpUnfinishedIssues(client, [solidityReviewKey]);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Clones an existing Jira issue into a specified project.
+ *
+ * This function retrieves the details of an existing issue and creates a new issue in the specified project
+ * with the same details (priority, summary, description, and issue type). It's a shallow clone and linked issues
+ * or custom fields are not copied.
+ *
+ * @param client - The Jira client instance used to perform the operations.
+ * @param originalIssueKey - The key of the issue to be cloned.
+ * @param projectKey - The key of the project where the new issue will be created.
+ * @returns A promise that resolves to the key of the newly created issue.
+ * @throws Will throw an error if the cloning process fails.
+ */
+export async function cloneIssue(
+  client: jira.Version3Client,
+  originalIssueKey: string,
+  projectKey: string,
+): Promise<string> {
+  try {
+    core.debug(`Trying to clone ${originalIssueKey}`);
+    const originalIssue = await client.issues.getIssue({
+      issueIdOrKey: originalIssueKey,
+    });
+
+    if (originalIssue.fields.issuetype === undefined) {
+      throw new Error(
+        `Issue ${originalIssueKey} is missing issue type id. This should not happen.`,
+      );
+    }
+
+    const newIssue = await client.issues.createIssue({
+      fields: {
+        project: {
+          key: projectKey,
+        },
+        priority: originalIssue.fields.priority,
+        summary: originalIssue.fields.summary,
+        description: originalIssue.fields.description,
+        issuetype: { id: originalIssue.fields.issuetype.id },
+      },
+    });
+    core.debug(`Cloned issue key: ${newIssue.key}`);
+    return newIssue.key;
+  } catch (error) {
+    core.error(`Error cloning issue ${originalIssueKey}: ` + error);
+    throw error;
+  }
+}
+
+/**
+ * Clones all linked issues of specified types from a source issue to a target issue within a given project.
+ *
+ * This function retrieves all linked issues of the specified types from the source issue, clones them into the target project,
+ * copies their checklists, and links them to the target issue. If any error occurs during the process, it attempts to clean up
+ * any partially created issues. If issue types are not provided, all linked issues are cloned.
+ *
+ * @param client - The Jira client instance used to perform the operations.
+ * @param projectKey - The key of the project where the new issues will be created.
+ * @param sourceIssueKey - The key of the source issue whose linked issues will be cloned.
+ * @param targetIssueKey - The key of the target issue to which the cloned issues will be linked.
+ * @param issueTypes - An array of issue types to filter the linked issues (e.g., 'Task', 'Bug').
+ * @param expectedLinkedIssues - The expected number of linked issues to be cloned.
+ * @param expectedMinChecklists - The minimum number of checklists each issue should have.
+ * @throws Will throw an error if the cloning process fails or if the number of linked issues does not match the expected count.
+ */
+export async function cloneLinkedIssues(
+  client: jira.Version3Client,
+  projectKey: string,
+  sourceIssueKey: string,
+  targetIssueKey: string,
+  issueTypes: string[],
+  expectedLinkedIssues: number,
+  expectedMinChecklists: number,
+) {
+  const linkedIssuesKeys: string[] = [];
+  try {
+    core.debug(
+      `Cloning to ${targetIssueKey} all issues with type '${join(...issueTypes)}' linked to ${sourceIssueKey}`,
+    );
+    const originalIssue = await client.issues.getIssue({
+      issueIdOrKey: sourceIssueKey,
+    });
+
+    const linkedIssues = originalIssue.fields.issuelinks.filter((link) => {
+      const issueTypeName = link.inwardIssue?.fields?.issuetype?.name;
+      if (!issueTypeName) {
+        return false;
       }
-      core.debug(`Searching for issue using jql: '${jql}'`)
-      const result = await client.issueSearch.searchForIssuesUsingJql({
-        jql: jql,
-        maxResults: maxResults,
-        fields: ['key']
+      return issueTypes.length === 0 || issueTypes.includes(issueTypeName);
+    });
+
+    if (linkedIssues.length !== expectedLinkedIssues) {
+      throw new Error(
+        `Expected exactly ${expectedLinkedIssues} linked issues of type ${join(...issueTypes)}, but got ${linkedIssues.length}`,
+      );
+    }
+
+    for (const issueLink of linkedIssues) {
+      if (!issueLink.inwardIssue?.key) {
+        throw new Error(
+          `Issue link ${issueLink.id} was missing inward issue or inward issue key`,
+        );
+      }
+
+      const linkedIssue = await client.issues.getIssue({
+        issueIdOrKey: issueLink.inwardIssue?.key,
       });
 
-      if (result.issues === undefined) {
-        core.debug('Found no matching issues.')
-        return [];
+      if (linkedIssue.fields.issuetype === undefined) {
+        throw new Error(
+          `Issue ${linkedIssue.key} is missing issue type id. This should not happen.`,
+        );
       }
 
-      return result.issues.map(issue => issue.key);
-    } catch (error) {
-      core.error(`Error searching for issues: ${error}`);
-      throw error
-    }
-  }
-
-  /**
-   * Links two Jira issues with a specified link type.
-   *
-   * This function creates a link between an inward issue and an outward issue using the provided link type.
-   * It logs the linking process and handles any errors that may occur during the operation.
-   *
-   * @param client - The Jira client instance used to perform the linking.
-   * @param inwardIssueKey - The key of the inward issue to be linked.
-   * @param outwardIssueKey - The key of the outward issue to be linked.
-   * @param linkType - The type of link to create between the issues (e.g., 'Blocks', 'Relates').
-   * @throws Will throw an error if the linking operation fails.
-   */
-  export async function linkIssues(client: jira.Version3Client, inwardIssueKey: string, outwardIssueKey: string, linkType: string) {
-    core.debug(`Linking issue ${inwardIssueKey} to ${outwardIssueKey} with link type of '${linkType}'`)
-    try {
-      await client.issueLinks.linkIssues({
-        type: {
-          name: linkType,
-        },
-        inwardIssue: {
-          key: inwardIssueKey,
-        },
-        outwardIssue: {
-          key: outwardIssueKey,
-        }
-      });
-
-      core.debug(`Successfully linked issues: ${inwardIssueKey} now '${linkType}' ${outwardIssueKey}`);
-    } catch (error) {
-        core.error(`Error linking issues ${inwardIssueKey} and ${outwardIssueKey}: ` + error);
-        throw error
-    }
-  }
-
-  /**
-   * Creates a new Solidity Review issue in the specified Jira project.
-   *
-   * This function clones an existing issue to create a new Solidity Review issue in the given project.
-   * It also clones all linked issues and their checklists. If any error occurs during the process,
-   * it attempts to clean up any partially created issues.
-   *
-   * @param client - The Jira client instance used to perform the operations.
-   * @param projectKey - The key of the project where the new issue will be created.
-   * @param sourceIssueKey - The key of the issue to be cloned as the new Solidity Review issue.
-   * @returns A promise that resolves to the key of the newly created Solidity Review issue.
-   * @throws Will throw an error if the creation or cloning process fails.
-   */
-  export async function createSolidityReviewIssue(client: jira.Version3Client, projectKey: string, sourceIssueKey: string) {
-    let solidityReviewKey = ""
-    try {
-      core.info(`Creating new Solidity Review issue in project ${projectKey}`)
-      solidityReviewKey = await cloneIssue(client, sourceIssueKey, projectKey)
-      await cloneLinkedIssues(client, projectKey, sourceIssueKey, solidityReviewKey, ['Epic'], 2, 1)
-      core.info(`Created new Solidity Review issue in project ${projectKey}. Issue key: ${solidityReviewKey}`)
-
-      return solidityReviewKey
-    } catch (error) {
-      core.setFailed('Failed to create new Solidity Review issue: ' + error)
-      if (solidityReviewKey !== '') {
-        await cleanUpUnfinishedIssues(client, [solidityReviewKey])
-      }
-      throw error
-    }
-  }
-
-  /**
-   * Clones an existing Jira issue into a specified project.
-   *
-   * This function retrieves the details of an existing issue and creates a new issue in the specified project
-   * with the same details (priority, summary, description, and issue type). It's a shallow clone and linked issues
-   * or custom fields are not copied.
-   *
-   * @param client - The Jira client instance used to perform the operations.
-   * @param originalIssueKey - The key of the issue to be cloned.
-   * @param projectKey - The key of the project where the new issue will be created.
-   * @returns A promise that resolves to the key of the newly created issue.
-   * @throws Will throw an error if the cloning process fails.
-   */
-  export async function cloneIssue(client: jira.Version3Client, originalIssueKey: string, projectKey: string): Promise<string> {
-    try {
-      core.debug(`Trying to clone ${originalIssueKey}`)
-      const originalIssue = await client.issues.getIssue({ issueIdOrKey: originalIssueKey });
-
-      if (originalIssue.fields.issuetype === undefined) {
-        throw new Error(`Issue ${originalIssueKey} is missing issue type id. This should not happen.`)
-      }
-
-      const newIssue = await client.issues.createIssue({
+      const newLinkedIssue = await client.issues.createIssue({
         fields: {
           project: {
             key: projectKey,
           },
-          priority: originalIssue.fields.priority,
-          summary: originalIssue.fields.summary,
-          description: originalIssue.fields.description,
-          issuetype: { id: originalIssue.fields.issuetype.id },
+          priority: linkedIssue.fields.priority,
+          summary: linkedIssue.fields.summary,
+          description: linkedIssue.fields.description,
+          issuetype: { id: linkedIssue.fields.issuetype.id },
         },
       });
-      core.debug(`Cloned issue key: ${newIssue.key}`)
-      return newIssue.key;
-    } catch (error) {
-      core.error(`Error cloning issue ${originalIssueKey}: ` + error)
-      throw error
-    }
-  }
+      linkedIssuesKeys.push(newLinkedIssue.key);
 
-  /**
-   * Clones all linked issues of specified types from a source issue to a target issue within a given project.
-   *
-   * This function retrieves all linked issues of the specified types from the source issue, clones them into the target project,
-   * copies their checklists, and links them to the target issue. If any error occurs during the process, it attempts to clean up
-   * any partially created issues. If issue types are not provided, all linked issues are cloned.
-   *
-   * @param client - The Jira client instance used to perform the operations.
-   * @param projectKey - The key of the project where the new issues will be created.
-   * @param sourceIssueKey - The key of the source issue whose linked issues will be cloned.
-   * @param targetIssueKey - The key of the target issue to which the cloned issues will be linked.
-   * @param issueTypes - An array of issue types to filter the linked issues (e.g., 'Task', 'Bug').
-   * @param expectedLinkedIssues - The expected number of linked issues to be cloned.
-   * @param expectedMinChecklists - The minimum number of checklists each issue should have.
-   * @throws Will throw an error if the cloning process fails or if the number of linked issues does not match the expected count.
-   */
-  export async function cloneLinkedIssues(client: jira.Version3Client, projectKey: string, sourceIssueKey: string, targetIssueKey: string, issueTypes: string[], expectedLinkedIssues: number, expectedMinChecklists: number) {
-    const linkedIssuesKeys: string[] = []
-    try {
-        core.debug(`Cloning to ${targetIssueKey} all issues with type '${join(...issueTypes)}' linked to ${sourceIssueKey}`)
-      const originalIssue = await client.issues.getIssue({ issueIdOrKey: sourceIssueKey });
+      core.debug(`Cloned linked issue key: ${newLinkedIssue.key}`);
 
-      const linkedIssues = originalIssue.fields.issuelinks.filter(link => {
-        const issueTypeName = link.inwardIssue?.fields?.issuetype?.name
-        if (!issueTypeName) {
-          return false
-        }
-        return issueTypes.length === 0 || issueTypes.includes(issueTypeName)
+      await copyAllChecklists(
+        linkedIssue.id,
+        newLinkedIssue.id,
+        expectedMinChecklists,
+      );
+
+      await client.issueLinks.linkIssues({
+        type: { name: "Blocks" },
+        inwardIssue: { key: newLinkedIssue.key },
+        outwardIssue: { key: targetIssueKey },
       });
 
-      if (linkedIssues.length !== expectedLinkedIssues) {
-        throw new Error(`Expected exactly ${expectedLinkedIssues} linked issues of type ${join(...issueTypes)}, but got ${linkedIssues.length}`)
-      }
+      core.debug(`Linked ${newLinkedIssue.key} to issue ${targetIssueKey}`);
+    }
+  } catch (error) {
+    core.error(
+      `Error cloning linked issues from ${sourceIssueKey} to ${targetIssueKey}:  ${error}`,
+    );
+    core.info("issues so far: " + linkedIssuesKeys);
+    await cleanUpUnfinishedIssues(client, linkedIssuesKeys);
+    throw error;
+  }
+}
 
-      for (const issueLink of linkedIssues) {
-        if (!issueLink.inwardIssue?.key) {
-          throw new Error(`Issue link ${issueLink.id} was missing inward issue or inward issue key`)
-        }
+/**
+ * Cleans up unfinished Jira issues by closing them with a 'Declined' resolution.
+ *
+ * This function iterates over the provided issue keys and attempts to close each issue with a 'Declined' resolution.
+ * If any error occurs during the process, it logs the error and returns it.
+ *
+ * @param client - The Jira client instance used to perform the operations.
+ * @param issueKeys - An array of issue keys to be closed.
+ * @returns A promise that resolves to `undefined` if all issues are closed successfully, or an error if any issue fails to close.
+ * @throws Will throw an error if closing any of the issues fails.
+ */
+async function cleanUpUnfinishedIssues(
+  client: jira.Version3Client,
+  issueKeys: string[],
+): Promise<unknown> {
+  try {
+    for (const key of issueKeys) {
+      await declineIssue(
+        client,
+        key,
+        "Closing issue due to an error in automatic creation of Solidity Review",
+      );
+    }
+    return;
+  } catch (error) {
+    core.error(
+      `Failed to close at least one of issues: ${join(...issueKeys)} due to: ${error}. Please close them manually`,
+    );
+    return error;
+  }
+}
 
-        const linkedIssue = await client.issues.getIssue({ issueIdOrKey: issueLink.inwardIssue?.key });
+/**
+ * Declines a Jira issue by transitioning it to a 'Closed' status with a 'Declined' resolution and adding a comment.
+ *
+ * This function transitions the specified Jira issue to the 'Closed' status using the provided transition ID and resolution.
+ * It also adds a comment to the issue explaining the reason for the decline.
+ *
+ * @param client - The Jira client instance used to perform the operations.
+ * @param issueKey - The key of the issue to be declined.
+ * @param commentText - The text of the comment to be added to the issue.
+ * @throws Will throw an error if the transition or comment operation fails.
+ */
+async function declineIssue(
+  client: jira.Version3Client,
+  issueKey: string,
+  commentText: string,
+) {
+  // in our JIRA '81' is transitionId of `Closed` status, using transition name did not work
+  await transitionIssueWithComment(
+    client,
+    issueKey,
+    "81",
+    "Declined",
+    commentText,
+  );
+}
 
-        if (linkedIssue.fields.issuetype === undefined) {
-            throw new Error(`Issue ${linkedIssue.key} is missing issue type id. This should not happen.`)
-          }
-
-        const newLinkedIssue = await client.issues.createIssue({
-          fields: {
-            project: {
-              key: projectKey,
+/**
+ * Transitions a Jira issue to a specified status with a given resolution and adds a comment.
+ *
+ * This function transitions the specified Jira issue to the status identified by the provided transition ID.
+ * It also sets the resolution of the issue and adds a comment explaining the reason for the transition.
+ *
+ * @param client - The Jira client instance used to perform the operations.
+ * @param issueKey - The key of the issue to be transitioned.
+ * @param transitionId - The ID of the transition to be applied to the issue.
+ * @param resolution - The resolution to be set for the issue (e.g., 'Fixed', 'Declined').
+ * @param commentText - The text of the comment to be added to the issue.
+ * @throws Will throw an error if the transition or comment operation fails.
+ */
+export async function transitionIssueWithComment(
+  client: jira.Version3Client,
+  issueKey: string,
+  transitionId: string,
+  resolution: string,
+  commentText: string,
+) {
+  try {
+    await client.issues.doTransition({
+      issueIdOrKey: issueKey,
+      transition: {
+        id: transitionId,
+      },
+      fields: {
+        resolution: {
+          name: resolution,
+        },
+      },
+      update: {
+        comment: [
+          {
+            add: {
+              body: {
+                type: "doc",
+                version: 1,
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [
+                      {
+                        type: "text",
+                        text: commentText,
+                      },
+                    ],
+                  },
+                ],
+              },
             },
-            priority: linkedIssue.fields.priority,
-            summary: linkedIssue.fields.summary,
-            description: linkedIssue.fields.description,
-            issuetype: { id: linkedIssue.fields.issuetype.id },
           },
-        });
-        linkedIssuesKeys.push(newLinkedIssue.key)
+        ],
+      },
+    });
 
-        core.debug(`Cloned linked issue key: ${newLinkedIssue.key}`);
-
-        await copyAllChecklists(linkedIssue.id, newLinkedIssue.id, expectedMinChecklists)
-
-        await client.issueLinks.linkIssues({
-          type: { name: 'Blocks' },
-          inwardIssue: { key: newLinkedIssue.key },
-          outwardIssue: { key: targetIssueKey },
-        });
-
-        core.debug(`Linked ${newLinkedIssue.key} to issue ${targetIssueKey}`);
-      }
-    } catch (error) {
-        core.error(`Error cloning linked issues from ${sourceIssueKey} to ${targetIssueKey}:  ${error}`);
-        core.info('issues so far: ' + linkedIssuesKeys)
-        await cleanUpUnfinishedIssues(client, linkedIssuesKeys)
-        throw error
-    }
+    core.debug(`Issue ${issueKey} successfully closed with comment.`);
+  } catch (error) {
+    core.error(`Failed to update issue ${issueKey}: ${error}`);
+    throw error;
   }
+}
 
-  /**
-   * Cleans up unfinished Jira issues by closing them with a 'Declined' resolution.
-   *
-   * This function iterates over the provided issue keys and attempts to close each issue with a 'Declined' resolution.
-   * If any error occurs during the process, it logs the error and returns it.
-   *
-   * @param client - The Jira client instance used to perform the operations.
-   * @param issueKeys - An array of issue keys to be closed.
-   * @returns A promise that resolves to `undefined` if all issues are closed successfully, or an error if any issue fails to close.
-   * @throws Will throw an error if closing any of the issues fails.
-   */
-  async function cleanUpUnfinishedIssues(client: jira.Version3Client, issueKeys: string[]): Promise<unknown> {
-    try {
-      for (const key of issueKeys) {
-        await declineIssue(client, key, 'Closing issue due to an error in automatic creation of Solidity Review')
-      }
-      return
-    } catch (error) {
-      core.error(`Failed to close at least one of issues: ${join(...issueKeys)} due to: ${error}. Please close them manually`)
-      return error
-    }
-  }
+/**
+ * Copies all checklists from a source Jira issue to a target Jira issue. Works only with checklists created with the plugin "Multiple checklists for Jira".
+ *
+ * This function retrieves the checklists from the source issue, verifies that the number of checklists meets the expected minimum,
+ * and then adds the checklists to the target issue.
+ *
+ * @param sourceIssueId - The ID of the source issue from which checklists will be copied.
+ * @param targetIssueId - The ID of the target issue to which checklists will be added.
+ * @param expectedMinChecklists - The minimum number of checklists expected in the source issue.
+ * @throws Will throw an error if the number of checklists in the source issue is less than the expected minimum or if any operation fails.
+ */
+export async function copyAllChecklists(
+  sourceIssueId: string,
+  targetIssueId: string,
+  expectedMinChecklists: number,
+) {
+  core.debug(
+    `Copying all checklists from ${sourceIssueId} to ${targetIssueId}`,
+  );
+  const checklistProperty = "sd-checklists-0";
+  const checklistJson = await getChecklistJSONFromIssue(
+    sourceIssueId,
+    checklistProperty,
+  );
+  assertChecklistCount(checklistJson, expectedMinChecklists);
+  addChecklistsToIssue(targetIssueId, checklistProperty, checklistJson);
+  core.debug(`Copied all checklists from ${sourceIssueId} to ${targetIssueId}`);
+}
 
-  /**
-   * Declines a Jira issue by transitioning it to a 'Closed' status with a 'Declined' resolution and adding a comment.
-   *
-   * This function transitions the specified Jira issue to the 'Closed' status using the provided transition ID and resolution.
-   * It also adds a comment to the issue explaining the reason for the decline.
-   *
-   * @param client - The Jira client instance used to perform the operations.
-   * @param issueKey - The key of the issue to be declined.
-   * @param commentText - The text of the comment to be added to the issue.
-   * @throws Will throw an error if the transition or comment operation fails.
-   */
-  async function declineIssue(client: jira.Version3Client, issueKey: string, commentText: string) {
-    // in our JIRA '81' is transitionId of `Closed` status, using transition name did not work
-    await transitionIssueWithComment(client,issueKey, '81', 'Declined', commentText)
-  }
-
-  /**
-   * Transitions a Jira issue to a specified status with a given resolution and adds a comment.
-   *
-   * This function transitions the specified Jira issue to the status identified by the provided transition ID.
-   * It also sets the resolution of the issue and adds a comment explaining the reason for the transition.
-   *
-   * @param client - The Jira client instance used to perform the operations.
-   * @param issueKey - The key of the issue to be transitioned.
-   * @param transitionId - The ID of the transition to be applied to the issue.
-   * @param resolution - The resolution to be set for the issue (e.g., 'Fixed', 'Declined').
-   * @param commentText - The text of the comment to be added to the issue.
-   * @throws Will throw an error if the transition or comment operation fails.
-   */
-  export async function transitionIssueWithComment(client: jira.Version3Client, issueKey: string, transitionId: string, resolution: string, commentText: string) {
-    try {
-      await client.issues.doTransition({
-        issueIdOrKey: issueKey,
-        transition: {
-          id: transitionId
-        },
-        fields: {
-          resolution: {
-            name: resolution
-          }
-        },
-        update: {
-          comment: [
-            {
-              add: {
-                body: {
-                  type: 'doc',
-                  version: 1,
-                  content: [
-                    {
-                      type: 'paragraph',
-                      content: [
-                        {
-                          type: 'text',
-                          text: commentText
-                        }
-                      ]
-                    }
-                  ]
-                }
-              }
-            }
-          ]
-        }
-      });
-
-      core.debug(`Issue ${issueKey} successfully closed with comment.`);
-    } catch (error) {
-      core.error(`Failed to update issue ${issueKey}: ${error}`);
-      throw error
-    }
-  }
-
-  /**
-   * Copies all checklists from a source Jira issue to a target Jira issue. Works only with checklists created with the plugin "Multiple checklists for Jira".
-   *
-   * This function retrieves the checklists from the source issue, verifies that the number of checklists meets the expected minimum,
-   * and then adds the checklists to the target issue.
-   *
-   * @param sourceIssueId - The ID of the source issue from which checklists will be copied.
-   * @param targetIssueId - The ID of the target issue to which checklists will be added.
-   * @param expectedMinChecklists - The minimum number of checklists expected in the source issue.
-   * @throws Will throw an error if the number of checklists in the source issue is less than the expected minimum or if any operation fails.
-   */
-  export async function copyAllChecklists(sourceIssueId: string, targetIssueId: string, expectedMinChecklists: number) {
-    core.debug(`Copying all checklists from ${sourceIssueId} to ${targetIssueId}`)
-    const checklistProperty = 'sd-checklists-0'
-    const checklistJson = await getChecklistJSONFromIssue(sourceIssueId, checklistProperty)
-    assertChecklistCount(checklistJson, expectedMinChecklists)
-    addChecklistsToIssue(targetIssueId, checklistProperty, checklistJson)
-    core.debug(`Copied all checklists from ${sourceIssueId} to ${targetIssueId}`)
-  }
-
-  /**
+/**
    * Asserts whether there are at least a specified number of checklists in the provided checklist JSON. Works only with checklists created with the plugin "Multiple checklists for Jira".
    *
    * This function checks if the `checklists` array in the provided JSON contains at least the specified minimum number of checklists.
@@ -462,183 +598,236 @@ ${SOLIDITY_REVIEW_PREFIX}PROJ-1234`)
    * @param minChecklistCount - The minimum number of checklists expected in the `checklists` array.
    * @throws Will throw an error if the `checklists` array is missing, not an array, or contains fewer checklists than `minChecklistCount`.
    */
-  export function assertChecklistCount(checklistJSON: any, minChecklistCount: number) {
-    if (checklistJSON.checklists) {
-      if (!(checklistJSON.checklists instanceof Array) || (checklistJSON.checklists as Array<any>).length < minChecklistCount) {
-        core.debug('Checklist JSON:')
-        core.debug(JSON.stringify(checklistJSON))
-        throw new Error(`Checklist JSON either did not contain "checklists" array or it's lenght was smaller than ${minChecklistCount}`)
-      }
-
-      return
+export function assertChecklistCount(
+  checklistJSON: any,
+  minChecklistCount: number,
+) {
+  if (checklistJSON.checklists) {
+    if (
+      !(checklistJSON.checklists instanceof Array) ||
+      (checklistJSON.checklists as Array<any>).length < minChecklistCount
+    ) {
+      core.debug("Checklist JSON:");
+      core.debug(JSON.stringify(checklistJSON));
+      throw new Error(
+        `Checklist JSON either did not contain "checklists" array or it's lenght was smaller than ${minChecklistCount}`,
+      );
     }
 
-    core.debug('Checklist JSON:')
-    core.debug(JSON.stringify(checklistJSON))
-    throw new Error('Checklist JSON did not contain any checklists.')
+    return;
   }
 
-  /**
-   * Adds provided checklists to a Jira issue. Works only with checklists created with the plugin "Multiple checklists for Jira".
-   * It's designed to work with the output of the `getChecklistJSONFromIssue()` function.
-   *
-   * This function sends a PUT request to the Jira API to add the checklists to the specified issue.
-   * It logs the process and handles any errors that may occur during the operation.
-   *
-   * @param issueId - The Jira issue ID (not key) of the issue to which checklists will be added.
-   * @param checklistProperty - The name of the checklist property, usually in the format `sd-checklists-{N}`.
-   * @param checklistsJson - The JSON object containing the checklists to be added, conforming to the "Multiple checklists for Jira" format.
-   * @throws Will throw an error if the operation to add checklists fails.
-   */
-  export async function addChecklistsToIssue(issueId: string, checklistProperty: string, checklistsJson: object) {
-    core.debug(`Adding checklists to issue ${issueId}`)
-    const { jiraHost, jiraUserName, jiraApiToken } = getJiraEnvVars();
+  core.debug("Checklist JSON:");
+  core.debug(JSON.stringify(checklistJSON));
+  throw new Error("Checklist JSON did not contain any checklists.");
+}
 
-    try {
+/**
+ * Adds provided checklists to a Jira issue. Works only with checklists created with the plugin "Multiple checklists for Jira".
+ * It's designed to work with the output of the `getChecklistJSONFromIssue()` function.
+ *
+ * This function sends a PUT request to the Jira API to add the checklists to the specified issue.
+ * It logs the process and handles any errors that may occur during the operation.
+ *
+ * @param issueId - The Jira issue ID (not key) of the issue to which checklists will be added.
+ * @param checklistProperty - The name of the checklist property, usually in the format `sd-checklists-{N}`.
+ * @param checklistsJson - The JSON object containing the checklists to be added, conforming to the "Multiple checklists for Jira" format.
+ * @throws Will throw an error if the operation to add checklists fails.
+ */
+export async function addChecklistsToIssue(
+  issueId: string,
+  checklistProperty: string,
+  checklistsJson: object,
+) {
+  core.debug(`Adding checklists to issue ${issueId}`);
+  const { jiraHost, jiraUserName, jiraApiToken } = getJiraEnvVars();
+
+  try {
     await axios.put(
-        `${jiraHost}rest/api/3/issue/${issueId}/properties/${checklistProperty}`,
-        checklistsJson,
-        {
+      `${jiraHost}rest/api/3/issue/${issueId}/properties/${checklistProperty}`,
+      checklistsJson,
+      {
         auth: {
-            username: jiraUserName,
-            password: jiraApiToken,
-        }
-    },
+          username: jiraUserName,
+          password: jiraApiToken,
+        },
+      },
     );
-    core.debug(`Added checklists successfully`)
-    } catch (error) {
-        core.error(`Failed to add checklists to issue ${issueId}: ${error}`)
-        throw error
-    }
+    core.debug(`Added checklists successfully`);
+  } catch (error) {
+    core.error(`Failed to add checklists to issue ${issueId}: ${error}`);
+    throw error;
   }
+}
 
-  /**
-   * Reads all checklists created with the plugin "Multiple checklists for Jira" and returns them as JSON.
-   * This JSON can be used as-is to add these checklists to another issue. It's meant to be used in tandem
-   * with `addChecklistsToIssue()`.
-   *
-   * This function sends a GET request to the Jira API to fetch the checklists from the specified issue.
-   * It logs the process and handles any errors that may occur during the operation.
-   *
-   * @param issueId - The Jira issue ID (not key) of the issue to check.
-   * @param checklistProperty - The name of the checklist property, usually in the format `sd-checklists-{N}`.
-   * @returns A promise that resolves to a JSON object containing the checklists.
-   * @throws Will throw an error if the operation to fetch checklists fails or if the response has unexpected content.
-   */
-  export async function getChecklistJSONFromIssue(issueId: string, checklistProperty: string): Promise<object> {
-    core.debug(`Fetching all checklists from issue ${issueId}`)
-    const { jiraHost, jiraUserName, jiraApiToken } = getJiraEnvVars();
+/**
+ * Reads all checklists created with the plugin "Multiple checklists for Jira" and returns them as JSON.
+ * This JSON can be used as-is to add these checklists to another issue. It's meant to be used in tandem
+ * with `addChecklistsToIssue()`.
+ *
+ * This function sends a GET request to the Jira API to fetch the checklists from the specified issue.
+ * It logs the process and handles any errors that may occur during the operation.
+ *
+ * @param issueId - The Jira issue ID (not key) of the issue to check.
+ * @param checklistProperty - The name of the checklist property, usually in the format `sd-checklists-{N}`.
+ * @returns A promise that resolves to a JSON object containing the checklists.
+ * @throws Will throw an error if the operation to fetch checklists fails or if the response has unexpected content.
+ */
+export async function getChecklistJSONFromIssue(
+  issueId: string,
+  checklistProperty: string,
+): Promise<object> {
+  core.debug(`Fetching all checklists from issue ${issueId}`);
+  const { jiraHost, jiraUserName, jiraApiToken } = getJiraEnvVars();
 
-    try {
-        const response = await axios.get(
-          `${jiraHost}rest/api/3/issue/${issueId}/properties/${checklistProperty}`,
-          {
-            auth: {
-              username: jiraUserName,
-              password: jiraApiToken,
-            },
-          }
-        );
+  try {
+    const response = await axios.get(
+      `${jiraHost}rest/api/3/issue/${issueId}/properties/${checklistProperty}`,
+      {
+        auth: {
+          username: jiraUserName,
+          password: jiraApiToken,
+        },
+      },
+    );
 
-        if (response.data.value?.checklists && response.data.value?.checklists instanceof Array) {
-            core.debug(`Found ${(response.data.value?.checklists as Array<unknown>).length} checklists`)
+    if (
+      response.data.value?.checklists &&
+      response.data.value?.checklists instanceof Array
+    ) {
+      core.debug(
+        `Found ${(response.data.value?.checklists as Array<unknown>).length} checklists`,
+      );
 
-            return response.data.value
-        }
-
-        throw new Error('Checklist response had unexpected content: ' + JSON.stringify(response.data))
-
-      } catch (error) {
-        core.error(`Error reading checklists from issue ${issueId}: ${error}`);
-
-        throw error
-      }
-  }
-
-  /**
-   * Queries Jira for open Solidity Review issues within a specified project.
-   *
-   * This function searches for issues within the given project that match the 'Initiative' issue type,
-   * contain 'Solidity Review' in their summary, and have an 'Open' status. It excludes any issue keys
-   * provided in the `issueKeysToIgnore` array and limits the number of results to 10.
-   *
-   * @param client - The Jira client instance used to perform the search.
-   * @param projectKey - The key of the project to search within.
-   * @param issueKeysToIgnore - An array of issue keys to exclude from the search results.
-   * @returns A promise that resolves to an array of issue keys that match the search criteria.
-   * @throws Will throw an error if the search operation fails.
-   */
-  async function getOpenSolidityReviewIssuesForProject(client: jira.Version3Client, projectKey: string, issueKeysToIgnore: string[]): Promise<string[]> {
-    //TODO: change 'Initiative' to 'Solidity Review' once it has been created
-    const issueKeys = await getIssueKeys(client, projectKey, 'Initiative', 'Solidity Review', 'Open', issueKeysToIgnore, 10)
-    core.info(`Found ${issueKeys.length} open Solidity Review issues for project ${projectKey}`)
-    return issueKeys
-  }
-
-  function extracProjectFromIssueKey(issueKey: string): string | undefined {
-    const pattern = /([A-Z]{2,})-\d+/
-
-    const match = issueKey.toUpperCase().match(pattern);
-    const projectExtracted = match ? match[1] : undefined
-
-    core.debug(`Extracted following project '${projectExtracted}' from issue '${issueKey}'`)
-
-    return projectExtracted
-  }
-
-  /**
-   * Reads Jira issue key of Solidity Review blueprint.
-   *
-   * This function retrieves the issue key from the environment variable `SOLIDITY_REVIEW_TEMPLATE_KEY`.
-   * The issue key is used as a blueprint for creating new Solidity Review issues.
-   *
-   * @returns {string} The key of the issue that will be used as a blueprint for creating new Solidity Review issues.
-   * @throws {Error} If the `SOLIDITY_REVIEW_TEMPLATE_KEY` environment variable is not set or is empty.
-   */
-  function readSolidityReviewTemplateKey(): string {
-    const issueKey = process.env.SOLIDITY_REVIEW_TEMPLATE_KEY;
-    if (!issueKey) {
-      throw Error("Missing required environment variable SOLIDITY_REVIEW_TEMPLATE_KEY");
+      return response.data.value;
     }
 
-    return issueKey
+    throw new Error(
+      "Checklist response had unexpected content: " +
+        JSON.stringify(response.data),
+    );
+  } catch (error) {
+    core.error(`Error reading checklists from issue ${issueId}: ${error}`);
+
+    throw error;
+  }
+}
+
+/**
+ * Queries Jira for open Solidity Review issues within a specified project.
+ *
+ * This function searches for issues within the given project that match the 'Initiative' issue type,
+ * contain 'Solidity Review' in their summary, and have an 'Open' status. It excludes any issue keys
+ * provided in the `issueKeysToIgnore` array and limits the number of results to 10.
+ *
+ * @param client - The Jira client instance used to perform the search.
+ * @param projectKey - The key of the project to search within.
+ * @param issueKeysToIgnore - An array of issue keys to exclude from the search results.
+ * @returns A promise that resolves to an array of issue keys that match the search criteria.
+ * @throws Will throw an error if the search operation fails.
+ */
+async function getOpenSolidityReviewIssuesForProject(
+  client: jira.Version3Client,
+  projectKey: string,
+  issueKeysToIgnore: string[],
+): Promise<string[]> {
+  //TODO: change 'Initiative' to 'Solidity Review' once it has been created
+  const issueKeys = await getIssueKeys(
+    client,
+    projectKey,
+    "Initiative",
+    "Solidity Review",
+    "Open",
+    issueKeysToIgnore,
+    10,
+  );
+  core.info(
+    `Found ${issueKeys.length} open Solidity Review issues for project ${projectKey}`,
+  );
+  return issueKeys;
+}
+
+function extracProjectFromIssueKey(issueKey: string): string | undefined {
+  const pattern = /([A-Z]{2,})-\d+/;
+
+  const match = issueKey.toUpperCase().match(pattern);
+  const projectExtracted = match ? match[1] : undefined;
+
+  core.debug(
+    `Extracted following project '${projectExtracted}' from issue '${issueKey}'`,
+  );
+
+  return projectExtracted;
+}
+
+/**
+ * Reads Jira issue key of Solidity Review blueprint.
+ *
+ * This function retrieves the issue key from the environment variable `SOLIDITY_REVIEW_TEMPLATE_KEY`.
+ * The issue key is used as a blueprint for creating new Solidity Review issues.
+ *
+ * @returns {string} The key of the issue that will be used as a blueprint for creating new Solidity Review issues.
+ * @throws {Error} If the `SOLIDITY_REVIEW_TEMPLATE_KEY` environment variable is not set or is empty.
+ */
+function readSolidityReviewTemplateKey(): string {
+  const issueKey = process.env.SOLIDITY_REVIEW_TEMPLATE_KEY;
+  if (!issueKey) {
+    throw Error(
+      "Missing required environment variable SOLIDITY_REVIEW_TEMPLATE_KEY",
+    );
   }
 
-  /**
-   * Exports Jira issue keys to GitHub environment variables if the `EXPORT_JIRA_ISSUE_KEYS` environment variable is set to 'true'.
-   *
-   * This function checks if the `EXPORT_JIRA_ISSUE_KEYS` environment variable is set to 'true'. If it is, it exports the provided
-   * Jira issue keys to the GitHub environment by appending them to the `GITHUB_ENV` file. The environment variables used are
-   * `PR_JIRA_ISSUE_KEY` for the pull request issue key and `SOLIDITY_REVIEW_ISSUE_KEY` for the Solidity review issue key.
-   *
-   * @param prIssueKey - The Jira issue key representing the pull request.
-   * @param solidityReviewIssueKey - The Jira issue key representing the Solidity review.
-   */
-  function exportIssueKeysToGithubEnv(prIssueKey: string, solidityReviewIssueKey: string) {
-    const shouldExport = process.env.EXPORT_JIRA_ISSUE_KEYS;
-    if (!shouldExport || shouldExport !== 'true' ) {
-      return
+  return issueKey;
+}
+
+/**
+ * Exports Jira issue keys to GitHub environment variables if the `EXPORT_JIRA_ISSUE_KEYS` environment variable is set to 'true'.
+ *
+ * This function checks if the `EXPORT_JIRA_ISSUE_KEYS` environment variable is set to 'true'. If it is, it exports the provided
+ * Jira issue keys to the GitHub environment by appending them to the `GITHUB_ENV` file. The environment variables used are
+ * `PR_JIRA_ISSUE_KEY` for the pull request issue key and `SOLIDITY_REVIEW_ISSUE_KEY` for the Solidity review issue key.
+ *
+ * @param prIssueKey - The Jira issue key representing the pull request.
+ * @param solidityReviewIssueKey - The Jira issue key representing the Solidity review.
+ */
+function exportIssueKeysToGithubEnv(
+  prIssueKey: string,
+  solidityReviewIssueKey: string,
+) {
+  const shouldExport = process.env.EXPORT_JIRA_ISSUE_KEYS;
+  if (!shouldExport || shouldExport !== "true") {
+    return;
+  }
+
+  const prIssueKeyEnvVar = "PR_JIRA_ISSUE_KEY";
+  const solidityReviewIssueKeyEnvVar = "SOLIDITY_REVIEW_JIRA_ISSUE_KEY";
+
+  fs.appendFileSync(
+    process.env.GITHUB_ENV ?? "",
+    `${prIssueKeyEnvVar}=${prIssueKey}\n`,
+  );
+  fs.appendFileSync(
+    process.env.GITHUB_ENV ?? "",
+    `${solidityReviewIssueKeyEnvVar}=${solidityReviewIssueKey}\n`,
+  );
+
+  core.info(
+    `Exported Jira issue key representing the PR as ${prIssueKeyEnvVar} env var`,
+  );
+  core.info(
+    `Exported Jira issue key representing the Solidity Review as ${solidityReviewIssueKeyEnvVar} env var`,
+  );
+}
+
+async function run() {
+  try {
+    await main();
+  } catch (error) {
+    if (error instanceof Error) {
+      return core.setFailed(error.message);
     }
-
-    const prIssueKeyEnvVar = 'PR_JIRA_ISSUE_KEY'
-    const solidityReviewIssueKeyEnvVar = 'SOLIDITY_REVIEW_JIRA_ISSUE_KEY'
-
-    fs.appendFileSync(process.env.GITHUB_ENV ?? '', `${prIssueKeyEnvVar}=${prIssueKey}\n`);
-    fs.appendFileSync(process.env.GITHUB_ENV ?? '', `${solidityReviewIssueKeyEnvVar}=${solidityReviewIssueKey}\n`);
-
-    core.info(`Exported Jira issue key representing the PR as ${prIssueKeyEnvVar} env var`)
-    core.info(`Exported Jira issue key representing the Solidity Review as ${solidityReviewIssueKeyEnvVar} env var`)
+    core.setFailed(error as any);
   }
+}
 
-  async function run() {
-    try {
-      await main();
-    } catch (error) {
-      if (error instanceof Error) {
-        return core.setFailed(error.message);
-      }
-      core.setFailed(error as any);
-    }
-  }
-
-  run();
+run();

--- a/libs/jira-tracing/lib.test.ts
+++ b/libs/jira-tracing/lib.test.ts
@@ -5,54 +5,87 @@ import {
   getGitTopLevel,
   parseIssueNumberFrom,
   tagsToLabels,
+  EMPTY_PREFIX, SOLIDITY_REVIEW_PREFIX
 } from "./lib";
 import * as core from "@actions/core";
 
 describe("parseIssueNumberFrom", () => {
   it("should return the first JIRA issue number found", () => {
-    let r = parseIssueNumberFrom("CORE-123", "CORE-456", "CORE-789");
+    let r = parseIssueNumberFrom(EMPTY_PREFIX, "CORE-123", "CORE-456", "CORE-789");
     expect(r).to.equal("CORE-123");
 
     r = parseIssueNumberFrom(
-      "2f3df5gf",
+        EMPTY_PREFIX,
       "chore/test-RE-78-branch",
-      "RE-78 Create new test branches",
+      "RE-78 Create new test branches"
     );
     expect(r).to.equal("RE-78");
 
     // handle lower case
-    r = parseIssueNumberFrom("core-123", "CORE-456", "CORE-789");
+    r = parseIssueNumberFrom(EMPTY_PREFIX, "core-123", "CORE-456", "CORE-789");
     expect(r).to.equal("CORE-123");
   });
 
   it("works with multiline commit bodies", () => {
-    const r = parseIssueNumberFrom(
+    let r = parseIssueNumberFrom(
+        EMPTY_PREFIX,
       `This is a multiline commit body
 
 CORE-1011`,
       "CORE-456",
-      "CORE-789",
+      "CORE-789"
+    );
+    expect(r).to.equal("CORE-1011");
+
+    r = parseIssueNumberFrom(
+        SOLIDITY_REVIEW_PREFIX,
+        `This is a multiline commit body with prefix
+
+${SOLIDITY_REVIEW_PREFIX}CORE-1011`,
+        "CORE-456",
+        "CORE-789"
+    );
+    expect(r).to.equal("CORE-1011");
+
+    r = parseIssueNumberFrom(
+        SOLIDITY_REVIEW_PREFIX,
+        `This is a multiline commit body with prefix
+
+CORE-111,
+${SOLIDITY_REVIEW_PREFIX}CORE-1011`,
+        "CORE-456",
+        "CORE-789"
     );
     expect(r).to.equal("CORE-1011");
   });
 
   it("should return undefined if no JIRA issue number is found", () => {
-    const result = parseIssueNumberFrom("No issue number");
+    const result = parseIssueNumberFrom(EMPTY_PREFIX, "No issue number");
     expect(result).to.be.undefined;
   });
 
   it("works when the label is in the middle of the commit message", () => {
     let r = parseIssueNumberFrom(
+        EMPTY_PREFIX,
       "This is a commit message with CORE-123 in the middle",
       "CORE-456",
-      "CORE-789",
+      "CORE-789"
     );
     expect(r).to.equal("CORE-123");
 
     r = parseIssueNumberFrom(
-      "#internal address security vulnerabilities RE-2917 around updating nodes and node operators on capabilities registry",
+        EMPTY_PREFIX,
+      "#internal address security vulnerabilities RE-2917 around updating nodes and node operators on capabilities registry"
     );
     expect(r).to.equal("RE-2917");
+  });
+
+  it("work also with a prefix", () => {
+    let r = parseIssueNumberFrom("PR: ", "PR: RE-78 Create new test branches");
+    expect(r).to.equal("RE-78");
+
+    r = parseIssueNumberFrom("PR: ", "RE-99, PR: RE-78 Create new test branches");
+    expect(r).to.equal("RE-78");
   });
 });
 
@@ -83,10 +116,10 @@ describe("getGitTopLevel", () => {
     await getGitTopLevel();
 
     expect(mockExecPromise).toHaveBeenCalledWith(
-      "git rev-parse --show-toplevel",
+      "git rev-parse --show-toplevel"
     );
     expect(mockConsoleLog).toHaveBeenCalledWith(
-      "Top-level directory: /path/to/top-level-dir",
+      "Top-level directory: /path/to/top-level-dir"
     );
   });
 
@@ -99,10 +132,10 @@ describe("getGitTopLevel", () => {
     await getGitTopLevel().catch(() => {});
 
     expect(mockExecPromise).toHaveBeenCalledWith(
-      "git rev-parse --show-toplevel",
+      "git rev-parse --show-toplevel"
     );
     expect(mockConsoleError).toHaveBeenCalledWith(
-      "Error executing command: Command failed",
+      "Error executing command: Command failed"
     );
   });
 
@@ -116,10 +149,10 @@ describe("getGitTopLevel", () => {
     await getGitTopLevel().catch(() => {});
 
     expect(mockExecPromise).toHaveBeenCalledWith(
-      "git rev-parse --show-toplevel",
+      "git rev-parse --show-toplevel"
     );
     expect(mockConsoleError).toHaveBeenCalledWith(
-      "Error in command output: Error: Command failed",
+      "Error in command output: Error: Command failed"
     );
   });
 });
@@ -129,10 +162,10 @@ describe("generateJiraIssuesLink", () => {
     expect(
       generateJiraIssuesLink(
         "https://smartcontract-it.atlassian.net/issues/",
-        "review-artifacts-automation-base:0de9b3b-head:e5b3b9d",
-      ),
+        "review-artifacts-automation-base:0de9b3b-head:e5b3b9d"
+      )
     ).toMatchInlineSnapshot(
-      `"https://smartcontract-it.atlassian.net/issues/?jql=labels+%3D+%22review-artifacts-automation-base%3A0de9b3b-head%3Ae5b3b9d%22"`,
+      `"https://smartcontract-it.atlassian.net/issues/?jql=labels+%3D+%22review-artifacts-automation-base%3A0de9b3b-head%3Ae5b3b9d%22"`
     );
   });
 });
@@ -143,7 +176,7 @@ describe("generateIssueLabel", () => {
     const baseRef = "0de9b3b";
     const headRef = "e5b3b9d";
     expect(generateIssueLabel(product, baseRef, headRef)).toMatchInlineSnapshot(
-      `"review-artifacts-automation-base:0de9b3b-head:e5b3b9d"`,
+      `"review-artifacts-automation-base:0de9b3b-head:e5b3b9d"`
     );
   });
 });

--- a/libs/jira-tracing/lib.test.ts
+++ b/libs/jira-tracing/lib.test.ts
@@ -5,19 +5,25 @@ import {
   getGitTopLevel,
   parseIssueNumberFrom,
   tagsToLabels,
-  EMPTY_PREFIX, SOLIDITY_REVIEW_PREFIX
+  EMPTY_PREFIX,
+  SOLIDITY_REVIEW_PREFIX,
 } from "./lib";
 import * as core from "@actions/core";
 
 describe("parseIssueNumberFrom", () => {
   it("should return the first JIRA issue number found", () => {
-    let r = parseIssueNumberFrom(EMPTY_PREFIX, "CORE-123", "CORE-456", "CORE-789");
+    let r = parseIssueNumberFrom(
+      EMPTY_PREFIX,
+      "CORE-123",
+      "CORE-456",
+      "CORE-789",
+    );
     expect(r).to.equal("CORE-123");
 
     r = parseIssueNumberFrom(
-        EMPTY_PREFIX,
+      EMPTY_PREFIX,
       "chore/test-RE-78-branch",
-      "RE-78 Create new test branches"
+      "RE-78 Create new test branches",
     );
     expect(r).to.equal("RE-78");
 
@@ -28,33 +34,33 @@ describe("parseIssueNumberFrom", () => {
 
   it("works with multiline commit bodies", () => {
     let r = parseIssueNumberFrom(
-        EMPTY_PREFIX,
+      EMPTY_PREFIX,
       `This is a multiline commit body
 
 CORE-1011`,
       "CORE-456",
-      "CORE-789"
+      "CORE-789",
     );
     expect(r).to.equal("CORE-1011");
 
     r = parseIssueNumberFrom(
-        SOLIDITY_REVIEW_PREFIX,
-        `This is a multiline commit body with prefix
+      SOLIDITY_REVIEW_PREFIX,
+      `This is a multiline commit body with prefix
 
 ${SOLIDITY_REVIEW_PREFIX}CORE-1011`,
-        "CORE-456",
-        "CORE-789"
+      "CORE-456",
+      "CORE-789",
     );
     expect(r).to.equal("CORE-1011");
 
     r = parseIssueNumberFrom(
-        SOLIDITY_REVIEW_PREFIX,
-        `This is a multiline commit body with prefix
+      SOLIDITY_REVIEW_PREFIX,
+      `This is a multiline commit body with prefix
 
 CORE-111,
 ${SOLIDITY_REVIEW_PREFIX}CORE-1011`,
-        "CORE-456",
-        "CORE-789"
+      "CORE-456",
+      "CORE-789",
     );
     expect(r).to.equal("CORE-1011");
   });
@@ -66,16 +72,16 @@ ${SOLIDITY_REVIEW_PREFIX}CORE-1011`,
 
   it("works when the label is in the middle of the commit message", () => {
     let r = parseIssueNumberFrom(
-        EMPTY_PREFIX,
+      EMPTY_PREFIX,
       "This is a commit message with CORE-123 in the middle",
       "CORE-456",
-      "CORE-789"
+      "CORE-789",
     );
     expect(r).to.equal("CORE-123");
 
     r = parseIssueNumberFrom(
-        EMPTY_PREFIX,
-      "#internal address security vulnerabilities RE-2917 around updating nodes and node operators on capabilities registry"
+      EMPTY_PREFIX,
+      "#internal address security vulnerabilities RE-2917 around updating nodes and node operators on capabilities registry",
     );
     expect(r).to.equal("RE-2917");
   });
@@ -84,7 +90,10 @@ ${SOLIDITY_REVIEW_PREFIX}CORE-1011`,
     let r = parseIssueNumberFrom("PR: ", "PR: RE-78 Create new test branches");
     expect(r).to.equal("RE-78");
 
-    r = parseIssueNumberFrom("PR: ", "RE-99, PR: RE-78 Create new test branches");
+    r = parseIssueNumberFrom(
+      "PR: ",
+      "RE-99, PR: RE-78 Create new test branches",
+    );
     expect(r).to.equal("RE-78");
   });
 });
@@ -116,10 +125,10 @@ describe("getGitTopLevel", () => {
     await getGitTopLevel();
 
     expect(mockExecPromise).toHaveBeenCalledWith(
-      "git rev-parse --show-toplevel"
+      "git rev-parse --show-toplevel",
     );
     expect(mockConsoleLog).toHaveBeenCalledWith(
-      "Top-level directory: /path/to/top-level-dir"
+      "Top-level directory: /path/to/top-level-dir",
     );
   });
 
@@ -132,10 +141,10 @@ describe("getGitTopLevel", () => {
     await getGitTopLevel().catch(() => {});
 
     expect(mockExecPromise).toHaveBeenCalledWith(
-      "git rev-parse --show-toplevel"
+      "git rev-parse --show-toplevel",
     );
     expect(mockConsoleError).toHaveBeenCalledWith(
-      "Error executing command: Command failed"
+      "Error executing command: Command failed",
     );
   });
 
@@ -149,10 +158,10 @@ describe("getGitTopLevel", () => {
     await getGitTopLevel().catch(() => {});
 
     expect(mockExecPromise).toHaveBeenCalledWith(
-      "git rev-parse --show-toplevel"
+      "git rev-parse --show-toplevel",
     );
     expect(mockConsoleError).toHaveBeenCalledWith(
-      "Error in command output: Error: Command failed"
+      "Error in command output: Error: Command failed",
     );
   });
 });
@@ -162,10 +171,10 @@ describe("generateJiraIssuesLink", () => {
     expect(
       generateJiraIssuesLink(
         "https://smartcontract-it.atlassian.net/issues/",
-        "review-artifacts-automation-base:0de9b3b-head:e5b3b9d"
-      )
+        "review-artifacts-automation-base:0de9b3b-head:e5b3b9d",
+      ),
     ).toMatchInlineSnapshot(
-      `"https://smartcontract-it.atlassian.net/issues/?jql=labels+%3D+%22review-artifacts-automation-base%3A0de9b3b-head%3Ae5b3b9d%22"`
+      `"https://smartcontract-it.atlassian.net/issues/?jql=labels+%3D+%22review-artifacts-automation-base%3A0de9b3b-head%3Ae5b3b9d%22"`,
     );
   });
 });
@@ -176,7 +185,7 @@ describe("generateIssueLabel", () => {
     const baseRef = "0de9b3b";
     const headRef = "e5b3b9d";
     expect(generateIssueLabel(product, baseRef, headRef)).toMatchInlineSnapshot(
-      `"review-artifacts-automation-base:0de9b3b-head:e5b3b9d"`
+      `"review-artifacts-automation-base:0de9b3b-head:e5b3b9d"`,
     );
   });
 });

--- a/libs/jira-tracing/lib.ts
+++ b/libs/jira-tracing/lib.ts
@@ -68,6 +68,14 @@ export function generateIssueLabel(
 }
 
 export async function getGitTopLevel(): Promise<string> {
+  const gitTopLevelEnv = process.env.GIT_TOP_LEVEL_DIR;
+  if (gitTopLevelEnv) {
+    core.debug(
+      `GIT_TOP_LEVEL_DIR env var was set tu ${gitTopLevelEnv}. Will use it.`,
+    );
+    return gitTopLevelEnv;
+  }
+
   const execPromise = promisify(exec);
   try {
     const { stdout, stderr } = await execPromise(

--- a/libs/jira-tracing/lib.ts
+++ b/libs/jira-tracing/lib.ts
@@ -7,14 +7,14 @@ import { join } from "path";
 import { isAxiosError } from "axios";
 import { formatAxiosError } from "./axios";
 
-export const EMPTY_PREFIX = ""
-export const PR_PREFIX = "PR issue: "
-export const SOLIDITY_REVIEW_PREFIX = "Solidity Review issue: "
+export const EMPTY_PREFIX = "";
+export const PR_PREFIX = "PR issue: ";
+export const SOLIDITY_REVIEW_PREFIX = "Solidity Review issue: ";
 
 export async function doesIssueExist(
   client: jira.Version3Client,
   issueNumber: string,
-  dryRun: boolean
+  dryRun: boolean,
 ) {
   const payload = {
     issueIdOrKey: issueNumber,
@@ -32,18 +32,18 @@ export async function doesIssueExist(
      */
     const issue = await client.issues.getIssue(payload);
     core.debug(
-      `JIRA issue id:${issue.id} key: ${issue.key} found while querying for ${issueNumber}`
+      `JIRA issue id:${issue.id} key: ${issue.key} found while querying for ${issueNumber}`,
     );
     if (issue.key !== issueNumber) {
       core.error(
-        `JIRA issue key ${issueNumber} not found, but found issue key ${issue.key} instead. This can happen if the identifier doesn't match an issue, in which case a case-insensitive search and check for moved issues is performed. Make sure the issue key is correct.`
+        `JIRA issue key ${issueNumber} not found, but found issue key ${issue.key} instead. This can happen if the identifier doesn't match an issue, in which case a case-insensitive search and check for moved issues is performed. Make sure the issue key is correct.`,
       );
       return false;
     }
 
     return true;
   } catch (e) {
-    handleError(e)
+    handleError(e);
     return false;
   }
 }
@@ -62,7 +62,7 @@ export function generateJiraIssuesLink(baseUrl: string, label: string) {
 export function generateIssueLabel(
   product: string,
   baseRef: string,
-  headRef: string
+  headRef: string,
 ) {
   return `review-artifacts-${product}-base:${baseRef}-head:${headRef}`;
 }
@@ -71,7 +71,7 @@ export async function getGitTopLevel(): Promise<string> {
   const execPromise = promisify(exec);
   try {
     const { stdout, stderr } = await execPromise(
-      "git rev-parse --show-toplevel"
+      "git rev-parse --show-toplevel",
     );
 
     if (stderr) {
@@ -102,7 +102,7 @@ export function parseIssueNumberFrom(
   ...inputs: (string | undefined)[]
 ): string | undefined {
   function parse(str?: string) {
-    prefix = prefix.toUpperCase()
+    prefix = prefix.toUpperCase();
     const jiraIssueRegex = new RegExp(`${prefix}([A-Z]{2,}-\\d+)`);
 
     const match = str?.toUpperCase().match(jiraIssueRegex);
@@ -116,7 +116,10 @@ export function parseIssueNumberFrom(
   return parsed[0];
 }
 
-export async function extractJiraIssueNumbersFrom(prefix: string, filePaths: string[]) {
+export async function extractJiraIssueNumbersFrom(
+  prefix: string,
+  filePaths: string[],
+) {
   const issueNumbers: string[] = [];
   const gitTopLevel = await getGitTopLevel();
 
@@ -156,7 +159,7 @@ export function getJiraEnvVars() {
 
   if (!jiraHost || !jiraUserName || !jiraApiToken) {
     core.setFailed(
-      "Error: Missing required environment variables: JIRA_HOST and JIRA_USERNAME and JIRA_API_TOKEN."
+      "Error: Missing required environment variables: JIRA_HOST and JIRA_USERNAME and JIRA_API_TOKEN.",
     );
     process.exit(1);
   }

--- a/libs/jira-tracing/package.json
+++ b/libs/jira-tracing/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "issue:update": "tsx update-jira-issue.ts",
     "issue:enforce": "tsx enforce-jira-issue.ts",
+    "issue:enforce-solidity-review": "tsx enforce-jira-solidity-review.ts",
     "issue:traceability": "tsx create-jira-traceability.ts",
     "test": "vitest"
   },

--- a/libs/jira-tracing/update-jira-issue.ts
+++ b/libs/jira-tracing/update-jira-issue.ts
@@ -1,13 +1,13 @@
 import * as core from "@actions/core";
 import jira from "jira.js";
-import { tagsToLabels, createJiraClient, parseIssueNumberFrom } from "./lib";
+import { tagsToLabels, createJiraClient, parseIssueNumberFrom, EMPTY_PREFIX } from "./lib";
 
 function updateJiraIssue(
   client: jira.Version3Client,
   issueNumber: string,
   tags: string[],
   fixVersionName: string,
-  dryRun: boolean,
+  dryRun: boolean
 ) {
   const payload = {
     issueIdOrKey: issueNumber,
@@ -19,8 +19,8 @@ function updateJiraIssue(
 
   core.info(
     `Updating JIRA issue ${issueNumber} with fix version ${fixVersionName} and labels [${payload.update.labels.join(
-      ", ",
-    )}]`,
+      ", "
+    )}]`
   );
   if (dryRun) {
     core.info("Dry run enabled, skipping JIRA issue update");
@@ -43,7 +43,7 @@ async function main() {
   const client = createJiraClient();
 
   // Checks for the Jira issue number and exit if it can't find it
-  const issueNumber = parseIssueNumberFrom(prTitle, commitMessage, branchName);
+  const issueNumber = parseIssueNumberFrom(EMPTY_PREFIX, prTitle, commitMessage, branchName);
   if (!issueNumber) {
     const msg =
       "No JIRA issue number found in: PR title, commit message, or branch name. Please include the issue ID in one of these.";
@@ -69,7 +69,7 @@ async function run() {
       core.setFailed(error.message);
     }
     core.setFailed(
-      "Error: Failed to update JIRA issue with fix version and labels.",
+      "Error: Failed to update JIRA issue with fix version and labels."
     );
   }
 }

--- a/libs/jira-tracing/update-jira-issue.ts
+++ b/libs/jira-tracing/update-jira-issue.ts
@@ -1,13 +1,18 @@
 import * as core from "@actions/core";
 import jira from "jira.js";
-import { tagsToLabels, createJiraClient, parseIssueNumberFrom, EMPTY_PREFIX } from "./lib";
+import {
+  tagsToLabels,
+  createJiraClient,
+  parseIssueNumberFrom,
+  EMPTY_PREFIX,
+} from "./lib";
 
 function updateJiraIssue(
   client: jira.Version3Client,
   issueNumber: string,
   tags: string[],
   fixVersionName: string,
-  dryRun: boolean
+  dryRun: boolean,
 ) {
   const payload = {
     issueIdOrKey: issueNumber,
@@ -19,8 +24,8 @@ function updateJiraIssue(
 
   core.info(
     `Updating JIRA issue ${issueNumber} with fix version ${fixVersionName} and labels [${payload.update.labels.join(
-      ", "
-    )}]`
+      ", ",
+    )}]`,
   );
   if (dryRun) {
     core.info("Dry run enabled, skipping JIRA issue update");
@@ -43,7 +48,12 @@ async function main() {
   const client = createJiraClient();
 
   // Checks for the Jira issue number and exit if it can't find it
-  const issueNumber = parseIssueNumberFrom(EMPTY_PREFIX, prTitle, commitMessage, branchName);
+  const issueNumber = parseIssueNumberFrom(
+    EMPTY_PREFIX,
+    prTitle,
+    commitMessage,
+    branchName,
+  );
   if (!issueNumber) {
     const msg =
       "No JIRA issue number found in: PR title, commit message, or branch name. Please include the issue ID in one of these.";
@@ -69,7 +79,7 @@ async function run() {
       core.setFailed(error.message);
     }
     core.setFailed(
-      "Error: Failed to update JIRA issue with fix version and labels."
+      "Error: Failed to update JIRA issue with fix version and labels.",
     );
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,8 @@ importers:
 
   actions/cicd-build-publish-charts: {}
 
+  actions/cicd-build-publish-docker: {}
+
   actions/cicd-changesets: {}
 
   actions/cleanup-old-branches: {}
@@ -135,7 +137,25 @@ importers:
 
   actions/crib-purge-environment: {}
 
+  actions/ctf-build-image: {}
+
   actions/ctf-build-test-image: {}
+
+  actions/ctf-build-tests: {}
+
+  actions/ctf-check-mod-version: {}
+
+  actions/ctf-cleanup: {}
+
+  actions/ctf-run-tests: {}
+
+  actions/ctf-run-tests-binary: {}
+
+  actions/ctf-setup-go: {}
+
+  actions/ctf-setup-run-tests-environment: {}
+
+  actions/ctf-show-grafana-in-test-summary: {}
 
   actions/dispatch-workflow: {}
 


### PR DESCRIPTION
Context: https://smartcontract-it.atlassian.net/browse/TT-1624

This PR adds support for appending Solidity Review issue to changeset file after either linking it to existing issue or creating a new issue from template.

Opened instead of https://github.com/smartcontractkit/chainlink/pull/14417 (already reviewed by @scheibinger), because when I started to work on this ticket this `jira-tracing` lib was still part of the `chainlink` repo. So this PR basically migrates what was done in that PR to this repo.