### PR TITLE
[TT-1624] bump jira tracing version

### DIFF
--- a/.changeset/calm-fishes-accept.md
+++ b/.changeset/calm-fishes-accept.md
@@ -1,0 +1,5 @@
+---
+"jira-tracing": minor
+---
+
+Additional Jira tracing between PRs and Solidity Review issues

--- a/libs/jira-tracing/package.json
+++ b/libs/jira-tracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-tracing",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Updates Jira issue with release information like the version and tags for a PR.",
   "main": "update-jira-issue.js",
   "type": "module",

--- a/libs/jira-tracing/package.json
+++ b/libs/jira-tracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-tracing",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "description": "Updates Jira issue with release information like the version and tags for a PR.",
   "main": "update-jira-issue.js",
   "type": "module",


### PR DESCRIPTION
In https://github.com/smartcontractkit/.github/pull/627 I have not bumped `libs/jira-tracing` version and thus no new tag was created, when that PR was merged. Here I do bump it.