### PR TITLE
CRIB-304 modify crib-deploy-environment

### DIFF
--- a/.changeset/orange-sheep-move.md
+++ b/.changeset/orange-sheep-move.md
@@ -1,0 +1,6 @@
+---
+"crib-deploy-environment": major
+---
+
+Instead of using product name to run CRIB we will use the name of the Devspace
+command configured in the crib repo.

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -181,7 +181,7 @@ runs:
 
         nix develop -c ./cribbit.sh "$NAMESPACE"
 
-        nix develop -c devspace ${{ inputs.command }} ${{ inputs.command-args }}
+        nix develop -c devspace run ${{ inputs.command }} ${{ inputs.command-args }}
     - name: Render notification template
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       id: render-slack-template

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -17,12 +17,6 @@ inputs:
     default: "0.0.0.0/0"
     description: "DevSpace ingress CIDRs."
     required: false
-  devspace-profiles:
-    default: ""
-    description: |
-      "Comma-separated list of DevSpace profiles to apply when running DevSpace commands.
-      Example: ci,values-dev-simulated-core-ocr1."
-    required: false
   ecr-private-registry:
     default: ""
     description:
@@ -46,9 +40,13 @@ inputs:
       "Namespace TTL, which defines how long a namespace will remain alive after
       creation."
     required: false
-  product:
+  command:
     default: "core"
-    description: "The name of the product (e.g., core, ccip)."
+    description: "The devspace command to run."
+    required: false
+  command-args:
+    default: "--skip-build"
+    description: "The arguments to pass to the devspace command."
     required: false
   product-image:
     required: false
@@ -82,20 +80,6 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Validate Inputs
-      shell: bash
-      run: |
-        # Validate product input
-        case "${{ inputs.product }}" in
-          "core"|"ccip")
-            echo "Product input is valid: ${{ inputs.product }}"
-            ;;
-          *)
-            echo "Invalid product input: ${{ inputs.product }}. Must be 'core' or 'ccip'."
-            exit 1
-            ;;
-        esac
-
     - name: Setup GAP
       uses: smartcontractkit/.github/actions/setup-gap@d316f66b2990ea4daa479daa3de6fc92b00f863e # setup-gap@0.3.2
       with:
@@ -171,8 +155,7 @@ runs:
         kubectl get namespace $NAMESPACE --show-labels
 
     - name: Deploy to CRIB ephemeral environment
-      working-directory:
-        ${{ github.workspace }}/crib/deployments/${{ inputs.product }}
+      working-directory: ${{ github.workspace }}/crib/deployments/chainlink
       shell: bash
       env:
         CHAINLINK_CODE_DIR: "../"
@@ -196,27 +179,9 @@ runs:
         # Kyverno needs some time to inject the RoleBinding
         sleep 3
 
-        # Check if product is ccip and set ATLAS_ENABLED and CCIP_UI_ENABLED accordingly
-        if [[ "${{ inputs.product }}" == "ccip" ]]; then
-          export ATLAS_ENABLED=true
-          export CCIP_UI_ENABLED=true
-        fi
-
         nix develop -c ./cribbit.sh "$NAMESPACE"
 
-        profile_args_array=()
-        if [[ -n "$PROFILES" ]]; then
-          # Convert comma-separated string to array
-          IFS=',' read -r -a profiles_array <<< "$PROFILES"
-
-          for profile in "${profiles_array[@]}"; do
-            profile_args_array+=("-p")
-            profile_args_array+=("$profile")
-          done
-          echo "running devspace with profile args: ${profile_args_array[@]}"
-        fi
-
-        nix develop -c devspace deploy --skip-build -o=${{ inputs.product-image-tag }} "${profile_args_array[@]}"
+        nix develop -c devspace ${{ inputs.command }} ${{ inputs.command-args }}
     - name: Render notification template
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       id: render-slack-template
@@ -234,7 +199,7 @@ runs:
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": ":red_circle: *Failed to provision CRIB environment for ${{ inputs.product }}*"
+                  "text": ":red_circle: *Failed to provision CRIB environment for ${{ inputs.command}}*"
                 }
               },
               {

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -163,6 +163,7 @@ runs:
         CRIB_SKIP_DOCKER_ECR_LOGIN: true
         CRIB_SKIP_HELM_ECR_LOGIN: true
         DEVSPACE_IMAGE: "${{inputs.product-image}}"
+        DEVSPACE_IMAGE_TAG: "${{inputs.product-image-tag}}"
         DEVSPACE_INGRESS_BASE_DOMAIN: ${{ inputs.ingress-base-domain }}
         DEVSPACE_INGRESS_CIDRS: ${{ inputs.devspace-ingress-cidrs }}
         PROFILES: ${{ inputs.devspace-profiles }}


### PR DESCRIPTION
# Update `crib-deploy-environment` Action to Use DevSpace Commands
## Overview
This PR updates the `crib-deploy-environment` GitHub Action to enhance flexibility and align it with the recent structural changes in the CRIB repository. Instead of using the `product` name to run CRIB deployments, the action now utilizes the name of the DevSpace command configured in the CRIB repo.

## Key Changes
* Removed `product` Input: The `product` input, which previously accepted values like `core` or `ccip`, has been replaced.

* Introduced `command` and `command-args` Inputs:

  * `command`: Specifies the DevSpace command to run (default: `core`).
  *` command-args`: Allows passing additional arguments to the DevSpace command (default: `--skip-build`).
Removed `devspace-profiles` Input: Profiles are now managed within the DevSpace configurations, eliminating the need for this input.

* Updated Working Directory: Changed the working directory from `crib/deployments/${{ inputs.product }}` to a fixed path: `crib/deployments/chainlink`, reflecting the new consolidated directory.

* Simplified Deployment Command: The action now runs deployments using:
```
nix develop -c devspace run ${{ inputs.command }} ${{ inputs.command-args }}
```
This replaces the previous complex command that handled profiles and image tags.

* Eliminated Input Validation Step: Removed the step that validated the product input since it's no longer required.

* Updated Environment Variables:
  * Added `DEVSPACE_IMAGE_TAG` to pass the image tag.
  * Removed variables related to profiles and conditional logic based on the `product`.
* Modified Slack Notifications: Adjusted the Slack notification template to use the `command` input instead of `product`.

## Notes
* Breaking Change: This update introduces a major version change for the `crib-deploy-environment` action due to the modifications in inputs and behavior.

* Migration Required: Users of this action will need to update their workflows to replace the `product` and `devspace-profiles` inputs with the new `command` and `command-args` inputs.

Before:
```
- name: Deploy to CRIB
  uses: smartcontractkit/.github/actions/crib-deploy-environment@v1
  with:
    product: "ccip"
    devspace-profiles: "ci"
    product-image: "your-image"
    product-image-tag: "your-tag"
```

After:
```
- name: Deploy to CRIB
  uses: smartcontractkit/.github/actions/crib-deploy-environment@v2
  with:
    command: "ccip"
    command-args: "--skip-build"
    product-image: "your-image"
    product-image-tag: "your-tag"
```

## References
CRIB Repository PR: [Merge /deployments/core and /deployments/ccip into /deployments/chainlink and Reorganize Dependencies](https://github.com/smartcontractkit/crib/pull/179)