### PR TITLE
fix: annotations, version comment edge case

### DIFF
--- a/.changeset/early-buses-give.md
+++ b/.changeset/early-buses-give.md
@@ -1,0 +1,5 @@
+---
+"gha-workflow-validator": patch
+---
+
+fix: small bugfix with logging and version comment errors

--- a/actions/gha-workflow-validator/src/__tests__/__snapshots__/action-reference-validation.test.ts.snap
+++ b/actions/gha-workflow-validator/src/__tests__/__snapshots__/action-reference-validation.test.ts.snap
@@ -1,0 +1,61 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ActionReferenceValidation > should invalidate action reference (sha-ref / no comment) 1`] = `
+[
+  {
+    "message": "No version comment found",
+    "severity": "warning",
+    "type": "version-comment",
+  },
+]
+`;
+
+exports[`ActionReferenceValidation > should invalidate single action reference (all errors) 1`] = `
+[
+  {
+    "message": "v2.11.0 is not a valid SHA reference",
+    "severity": "error",
+    "type": "sha-ref",
+  },
+  {
+    "message": "No version comment found",
+    "severity": "warning",
+    "type": "version-comment",
+  },
+  {
+    "message": "Action is using node16",
+    "severity": "warning",
+    "type": "node-version",
+  },
+]
+`;
+
+exports[`ActionReferenceValidation > should invalidate single action reference (bad sha ref) 1`] = `
+[
+  {
+    "message": "v3.0.2 is not a valid SHA reference",
+    "severity": "error",
+    "type": "sha-ref",
+  },
+]
+`;
+
+exports[`ActionReferenceValidation > should invalidate single action reference (no version comment) 1`] = `
+[
+  {
+    "message": "No version comment found",
+    "severity": "warning",
+    "type": "version-comment",
+  },
+]
+`;
+
+exports[`ActionReferenceValidation > should invalidate single action reference (node16) 1`] = `
+[
+  {
+    "message": "Action is using node16",
+    "severity": "warning",
+    "type": "node-version",
+  },
+]
+`;

--- a/actions/gha-workflow-validator/src/output.ts
+++ b/actions/gha-workflow-validator/src/output.ts
@@ -10,7 +10,7 @@ import {
 } from "./validations/validation-check.js";
 import { FIXING_ERRORS, htmlLink } from "./strings";
 
-export function logErrors(
+export function logValidationMessages(
   validationResults: FileValidationResult[],
   annotatePR: boolean = false,
 ) {


### PR DESCRIPTION
### Changes

1. Changed logging/annotation ordering so warnings + summary are still logged before exiting
2. Updated `version-comment` action reference errors, and the logic for "trusted" actions
	* If an action ref is trusted, a `version-comment` error will still appear if they used a `sha` ref

---

https://smartcontract-it.atlassian.net/browse/RE-2963

 	