### PR TITLE
fix: parse quoted action references properly

### DIFF
--- a/.changeset/shaggy-coats-joke.md
+++ b/.changeset/shaggy-coats-joke.md
@@ -1,0 +1,5 @@
+---
+"gha-workflow-validator": patch
+---
+
+fix: bug when parsing action references wrapped in quotes

--- a/actions/gha-workflow-validator/dist/index.js
+++ b/actions/gha-workflow-validator/dist/index.js
@@ -24188,7 +24188,9 @@ function extractActionReferenceFromLine(line) {
     const searchQuote = isDoubleQuoted ? `"` : `'`;
     const indexOfQuote = actionIdentifier.indexOf(`${searchQuote}`);
     if (indexOfQuote === -1 || indexOfQuote !== actionIdentifier.length - 1) {
-      core3.warning("Invalid action reference - unmatched/misplaced quote (skipping): " + line);
+      core3.warning(
+        "Invalid action reference - unmatched/misplaced quote (skipping): " + line
+      );
       return;
     } else {
       actionIdentifier = actionIdentifier.substring(0, indexOfQuote);

--- a/actions/gha-workflow-validator/dist/index.js
+++ b/actions/gha-workflow-validator/dist/index.js
@@ -24180,10 +24180,23 @@ function extractActionReferenceFromLine(line) {
     return;
   }
   const trimmedUses = line.substring(line.indexOf(trimSubString) + trimSubString.length).trim();
-  if (trimmedUses.startsWith("./")) {
+  let [actionIdentifier, ...comment] = trimmedUses.split("#");
+  const isDoubleQuoted = actionIdentifier.startsWith(`"`);
+  const isSingleQuoted = actionIdentifier.startsWith(`'`);
+  if (isDoubleQuoted || isSingleQuoted) {
+    actionIdentifier = actionIdentifier.substring(1).trim();
+    const searchQuote = isDoubleQuoted ? `"` : `'`;
+    const indexOfQuote = actionIdentifier.indexOf(`${searchQuote}`);
+    if (indexOfQuote === -1 || indexOfQuote !== actionIdentifier.length - 1) {
+      core3.warning("Invalid action reference - unmatched/misplaced quote (skipping): " + line);
+      return;
+    } else {
+      actionIdentifier = actionIdentifier.substring(0, indexOfQuote);
+    }
+  }
+  if (actionIdentifier.startsWith("./")) {
     return;
   }
-  const [actionIdentifier, ...comment] = trimmedUses.split("#");
   const [identifier, gitRef] = actionIdentifier.trim().split("@");
   const [owner, repo, ...path] = identifier.split("/");
   const repoPath = (path.length > 0 ? "/" : "") + path.join("/");

--- a/actions/gha-workflow-validator/src/__tests__/action-reference-validation.test.ts
+++ b/actions/gha-workflow-validator/src/__tests__/action-reference-validation.test.ts
@@ -334,7 +334,37 @@ describe(extractActionReferenceFromLine.name, () => {
   });
 
   it("parses local reference as no reference", () => {
-    const line = "-      uses: ./.github/actions/local-action";
+    const line = "-      uses: ./.github/actions/local-action # comment";
+    const actionReference = extractActionReferenceFromLine(line);
+    expect(actionReference).toBeUndefined();
+  });
+
+  it("parses local reference as no reference (with single quotes)", () => {
+    const line = "-      uses: './.github/actions/local-action' # comment";
+    const actionReference = extractActionReferenceFromLine(line);
+    expect(actionReference).toBeUndefined();
+  });
+
+  it("parses local reference as no reference (with double quotes)", () => {
+    const line = '-      uses: "./.github/actions/local-action" # comment';
+    const actionReference = extractActionReferenceFromLine(line);
+    expect(actionReference).toBeUndefined();
+  });
+
+  it("parses invalid reference as no reference (unmatched quote)", () => {
+    const line = '-      uses: "./.github/actions/local-action # comment';
+    const actionReference = extractActionReferenceFromLine(line);
+    expect(actionReference).toBeUndefined();
+  });
+
+  it("parses invalid reference as no reference (unmatched quote 2)", () => {
+    const line = "-      uses: \"./.github/actions/local-action' # comment";
+    const actionReference = extractActionReferenceFromLine(line);
+    expect(actionReference).toBeUndefined();
+  });
+
+  it("parses invalid reference as no reference (misplaced quotes)", () => {
+    const line = '-      uses: "./.github/actions/"local-action # comment';
     const actionReference = extractActionReferenceFromLine(line);
     expect(actionReference).toBeUndefined();
   });

--- a/actions/gha-workflow-validator/src/__tests__/action-reference-validation.test.ts
+++ b/actions/gha-workflow-validator/src/__tests__/action-reference-validation.test.ts
@@ -287,8 +287,39 @@ describe(extractActionReferenceFromLine.name, () => {
     });
   });
 
+  it("extracts action reference (quoted / trusted)", () => {
+    const line =
+      '        - uses: "smartcontractkit/.github/actions/foo@bar" # foo@1.0.0';
+    const actionReference = extractActionReferenceFromLine(line);
+
+    expect(actionReference).toEqual({
+      owner: "smartcontractkit",
+      repo: ".github",
+      repoPath: "/actions/foo",
+      ref: "bar",
+      comment: "foo@1.0.0",
+      isWorkflowFile: false,
+      trusted: true,
+    });
+  });
+
   it("extracts action reference (untrusted)", () => {
     const line = "        - uses: dorny/paths-filter@bar # v1.0.0";
+    const actionReference = extractActionReferenceFromLine(line);
+
+    expect(actionReference).toEqual({
+      owner: "dorny",
+      repo: "paths-filter",
+      repoPath: "",
+      ref: "bar",
+      comment: "v1.0.0",
+      isWorkflowFile: false,
+      trusted: false,
+    });
+  });
+
+  it("extracts action reference (quoted / untrusted)", () => {
+    const line = '        - uses: "dorny/paths-filter@bar" # v1.0.0';
     const actionReference = extractActionReferenceFromLine(line);
 
     expect(actionReference).toEqual({

--- a/actions/gha-workflow-validator/src/validations/action-reference-validations.ts
+++ b/actions/gha-workflow-validator/src/validations/action-reference-validations.ts
@@ -236,17 +236,38 @@ export function extractActionReferenceFromLine(
     return;
   }
 
-  // trim past the "uses:" substring to get "<owner>/<repo><optional path>@<ref> # <optional comment>""
+  // trim past the "uses:" substring to get "<owner>/<repo><optional path>@<ref> # <optional comment>"
   const trimmedUses = line
     .substring(line.indexOf(trimSubString) + trimSubString.length)
     .trim();
 
-  if (trimmedUses.startsWith("./")) {
+  let [actionIdentifier, ...comment] = trimmedUses.split("#");
+
+  // Check if the action reference is quoted
+  const isDoubleQuoted = actionIdentifier.startsWith(`"`);
+  const isSingleQuoted = actionIdentifier.startsWith(`'`);
+  if (isDoubleQuoted || isSingleQuoted) {
+    actionIdentifier = actionIdentifier.substring(1).trim();
+
+    const searchQuote = isDoubleQuoted ? `"` : `'`;
+    const indexOfQuote = actionIdentifier.indexOf(`${searchQuote}`);
+
+    if (indexOfQuote === -1 || indexOfQuote !== actionIdentifier.length - 1) {
+      core.warning(
+        "Invalid action reference - unmatched/misplaced quote (skipping): " +
+          line,
+      );
+      return;
+    } else {
+      actionIdentifier = actionIdentifier.substring(0, indexOfQuote);
+    }
+  }
+
+  if (actionIdentifier.startsWith("./")) {
     // Local action reference - do not extract or validate these.
     return;
   }
 
-  const [actionIdentifier, ...comment] = trimmedUses.split("#");
   const [identifier, gitRef] = actionIdentifier.trim().split("@");
   const [owner, repo, ...path] = identifier.split("/");
   const repoPath = (path.length > 0 ? "/" : "") + path.join("/");


### PR DESCRIPTION
A bug was found internally that broke parsing of local action references when the action reference's path was in quotes. This addresses this bug.

### Changes

- Fix parsing of actions when wrapped in quotes

### Testing

- Added unit tests

---

https://smartcontract-it.atlassian.net/browse/RE-2963
