### PR TITLE
RE-3058 Adding support for generating .tool-versions default file

### DIFF
--- a/.changeset/afraid-rings-wonder.md
+++ b/.changeset/afraid-rings-wonder.md
@@ -1,0 +1,5 @@
+---
+"ci-prettier": patch
+---
+
+Adding support for creating default .tool-versions file

--- a/actions/ci-prettier/action.yml
+++ b/actions/ci-prettier/action.yml
@@ -21,6 +21,11 @@ inputs:
     description: ""
     required: false
     default: ".tool-versions"
+  nodejs-version:
+    description:
+      "NodeJS version used only if the node-version-file isn't provided"
+    required: false
+    default: "^20.16.0"
   pnpm-version:
     description: ""
     required: false
@@ -53,6 +58,13 @@ runs:
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
+
+    - name: Create .tool-versions file if it doesn't exist
+      shell: bash
+      run: |
+        if [ ! -f "${{ inputs.node-version-file }}" ]; then
+          echo "nodejs ${{ inputs.nodejs-version }}" > ${{ inputs.node-version-file }}
+        fi
 
     - name: Setup nodejs
       uses: smartcontractkit/.github/actions/setup-nodejs@5b1046c28343660ecb84844c6fa95a66d1cdb52e # setup-nodejs@0.2.1


### PR DESCRIPTION
## What

RE-3058 Adding support for generating .tool-versions default file. 

## Why 

In order to avoid creating the [required file](https://github.com/smartcontractkit/.github/blob/ef7717407a45c59833fe792d6d767bc21d6d1def/actions/ci-prettier/action.yml#L60) in the main repo, I think it's easier just to generate it based on the version. This change doesn't affect existing approach. 