### PR TITLE
chore: update actions/* dependencies

### DIFF
--- a/.changeset/yellow-shrimps-trade.md
+++ b/.changeset/yellow-shrimps-trade.md
@@ -1,0 +1,44 @@
+---
+"cicd-build-publish-artifacts-go": patch
+"cicd-build-publish-artifacts-ts": patch
+"guard-from-missing-changesets": patch
+"policy-bot-config-validator": patch
+"cicd-build-publish-charts": patch
+"cicd-build-publish-docker": patch
+"llm-action-error-reporter": patch
+"crib-deploy-environment": patch
+"gha-workflow-validator": patch
+"guard-tag-from-branch": patch
+"cleanup-old-branches": patch
+"ctf-build-test-image": patch
+"ctf-run-tests-binary": patch
+"slack-notify-git-ref": patch
+"md-confluence-sync": patch
+"wait-for-workflows": patch
+"ci-benchmarking": patch
+"ci-sonarqube-go": patch
+"ci-sonarqube-ts": patch
+"cicd-changesets": patch
+"ctf-build-image": patch
+"ctf-build-tests": patch
+"ci-kubeconform": patch
+"ci-lint-charts": patch
+"setup-renovate": patch
+"update-actions": patch
+"ctf-run-tests": patch
+"llm-pr-writer": patch
+"go-mod-validator": patch
+"ci-lint-misc": patch
+"ctf-setup-go": patch
+"setup-golang": patch
+"setup-nodejs": patch
+"ci-prettier": patch
+"ci-test-sol": patch
+"ci-lint-go": patch
+"ci-lint-ts": patch
+"ci-test-go": patch
+"ci-test-ts": patch
+"nx-chainlink": patch
+---
+
+chore: bump actions/\* references to latest version

--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@v4.2.1
 
       - name: ci-lint
         uses: ./actions/ci-lint-ts
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@v4.2.1
 
       - name: ci-prettier
         uses: ./actions/ci-prettier
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@v4.2.1
 
       - name: ci-lint-misc
         uses: ./actions/ci-lint-misc
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@v4.2.1
         with:
           # Commit back any changes based on the commit that triggered this action
           # rather than merge commit of main into the PR branch
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@v4.2.1
 
       - name: Setup pnpm
         uses: ./actions/setup-nodejs
@@ -109,7 +109,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@v4.2.1
 
       - name: ci-test
         uses: ./actions/ci-test-ts
@@ -127,7 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@v4.2.1
 
       - name: ci-build-artifacts
         uses: ./actions/cicd-build-publish-artifacts-ts
@@ -145,7 +145,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@v4.2.1
 
       - name: Setup pnpm
         uses: ./actions/setup-nodejs
@@ -164,7 +164,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@v4.2.1
 
       - name: Setup pnpm
         uses: ./actions/setup-nodejs

--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -178,16 +178,3 @@ jobs:
       - name: Run unit tests for gha-workflow-validator
         shell: bash
         run: pnpm nx run gha-workflow-validator:test
-
-  validate-worfklow-changes:
-    permissions:
-      contents: read
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-      - name: GHA Workflow Validator
-        uses: smartcontractkit/.github/actions/gha-workflow-validator@d316f66b2990ea4daa479daa3de6fc92b00f863e # gha-workflow-validator@0.2.0
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          include-all-action-definitions: true

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@v4.2.1
 
       - name: ci-lint
         uses: ./actions/ci-lint-ts
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@v4.2.1
 
       - name: ci-prettier
         uses: ./actions/ci-prettier
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@v4.2.1
 
       - name: ci-test
         uses: ./actions/ci-test-ts
@@ -71,7 +71,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@v4.2.1
         with:
           fetch-depth: 0
 
@@ -95,7 +95,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@v4.2.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -284,13 +284,13 @@ jobs:
               image_versions="${{ github.sha }}"
             else
               image_versions+=",${{ github.sha }}"
-            fi            
+            fi
           fi
 
           # Convert the comma-separated string to a JSON array
           image_versions=$(echo "$image_versions" | jq -Rc 'if . == "" then "" else split(",") | if . == [""] then "" else . end end')
 
-          echo "Required Chainlink image versions: $image_versions"   
+          echo "Required Chainlink image versions: $image_versions"
           echo "versions=$image_versions" >> "$GITHUB_OUTPUT"
 
       - name: Create matrix for required Chainlink plugin versions
@@ -298,7 +298,7 @@ jobs:
         shell: bash
         run: |
           image_versions=$(echo "${{ inputs.require_chainlink_plugin_versions_in_qa_ecr }}" | jq -Rc 'if . == "" then "" else split(",") | if . == [""] then "" else . end end')
-          echo "Required Chainlink plugin image versions: $image_versions"   
+          echo "Required Chainlink plugin image versions: $image_versions"
           echo "versions=$image_versions" >> "$GITHUB_OUTPUT"
 
   check-test-configurations:
@@ -308,7 +308,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        uses: actions/checkout@v4.2.1
       - name: Install citool
         shell: bash
         run: go install
@@ -352,7 +352,7 @@ jobs:
       workflow_id: ${{ steps.gen_id.outputs.workflow_id }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        uses: actions/checkout@v4.2.1
       - name: Setup Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
@@ -456,7 +456,7 @@ jobs:
             echo "::error::Error: Some of the tests require custom test secrets to run. Please see workflow logs and set 'test_secrets_override_key' to run these tests."
             exit 1
           else
-            echo "No tests require secrets. Proceeding without additional secret setup."          
+            echo "No tests require secrets. Proceeding without additional secret setup."
           fi
 
       - name: Generate random workflow id
@@ -489,7 +489,7 @@ jobs:
           }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        uses: actions/checkout@v4.2.1
 
       - name: Get Chainlink image
         uses: ./.github/actions/build-chainlink-image
@@ -526,7 +526,7 @@ jobs:
           }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        uses: actions/checkout@v4.2.1
 
       - name: Get Chainlink plugins image
         uses: ./.github/actions/build-chainlink-image
@@ -587,7 +587,7 @@ jobs:
         continue-on-error: true
 
       - name: Checkout repository
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        uses: actions/checkout@v4.2.1
       - name: Install jq
         run: sudo apt-get install -y jq
 
@@ -825,7 +825,7 @@ jobs:
         }}.amazonaws.com/chainlink-tests
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        uses: actions/checkout@v4.2.1
       - name: Build Test Runner Image
         id: build-test-runner-image
         uses: smartcontractkit/.github/actions/ctf-build-test-image@a5e4f4c8fbb8e15ab2ad131552eca6ac83c4f4b3 # ctf-build-test-image@0.1.0
@@ -894,7 +894,7 @@ jobs:
         continue-on-error: true
 
       - name: Checkout repository
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        uses: actions/checkout@v4.2.1
       - name: Install jq
         run: sudo apt-get install -y jq
 

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -1032,7 +1032,7 @@ jobs:
       test_results: ${{ steps.set_test_results.outputs.results }}
     steps:
       - name: Download all test result artifacts
-        uses: actions/download-artifact@9c19ed7fe5d278cd354c7dfd5d3b88589c7e2395 # v4.1.6
+        uses: actions/download-artifact@v4.1.8
         with:
           path: test_results
           pattern:

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -744,13 +744,13 @@ jobs:
         if:
           inputs.enable_otel_traces_for_ocr2_plugins &&
           matrix.tests.test_env_vars.ENABLE_OTEL_TRACES == 'true'
-        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: trace-data
           path: ./integration-tests/smoke/traces/trace-data.json
 
       - name: Upload test log as artifact
-        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        uses: actions/upload-artifact@v4.4.3
         if: inputs.test_log_upload_on_failure && failure()
         with:
           name: test_log_${{ env.TEST_ID }}
@@ -760,7 +760,7 @@ jobs:
 
       - name: Upload cl node coverage data as artifact
         if: inputs.upload_cl_node_coverage_artifact
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@v4.4.3
         timeout-minutes: 2
         continue-on-error: true
         with:
@@ -778,7 +778,7 @@ jobs:
           echo "{\"id\": \"$id\", \"result\": \"$result\"}" > test_result.json
 
       - name: Upload test result as artifact
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@v4.4.3
         with:
           name:
             test_result_${{ needs.load-test-configurations.outputs.workflow_id
@@ -788,7 +788,7 @@ jobs:
 
       - name: Upload custom test artifacts
         if: failure() && matrix.tests.test_artifacts_on_failure != ''
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@v4.4.3
         with:
           name:
             custom_test_artifacts_${{ env.TEST_ID }}_${{
@@ -999,7 +999,7 @@ jobs:
           QA_KUBECONFIG: ${{ secrets.QA_KUBECONFIG }}
 
       - name: Upload test log as artifact
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@v4.4.3
         if: inputs.test_log_upload_on_failure && failure()
         with:
           name: test_log_${{ env.TEST_ID }}
@@ -1009,7 +1009,7 @@ jobs:
 
       - name: Upload custom test artifacts
         if: failure() && matrix.tests.test_artifacts_on_failure != ''
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@v4.4.3
         with:
           name:
             custom_test_artifacts_${{ env.TEST_ID }}_${{

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -354,7 +354,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4.2.1
       - name: Setup Go
-        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        uses: actions/setup-go@v5.0.2
         with:
           go-version: "1.22.6"
           check-latest: true

--- a/.github/workflows/schedule-renovate.yml
+++ b/.github/workflows/schedule-renovate.yml
@@ -15,7 +15,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@v4.2.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/solidity-review-artifacts.yml
+++ b/.github/workflows/solidity-review-artifacts.yml
@@ -171,7 +171,7 @@ jobs:
           done
 
       - name: Upload basic info and modified contracts list
-        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+        uses: actions/upload-artifact@v4.4.3
         timeout-minutes: 2
         continue-on-error: true
         with:
@@ -266,7 +266,7 @@ jobs:
           FOUNDRY_PROFILE: ${{ inputs.product }}
 
       - name: Upload Artifacts for product contracts
-        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+        uses: actions/upload-artifact@v4.4.3
         timeout-minutes: 2
         continue-on-error: true
         with:
@@ -375,7 +375,7 @@ jobs:
           ./dot_github/tools/scripts/solidity/generate_slither_report.sh "${{ github.server_url }}/${{ github.repository }}/blob/${{ env.head_ref }}/" "${{ inputs.slither_config_file_path }}" "${{ inputs.contracts_directory }}" "$contract_list" "${{ env.artifacts_dir }}/slither-reports" "--solc-remaps @=${{ inputs.contracts_directory }}/node_modules/@"
 
       - name: Upload UMLs and Slither reports
-        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+        uses: actions/upload-artifact@v4.4.3
         timeout-minutes: 10
         continue-on-error: true
         with:
@@ -412,7 +412,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload all artifacts as single package
-        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+        uses: actions/upload-artifact@v4.4.3
         with:
           name:
             review-artifacts-${{ inputs.product }}-${{ inputs.base_ref }}-${{

--- a/.github/workflows/solidity-review-artifacts.yml
+++ b/.github/workflows/solidity-review-artifacts.yml
@@ -135,7 +135,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout the caller repository
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        uses: actions/checkout@v4.2.1
         with:
           fetch-depth: 0
 
@@ -195,7 +195,7 @@ jobs:
     needs: [gather-basic-info]
     steps:
       - name: Checkout the caller repository
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        uses: actions/checkout@v4.2.1
         with:
           ref: ${{ env.head_ref }}
 
@@ -291,13 +291,13 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout caller repository
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        uses: actions/checkout@v4.2.1
         with:
           fetch-depth: 0
           ref: ${{ env.head_ref }}
 
       - name: Checkout .github repository
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        uses: actions/checkout@v4.2.1
         with:
           repository: smartcontractkit/.github
           ref: 65249c7eae628aad6e70a0c0850d981cd0074bf9
@@ -354,7 +354,7 @@ jobs:
             echo "::debug::contracts directory isn't the root directory, but ${{ inputs.contracts_directory }}."
             echo "::debug::it's probable that remappings.txt is stored there. Copying it to root folder"
 
-            ./dot_github/tools/scripts/solidity/modify_remappings.sh "${{ inputs.contracts_directory }}" "${{ inputs.contracts_directory }}/remappings.txt"          
+            ./dot_github/tools/scripts/solidity/modify_remappings.sh "${{ inputs.contracts_directory }}" "${{ inputs.contracts_directory }}/remappings.txt"
             mv remappings_modified.txt remappings.txt
           fi
 
@@ -365,9 +365,9 @@ jobs:
         run: |
           contract_list="${{ inputs.product_files }}"
 
-          # without foundry.toml in the root of directory from which we execute further scripts, Slither sometimes fails to use remappings correctly          
+          # without foundry.toml in the root of directory from which we execute further scripts, Slither sometimes fails to use remappings correctly
           if [[ -n "${{ inputs.contracts_directory }}" && ("${{ inputs.contracts_directory }}" != "./" && "${{ inputs.contracts_directory }}" != ".") ]]; then
-            echo "::debug::contracts directory isn't the root directory, but in ${{ inputs.contracts_directory }}. Copying foundry.toml to root folder"          
+            echo "::debug::contracts directory isn't the root directory, but in ${{ inputs.contracts_directory }}. Copying foundry.toml to root folder"
             cp "${{ inputs.contracts_directory }}"/foundry.toml foundry.toml
           fi
 
@@ -446,13 +446,13 @@ jobs:
 
       - name: Checkout caller repository
         if: ${{ inputs.link_with_jira == true }}
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        uses: actions/checkout@v4.2.1
         with:
           ref: ${{ env.head_ref }}
 
       - name: Checkout chainlink-github-actions repository
         if: ${{ inputs.link_with_jira == true }}
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        uses: actions/checkout@v4.2.1
         with:
           repository: smartcontractkit/.github
           ref: 65249c7eae628aad6e70a0c0850d981cd0074bf9

--- a/.github/workflows/solidity-review-artifacts.yml
+++ b/.github/workflows/solidity-review-artifacts.yml
@@ -406,7 +406,7 @@ jobs:
     needs: [coverage-and-book, uml-static-analysis, gather-basic-info]
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        uses: actions/download-artifact@v4.1.8
         with:
           path: review_artifacts
           merge-multiple: true

--- a/.github/workflows/solidity-review-artifacts.yml
+++ b/.github/workflows/solidity-review-artifacts.yml
@@ -321,7 +321,7 @@ jobs:
 
       - name: Set up Python
         if: ${{ inputs.generate_slither_reports == true }}
-        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f #v5.1.1
+        uses: actions/setup-python@v5.2.0
         with:
           python-version: "3.8"
 

--- a/actions/ci-benchmarking/action.yml
+++ b/actions/ci-benchmarking/action.yml
@@ -53,7 +53,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout Code
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      uses: actions/checkout@v4.2.1
 
     - name: Setup Go Environment
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2

--- a/actions/ci-benchmarking/action.yml
+++ b/actions/ci-benchmarking/action.yml
@@ -100,7 +100,7 @@ runs:
 
     - name: Download Previous Benchmark Data
       if: ${{ env.IS_PR == 'true' || env.IS_MERGE == 'true' }}
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache@v4.1.1
       with:
         path: ./cache
         key: ${{ runner.os }}-benchmark
@@ -132,7 +132,7 @@ runs:
 
     - name: Upload Updated Benchmark Data
       if: ${{ env.IS_MERGE == 'true' }}
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache@v4.1.1
       with:
         path: ./cache
         key: ${{ runner.os }}-benchmark

--- a/actions/ci-benchmarking/action.yml
+++ b/actions/ci-benchmarking/action.yml
@@ -56,7 +56,7 @@ runs:
       uses: actions/checkout@v4.2.1
 
     - name: Setup Go Environment
-      uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+      uses: actions/setup-go@v5.0.2
       with:
         go-version: "stable"
 

--- a/actions/ci-kubeconform/action.yml
+++ b/actions/ci-kubeconform/action.yml
@@ -64,7 +64,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      uses: actions/checkout@v4.2.1
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/ci-kubeconform/action.yml
+++ b/actions/ci-kubeconform/action.yml
@@ -69,7 +69,7 @@ runs:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 
     - name: Install Go
-      uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+      uses: actions/setup-go@v5.0.2
       with:
         go-version-file: ${{ inputs.go-version-file }}
 

--- a/actions/ci-lint-charts/action.yml
+++ b/actions/ci-lint-charts/action.yml
@@ -49,7 +49,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      uses: actions/checkout@v4.2.1
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/ci-lint-go/action.yml
+++ b/actions/ci-lint-go/action.yml
@@ -123,7 +123,7 @@ runs:
         envFile: ${{ inputs.env-files }}
 
     - name: Setup go
-      uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+      uses: actions/setup-go@v5.0.2
       with:
         go-version-file: ${{ inputs.go-version-file }}
         cache: ${{ inputs.use-go-cache }}

--- a/actions/ci-lint-go/action.yml
+++ b/actions/ci-lint-go/action.yml
@@ -88,7 +88,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      uses: actions/checkout@v4.2.1
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/ci-lint-go/action.yml
+++ b/actions/ci-lint-go/action.yml
@@ -145,7 +145,7 @@ runs:
 
     - name: Store lint report artifact
       if: always()
-      uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+      uses: actions/upload-artifact@v4.4.3
       with:
         name: golangci-lint-report
         path: ${{ inputs.go-directory }}/golangci-lint-report.xml

--- a/actions/ci-lint-misc/action.yml
+++ b/actions/ci-lint-misc/action.yml
@@ -36,7 +36,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      uses: actions/checkout@v4.2.1
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/ci-lint-ts/action.yml
+++ b/actions/ci-lint-ts/action.yml
@@ -53,7 +53,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      uses: actions/checkout@v4.2.1
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/ci-lint-ts/action.yml
+++ b/actions/ci-lint-ts/action.yml
@@ -78,7 +78,7 @@ runs:
 
     - name: Store lint result artifacts
       if: always()
-      uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+      uses: actions/upload-artifact@v4.4.3
       with:
         name: ts-lint-results
         path: ./eslint-report.json

--- a/actions/ci-prettier/action.yml
+++ b/actions/ci-prettier/action.yml
@@ -55,7 +55,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      uses: actions/checkout@v4.2.1
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/ci-sonarqube-go/action.yml
+++ b/actions/ci-sonarqube-go/action.yml
@@ -75,7 +75,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      uses: actions/checkout@v4.2.1
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 
@@ -110,9 +110,9 @@ runs:
       uses: sonarsource/sonarqube-scan-action@aecaf43ae57e412bd97d70ef9ce6076e672fe0a9 # v2.3.0
       with:
         args: >
-          -Dsonar.go.tests.reportPaths=${{ 
+          -Dsonar.go.tests.reportPaths=${{
             inputs.test-result-report-path
-          }} -Dsonar.go.coverage.reportPaths=${{ 
+          }} -Dsonar.go.coverage.reportPaths=${{
             inputs.test-coverage-report-path
           }}
       env:
@@ -124,11 +124,11 @@ runs:
       uses: sonarsource/sonarqube-scan-action@aecaf43ae57e412bd97d70ef9ce6076e672fe0a9 # v2.3.0
       with:
         args: >
-          -Dsonar.go.tests.reportPaths=${{ 
-            inputs.test-result-report-path 
-          }} -Dsonar.go.coverage.reportPaths=${{ 
+          -Dsonar.go.tests.reportPaths=${{
+            inputs.test-result-report-path
+          }} -Dsonar.go.coverage.reportPaths=${{
             inputs.test-coverage-report-path
-          }} -Dsonar.go.golangci-lint.reportPaths=${{ 
+          }} -Dsonar.go.golangci-lint.reportPaths=${{
             inputs.lint-report-path
           }}
       env:

--- a/actions/ci-sonarqube-ts/action.yml
+++ b/actions/ci-sonarqube-ts/action.yml
@@ -77,7 +77,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      uses: actions/checkout@v4.2.1
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 
@@ -112,10 +112,10 @@ runs:
       uses: sonarsource/sonarqube-scan-action@aecaf43ae57e412bd97d70ef9ce6076e672fe0a9 # v2.3.0
       with:
         args: >
-          -Dsonar.junit.reportPaths=${{ 
-            inputs.junit-xml-report-path 
+          -Dsonar.junit.reportPaths=${{
+            inputs.junit-xml-report-path
           }} -Dsonar.typescript.lcov.reportPaths=${{
-            inputs.typescript-lcov-report-path 
+            inputs.typescript-lcov-report-path
           }}
       env:
         SONAR_TOKEN: ${{ inputs.sonar-token }}
@@ -126,12 +126,12 @@ runs:
       uses: sonarsource/sonarqube-scan-action@aecaf43ae57e412bd97d70ef9ce6076e672fe0a9 # v2.3.0
       with:
         args: >
-          -Dsonar.junit.reportPaths=${{ 
-            inputs.junit-xml-report-path 
+          -Dsonar.junit.reportPaths=${{
+            inputs.junit-xml-report-path
           }} -Dsonar.typescript.lcov.reportPaths=${{
-            inputs.typescript-lcov-report-path 
+            inputs.typescript-lcov-report-path
           }} -Dsonar.eslint.reportPaths=${{
-            inputs.eslint-json-report-path 
+            inputs.eslint-json-report-path
           }}
       env:
         SONAR_TOKEN: ${{ inputs.sonar-token }}

--- a/actions/ci-test-go/action.yml
+++ b/actions/ci-test-go/action.yml
@@ -117,7 +117,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      uses: actions/checkout@v4.2.1
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/ci-test-go/action.yml
+++ b/actions/ci-test-go/action.yml
@@ -182,7 +182,7 @@ runs:
 
     - name: Store test report artifacts
       if: always()
-      uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+      uses: actions/upload-artifact@v4.4.3
       with:
         name: go-test-results
         path: |
@@ -191,7 +191,7 @@ runs:
 
     - name: Store race coverage report
       if: ${{ inputs.enable-go-test-race == 'true' }}
-      uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+      uses: actions/upload-artifact@v4.4.3
       with:
         name: go-test-race-results
         path: race/*.txt

--- a/actions/ci-test-sol/action.yml
+++ b/actions/ci-test-sol/action.yml
@@ -74,7 +74,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      uses: actions/checkout@v4.2.1
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/ci-test-ts/action.yml
+++ b/actions/ci-test-ts/action.yml
@@ -53,7 +53,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      uses: actions/checkout@v4.2.1
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/ci-test-ts/action.yml
+++ b/actions/ci-test-ts/action.yml
@@ -79,7 +79,7 @@ runs:
 
     - name: Store test result artifacts
       if: always()
-      uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+      uses: actions/upload-artifact@v4.4.3
       with:
         name: ts-test-results
         path: |

--- a/actions/cicd-build-publish-artifacts-go/action.yml
+++ b/actions/cicd-build-publish-artifacts-go/action.yml
@@ -125,7 +125,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      uses: actions/checkout@v4.2.1
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
         ref: ${{ inputs.checkout-ref }}

--- a/actions/cicd-build-publish-artifacts-go/action.yml
+++ b/actions/cicd-build-publish-artifacts-go/action.yml
@@ -155,7 +155,7 @@ runs:
           "https://github.com/"
 
     - name: Setup go
-      uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+      uses: actions/setup-go@v5.0.2
       with:
         go-version-file: ${{ inputs.go-version-file }}
         cache: ${{ inputs.use-go-cache }}

--- a/actions/cicd-build-publish-artifacts-ts/action.yml
+++ b/actions/cicd-build-publish-artifacts-ts/action.yml
@@ -89,7 +89,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      uses: actions/checkout@v4.2.1
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/cicd-build-publish-charts/action.yml
+++ b/actions/cicd-build-publish-charts/action.yml
@@ -67,7 +67,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      uses: actions/checkout@v4.2.1
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/cicd-build-publish-docker/action.yml
+++ b/actions/cicd-build-publish-docker/action.yml
@@ -78,7 +78,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      uses: actions/checkout@v4.2.1
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/cicd-changesets/action.yml
+++ b/actions/cicd-changesets/action.yml
@@ -118,7 +118,7 @@ runs:
         url: ${{ inputs.aws-lambda-url }}
 
     - name: Checkout repo
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      uses: actions/checkout@v4.2.1
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
         token: ${{ steps.get-gh-token.outputs.access-token }}

--- a/actions/cleanup-old-branches/action.yml
+++ b/actions/cleanup-old-branches/action.yml
@@ -42,7 +42,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      uses: actions/checkout@v4.2.1
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -99,7 +99,7 @@ runs:
         gc-org-id: ${{ inputs.gc-org-id }}
 
     - name: Checkout crib repo
-      uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+      uses: actions/checkout@v4.2.1
       with:
         repository: "smartcontractkit/crib"
         ref: ${{ inputs.crib-repo-ref }}

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -184,7 +184,7 @@ runs:
 
         nix develop -c devspace run ${{ inputs.command }} ${{ inputs.command-args }}
     - name: Render notification template
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      uses: actions/github-script@v7.0.1
       id: render-slack-template
       if:
         failure() && inputs.crib-alert-slack-webhook != '' && inputs.send-alerts

--- a/actions/ctf-build-image/action.yml
+++ b/actions/ctf-build-image/action.yml
@@ -67,7 +67,7 @@ runs:
   steps:
     - name: Checkout Chainlink repo
       if: ${{ inputs.should_checkout == 'true' }}
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      uses: actions/checkout@v4.2.1
       with:
         repository: ${{ inputs.cl_repo }}
         ref: ${{ inputs.cl_ref }}

--- a/actions/ctf-build-image/action.yml
+++ b/actions/ctf-build-image/action.yml
@@ -71,7 +71,7 @@ runs:
       with:
         repository: ${{ inputs.cl_repo }}
         ref: ${{ inputs.cl_ref }}
-    - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+    - uses: actions/setup-go@v5.0.2
       env:
         GOPRIVATE: ${{ inputs.GOPRIVATE }}
       with:

--- a/actions/ctf-build-test-image/action.yml
+++ b/actions/ctf-build-test-image/action.yml
@@ -70,7 +70,7 @@ runs:
         echo "short_sha=${short_sha}" >> "$GITHUB_OUTPUT"
     - name: Checkout chainlink-testing-framework
       if: steps.version.outputs.is_semantic == 'false'
-      uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+      uses: actions/checkout@v4.2.1
       with:
         repository: smartcontractkit/chainlink-testing-framework
         ref: main

--- a/actions/ctf-build-tests/action.yml
+++ b/actions/ctf-build-tests/action.yml
@@ -92,7 +92,7 @@ runs:
         echo "Built binary at ./integration-tests/tests"
 
     - name: Publish Binary
-      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+      uses: actions/upload-artifact@v4.4.3
       with:
         name: ${{ inputs.binary_name }}
         path: ./integration-tests/tests

--- a/actions/ctf-run-tests-binary/action.yml
+++ b/actions/ctf-run-tests-binary/action.yml
@@ -111,7 +111,7 @@ runs:
     # Download any external artifacts
     - name: Download Artifacts
       if: inputs.download_contract_artifacts_path != 'none'
-      uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+      uses: actions/download-artifact@v4.1.8
       with:
         name: artifacts
         path: ${{ inputs.download_contract_artifacts_path }}

--- a/actions/ctf-run-tests-binary/action.yml
+++ b/actions/ctf-run-tests-binary/action.yml
@@ -141,7 +141,7 @@ runs:
 
     - name: Publish Artifacts
       if: failure()
-      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+      uses: actions/upload-artifact@v4.4.3
       with:
         name: ${{ inputs.artifacts_name }}
         path: ${{ inputs.artifacts_location }}

--- a/actions/ctf-run-tests/action.yml
+++ b/actions/ctf-run-tests/action.yml
@@ -205,7 +205,7 @@ runs:
     # Download any external artifacts
     - name: Download Artifacts
       if: inputs.download_contract_artifacts_path != 'none'
-      uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+      uses: actions/download-artifact@v4.1.8
       with:
         name: artifacts
         path: ${{ inputs.download_contract_artifacts_path }}

--- a/actions/ctf-run-tests/action.yml
+++ b/actions/ctf-run-tests/action.yml
@@ -304,7 +304,7 @@ runs:
 
     - name: Publish Artifacts
       if: failure()
-      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+      uses: actions/upload-artifact@v4.4.3
       with:
         name: ${{ inputs.artifacts_name }}
         path: ${{ inputs.artifacts_location }}

--- a/actions/ctf-setup-go/action.yml
+++ b/actions/ctf-setup-go/action.yml
@@ -54,7 +54,7 @@ runs:
 
     - name: Cache Go Modules
       if: inputs.cache_restore_only == 'false' && inputs.no_cache == 'false'
-      uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
+      uses: actions/cache@v4.1.1
       id: cache-packages
       with:
         path: ${{ steps.go-cache-dir.outputs.gomodcache }}
@@ -64,7 +64,7 @@ runs:
         restore-keys: |
           ${{ runner.os }}-${{ inputs.cache_key_id }}-gomod-
 
-    - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+    - uses: actions/cache@v4.1.1
       if: inputs.cache_restore_only == 'false' && inputs.cache_builds == 'true'
       name: Cache Go Builds
       with:
@@ -78,7 +78,7 @@ runs:
 
     - name: Restore Go Modules
       if: inputs.cache_restore_only != 'false' && inputs.no_cache == 'false'
-      uses: actions/cache/restore@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
+      uses: actions/cache/restore@v4.1.1
       id: restore-cache-packages
       with:
         path: |

--- a/actions/ctf-setup-go/action.yml
+++ b/actions/ctf-setup-go/action.yml
@@ -38,7 +38,7 @@ runs:
   using: composite
   steps:
     - name: Setup Go
-      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      uses: actions/setup-go@v5.0.2
       with:
         go-version: ${{ inputs.go_version }}
         go-version-file: ${{ inputs.go_mod_path }}

--- a/actions/gha-workflow-validator/src/validations/action-reference-validations.ts
+++ b/actions/gha-workflow-validator/src/validations/action-reference-validations.ts
@@ -227,7 +227,7 @@ export function extractActionReferenceFromLine(
   }
 
   // example line:
-  // - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+  // - uses: actions/checkout@v4.2.1
   const trimSubString = "uses:";
   const usesIndex = trimmedLine.indexOf(trimSubString);
 

--- a/actions/guard-from-missing-changesets/action.yml
+++ b/actions/guard-from-missing-changesets/action.yml
@@ -35,7 +35,7 @@ runs:
   steps:
     - name: Checkout full repo
       if: inputs.checkout == 'true'
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      uses: actions/checkout@v4.2.1
     - name: Install changesets
       shell: bash
       run: ${{ github.action_path }}/scripts/install-changesets.sh

--- a/actions/guard-tag-from-branch/action.yml
+++ b/actions/guard-tag-from-branch/action.yml
@@ -30,7 +30,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      uses: actions/checkout@v4.2.1
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/llm-action-error-reporter/action.yml
+++ b/actions/llm-action-error-reporter/action.yml
@@ -52,7 +52,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout calling repo
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      uses: actions/checkout@v4.2.1
 
     - name: Check if this run is invoked from a pull request event
       shell: bash
@@ -87,7 +87,7 @@ runs:
 
     - name: Checkout action repo
       if: ${{ env.SKIP_ACTION == 'false' }}
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      uses: actions/checkout@v4.2.1
       with:
         repository: smartcontractkit/.github
         ref: ${{ inputs.workflow-ref }}

--- a/actions/llm-pr-writer/action.yml
+++ b/actions/llm-pr-writer/action.yml
@@ -72,13 +72,13 @@ runs:
 
     - name: Checkout calling repo
       if: ${{ env.SKIP_ACTION == 'false' }}
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      uses: actions/checkout@v4.2.1
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 
     - name: Checkout action repo
       if: ${{ env.SKIP_ACTION == 'false' }}
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      uses: actions/checkout@v4.2.1
       with:
         repository: smartcontractkit/.github
         ref: ${{ inputs.workflow-ref }}

--- a/actions/md-confluence-sync/action.yml
+++ b/actions/md-confluence-sync/action.yml
@@ -73,7 +73,7 @@ runs:
         this-job-name: ${{ inputs.metrics-job-name }}
 
     - name: Set up Go
-      uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+      uses: actions/setup-go@v5.0.2
 
     - name: Setup tools
       shell: bash

--- a/actions/md-confluence-sync/action.yml
+++ b/actions/md-confluence-sync/action.yml
@@ -58,7 +58,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      uses: actions/checkout@v4.2.1
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/policy-bot-config-validator/README.md
+++ b/actions/policy-bot-config-validator/README.md
@@ -37,7 +37,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        uses: actions/checkout@v4.2.1
 
       - name: Policy Bot Validator
         uses: smartcontractkit/.github/actions/policy-bot-config-validator@<commit> # policy-bot-config-validator@x.y.z

--- a/actions/setup-golang/action.yml
+++ b/actions/setup-golang/action.yml
@@ -41,10 +41,10 @@ runs:
       shell: bash
       id: go-cache-dir
       run: |
-        echo "gomodcache=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT 
+        echo "gomodcache=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
         echo "gobuildcache=$(go env GOCACHE)" >> $GITHUB_OUTPUT
 
-    - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+    - uses: actions/cache@v4.1.1
       name: Cache Go Modules
       with:
         path: |
@@ -57,7 +57,7 @@ runs:
         restore-keys: |
           ${{ runner.os }}-gomod-${{ inputs.cache-version }}-
 
-    - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+    - uses: actions/cache@v4.1.1
       if: ${{ inputs.only-modules == 'false' }}
       name: Cache Go Build Outputs
       with:

--- a/actions/setup-golang/action.yml
+++ b/actions/setup-golang/action.yml
@@ -26,7 +26,7 @@ runs:
   using: composite
   steps:
     - name: Set up Go
-      uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+      uses: actions/setup-go@v5.0.2
       with:
         go-version-file: ${{ inputs.go-version-file }}
         cache: ${{ inputs.use-go-cache }}

--- a/actions/setup-nodejs/action.yml
+++ b/actions/setup-nodejs/action.yml
@@ -48,7 +48,7 @@ runs:
 
     - name: Setup pnpm cache
       if: inputs.use-cache == 'true'
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache@v4.1.1
       with:
         path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/actions/setup-nodejs/action.yml
+++ b/actions/setup-nodejs/action.yml
@@ -29,7 +29,7 @@ runs:
   using: composite
   steps:
     - name: Install node
-      uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
+      uses: actions/setup-node@v4.0.4
       with:
         node-version-file: ${{ inputs.node-version-file }}
 

--- a/actions/setup-renovate/action.yml
+++ b/actions/setup-renovate/action.yml
@@ -48,7 +48,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      uses: actions/checkout@v4.2.1
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/slack-notify-git-ref/action.yml
+++ b/actions/slack-notify-git-ref/action.yml
@@ -66,7 +66,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      uses: actions/checkout@v4.2.1
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
     - name: Validate inputs

--- a/actions/update-actions/action.yml
+++ b/actions/update-actions/action.yml
@@ -56,7 +56,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      uses: actions/checkout@v4.2.1
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/wait-for-workflows/README.md
+++ b/actions/wait-for-workflows/README.md
@@ -14,7 +14,7 @@ jobs:
     if: always()
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        uses: actions/checkout@v4.2.1
         with:
           ref:
             ${{ github.event.pull_request.head.sha ||

--- a/actions/wait-for-workflows/action.yml
+++ b/actions/wait-for-workflows/action.yml
@@ -33,7 +33,7 @@ runs:
   steps:
     - name: wait-for-workflows
       id: wfw
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      uses: actions/github-script@v7.0.1
       env:
         MAX_TIMEOUT: ${{ inputs.max-timeout }}
         POLLING_INTERVAL: ${{ inputs.polling-interval }}
@@ -59,7 +59,7 @@ runs:
               const workflows = WORKFLOW_RUNS_FOR_REPO_RESPONSE.data.workflow_runs.reduce((acc, val) => acc.concat([{ run_id: val.id, name: val.name, workflow_id: val.workflow_id, run_attempt: val.run_attempt }]), [])
               console.log("workflow_runs:", workflows)
             }
-            
+
             // pending workflows
             const PENDING_WORKFLOWS = WORKFLOW_RUNS_FOR_REPO_RESPONSE.data.workflow_runs.filter(
               (run) => !EXCLUDE_WORKFLOW_RUN_IDS.includes(run.id) && !EXCLUDE_WORKFLOW_NAMES.includes(run.name) && !EXCLUDE_WORKFLOW_IDS.includes(run.workflow_id) && (run.status == 'queued' || run.status == 'in_progress')

--- a/apps/go-mod-validator/workflows/validate.yml
+++ b/apps/go-mod-validator/workflows/validate.yml
@@ -8,6 +8,6 @@ jobs:
     name: Validate go.mod dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+      - uses: actions/checkout@v4.2.1
       - name: Validate go.mod
         uses: smartcontractkit/.github/apps/go-mod-validator@3deb8db9f687eee0678d2411ef40074078173e9a #v0.2.1

--- a/libs/nx-chainlink/src/generators/create-gh-action/files/composite/debug/action.yml.template
+++ b/libs/nx-chainlink/src/generators/create-gh-action/files/composite/debug/action.yml.template
@@ -33,7 +33,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      uses: actions/checkout@v4.2.1
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/libs/nx-chainlink/src/generators/create-gh-action/files/composite/default/action.yml.template
+++ b/libs/nx-chainlink/src/generators/create-gh-action/files/composite/default/action.yml.template
@@ -33,7 +33,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      uses: actions/checkout@v4.2.1
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 


### PR DESCRIPTION
### Changes

* Update all references to `actions/*` dependencies
* Update the reference to use the git tag, as they are apart of our "trusted" orgs (as per gha-workflow-validator).