### PR TITLE
exposing DEVSPACE_NAMESPACE variable to the crib CLI running inside the nix shell

### DIFF
--- a/.changeset/light-rules-share.md
+++ b/.changeset/light-rules-share.md
@@ -1,0 +1,6 @@
+---
+"crib-deploy-environment": minor
+---
+
+exposing DEVSPACE_NAMESPACE variable to the crib CLI running inside the nix
+shell

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -174,13 +174,13 @@ runs:
         echo "Working directory: $(pwd)"
 
         # Get the namespace name from GitHub Actions output
-        NAMESPACE="${{ steps.generate-ns-name.outputs.devspace-namespace }}"
-        echo "Using $NAMESPACE Kubernetes namespace"
+        export DEVSPACE_NAMESPACE="${{ steps.generate-ns-name.outputs.devspace-namespace }}"
+        echo "Using $DEVSPACE_NAMESPACE Kubernetes namespace"
 
         # Kyverno needs some time to inject the RoleBinding
         sleep 3
 
-        nix develop -c ./cribbit.sh "$NAMESPACE"
+        nix develop -c ./cribbit.sh "$DEVSPACE_NAMESPACE"
 
         nix develop -c devspace run ${{ inputs.command }} ${{ inputs.command-args }}
     - name: Render notification template


### PR DESCRIPTION
This is required in order to test crib after https://github.com/smartcontractkit/crib/pull/227 is merged.