### PR TITLE
chore: disable go-mod-validator e2e tests

### DIFF
--- a/apps/go-mod-validator/test/e2e.test.ts
+++ b/apps/go-mod-validator/test/e2e.test.ts
@@ -77,7 +77,7 @@ async function setupNonPR(repo: string, commitSha: string) {
   return nockDone;
 }
 
-describe("e2e tests", () => {
+describe.skip("e2e tests", () => {
   const annotationSpy = vi.spyOn(core, "error");
 
   async function testEntrypoint() {


### PR DESCRIPTION
### Changes

- Disable `go-mod-validator` `e2e` tests, it's now failing with no change. This is because it's testing dependencies are not static.