### PR TITLE
Adding additional inputs for labeling resources in the composite CRIB GHA

### DIFF
--- a/.changeset/popular-camels-perform.md
+++ b/.changeset/popular-camels-perform.md
@@ -1,0 +1,5 @@
+---
+"crib-deploy-environment": minor
+---
+
+Adding additional inputs for labeling resources in the composite CRIB GHA

--- a/.changeset/sweet-tigers-live.md
+++ b/.changeset/sweet-tigers-live.md
@@ -1,5 +1,5 @@
 ---
-"crib-deploy-environment": minor
+"crib-deploy-environment": major
 ---
 
 Adding additional inputs for labeling resources in the composite CRIB GHA

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -72,6 +72,18 @@ inputs:
     default: "main"
     required: false
     description: Useful for testing updates in CRIB
+  chainlink-team:
+    default: ""
+    required: true
+    description: |
+      Specify a relevant value for tagging resources and attributing
+      costs to the correct team.
+  chainlink-product:
+    default: ""
+    required: true
+    description: |
+      Specify a relevant value for tagging resources and attributing
+      costs to the correct product.
 outputs:
   devspace-namespace:
     description: "Kubernetes namespace used to provision a CRIB environment."
@@ -136,15 +148,28 @@ runs:
         sanitized_branch=$(echo "${{ steps.generate-ns-name.outputs.branch-name }}" \
           | sed 's/[^a-zA-Z0-9._-]/_/g' | cut -c1-63 | sed 's/[._-]$//')
 
+        # Validate that chainlink-team and chainlink-product inputs adhere to the Kubernetes label format.
+        if [[ ! "${{ inputs.chainlink-team }}" =~ ^[a-zA-Z0-9_.-]+$ ]] || [[ "${{ inputs.chainlink-team }}" -gt 63 ]] || [[ "${{ inputs.chainlink-team }}" =~ ^\. ]] || [[ "${{ inputs.chainlink-team }}" =~ \.$ ]]; then
+          echo "Invalid value for chainlink-team label: ${{ inputs.chainlink-team }}. Must be up to 63 characters, contain only letters, numbers, hyphens, underscores, and dots, and cannot start or end with a dot."
+          exit 1
+        fi
+
+        if [[ ! "${{ inputs.chainlink-product }}" =~ ^[a-zA-Z0-9_.-]+$ ]] || [[ "${{ inputs.chainlink-product }}" -gt 63 ]] || [[ "${{ inputs.chainlink-product }}" =~ ^\. ]] || [[ "${{ inputs.chainlink-product }}" =~ \.$ ]]; then
+          echo "Invalid value for chainlink-product label: ${{ inputs.chainlink-product }}. Must be up to 63 characters, contain only letters, numbers, hyphens, underscores, and dots, and cannot start or end with a dot."
+          exit 1
+        fi
+
         NAMESPACE="${{ steps.generate-ns-name.outputs.devspace-namespace }}"
         echo "Creating $NAMESPACE Kubernetes namespace.."
         kubectl create ns "$NAMESPACE"
 
         kubectl label namespace $NAMESPACE \
-          repo=${{ steps.generate-ns-name.outputs.repo-name }} \
           branch="${sanitized_branch}" \
+          chain.link/product=${{ inputs.chainlink-product }} \
+          chain.link/team=${{ inputs.chainlink-team }} \
           commit=${{ steps.generate-ns-name.outputs.commit-sha }} \
           pr-number=${{ steps.generate-ns-name.outputs.pr-number || 'none' }} \
+          repo=${{ steps.generate-ns-name.outputs.repo-name }} \
           workflow-job=${{ steps.generate-ns-name.outputs.workflow-job }} \
           workflow-run-number=${{ steps.generate-ns-name.outputs.workflow-run-number }}
 
@@ -183,6 +208,7 @@ runs:
         nix develop -c ./cribbit.sh "$DEVSPACE_NAMESPACE"
 
         nix develop -c devspace run ${{ inputs.command }} ${{ inputs.command-args }}
+
     - name: Render notification template
       uses: actions/github-script@v7.0.1
       id: render-slack-template


### PR DESCRIPTION
## What 

See title. 

## Why

The labels related to the team and product will be added to the namespace and later propagated to all resources within the specific CRIB namespace.

## Testing 

```
❯ kg svc -n crib-ci-b73e8 -o yaml | grep team
     chain.link/team: chainlink-test-team
      chain.link/team: chainlink-test-team
      chain.link/team: chainlink-test-team
      chain.link/team: chainlink-test-team

~/git/chainlink/crib-ingress/kyverno               
❯ kgp -n crib-ci-b73e8 -o yaml | grep product
      chain.link/product: awesome-product-foo-bar
      chain.link/product: awesome-product-foo-bar
      chain.link/product: awesome-product-foo-bar

~/git/chainlink/crib-ingress/kyverno                  
❯ kg ns crib-ci-b73e8 -o yaml
apiVersion: v1
kind: Namespace
metadata:
  annotations:
  creationTimestamp: "2024-11-04T13:12:35Z"
  labels:
    branch: nrailic-ci-test
    chain.link/product: awesome-product-foo-bar
    chain.link/team: chainlink-test-team
    cleanup.kyverno.io/ttl: 1h
    
  *** redacted ***

```
