### PR TITLE
Adding support for gracefully terminating CRIB Kubernetes namespace

### DIFF
--- a/.changeset/little-ducks-behave.md
+++ b/.changeset/little-ducks-behave.md
@@ -1,0 +1,5 @@
+---
+"crib-purge-environment": minor
+---
+
+Adding support for gracefully terminating Kubernetes namespace

--- a/actions/crib-purge-environment/action.yml
+++ b/actions/crib-purge-environment/action.yml
@@ -1,7 +1,7 @@
 name: crib-purge-environment
 description: |
-  Action to destroy CRIB ephemeral environment.
-  It requires running crib-deployment-environment beforehand
+  Action to destroy the CRIB ephemeral environment.
+  It requires running `crib-deployment-environment` beforehand
   and depends on the environment setup from a dependent composite action.
 
 inputs:
@@ -9,15 +9,17 @@ inputs:
     description: "The CRIB namespace that should be destroyed."
     required: true
   gracefully-terminate:
-    description: "Whether to gracefully terminate the namespace."
+    description:
+      "Whether to gracefully terminate the namespace. Defaults to false. If set
+      to true, please also provide the termination period."
     required: false
     default: "false"
   gracefully-terminate-period:
-    description:
+    description: |
       "The grace period (in seconds) for gracefully terminating the namespace.
-      Default is 60 seconds."
+      Default is 0 seconds."
     required: false
-    default: "60"
+    default: "0"
 
 runs:
   using: composite
@@ -35,15 +37,7 @@ runs:
         # Check if the namespace exists
         if kubectl get ns "$NAMESPACE" > /dev/null 2>&1; then
           echo "Namespace $NAMESPACE exists. Proceeding with deletion.."
-
-          # Check if graceful termination is enabled
-          if [ "$GRACEFULLY_TERMINATE" == "true" ]; then
-            echo "Gracefully terminating the namespace respecting the grace period."
-            kubectl delete ns "$NAMESPACE" --grace-period="$GRACEFULLY_TERMINATE_PERIOD" --wait=true
-          else
-            echo "Forcefully terminating the namespace without grace period."
-            kubectl delete ns "$NAMESPACE" --grace-period=0 --wait=false
-          fi
+          kubectl delete ns "$NAMESPACE" --grace-period="$GRACEFULLY_TERMINATE_PERIOD" --wait="$GRACEFULLY_TERMINATE"
         else
           echo "Namespace $NAMESPACE does not exist. Skipping deletion."
         fi

--- a/actions/crib-purge-environment/action.yml
+++ b/actions/crib-purge-environment/action.yml
@@ -1,13 +1,23 @@
 name: crib-purge-environment
 description: |
-  Action to destroy CRIB epehemeral environment.
-  It requires to run crib-deployment-environment beforehand
+  Action to destroy CRIB ephemeral environment.
+  It requires running crib-deployment-environment beforehand
   and depends on the environment setup from a dependent composite action.
 
 inputs:
   namespace:
     description: "The CRIB namespace that should be destroyed."
     required: true
+  gracefully-terminate:
+    description: "Whether to gracefully terminate the namespace."
+    required: false
+    default: "false"
+  gracefully-terminate-period:
+    description:
+      "The grace period (in seconds) for gracefully terminating the namespace.
+      Default is 60 seconds."
+    required: false
+    default: "60"
 
 runs:
   using: composite
@@ -19,11 +29,21 @@ runs:
         KUBECACHEDIR: /dev/null
       run: |
         NAMESPACE="${{ inputs.namespace }}"
+        GRACEFULLY_TERMINATE="${{ inputs.gracefully-terminate }}"
+        GRACEFULLY_TERMINATE_PERIOD="${{ inputs.gracefully-terminate-period }}"
 
         # Check if the namespace exists
         if kubectl get ns "$NAMESPACE" > /dev/null 2>&1; then
           echo "Namespace $NAMESPACE exists. Proceeding with deletion.."
-          kubectl delete ns "$NAMESPACE" --grace-period=0 --wait=false
+
+          # Check if graceful termination is enabled
+          if [ "$GRACEFULLY_TERMINATE" == "true" ]; then
+            echo "Gracefully terminating the namespace respecting the grace period."
+            kubectl delete ns "$NAMESPACE" --grace-period="$GRACEFULLY_TERMINATE_PERIOD" --wait=true
+          else
+            echo "Forcefully terminating the namespace without grace period."
+            kubectl delete ns "$NAMESPACE" --grace-period=0 --wait=false
+          fi
         else
           echo "Namespace $NAMESPACE does not exist. Skipping deletion."
         fi


### PR DESCRIPTION
## What 

See title. 

## Why 

In some cases we may want to gracefully terminate namespace. The grace period for a namespace refers to the time Kubernetes will wait for all resources (pods, services, etc.) within the namespace to be cleaned up before the namespace itself is deleted. This allows for resources within the namespace to be gracefully terminated.
