### PR TITLE
feat: Prepend banner and remove lock

### DIFF
--- a/.changeset/forty-hats-exercise.md
+++ b/.changeset/forty-hats-exercise.md
@@ -1,0 +1,6 @@
+---
+"md-confluence-sync": minor
+---
+
+Prepend Disclaimer banner to prevent manual edits. Remove lock from the article,
+so they can be labeled for deletion

--- a/.changeset/forty-hats-exercise.md
+++ b/.changeset/forty-hats-exercise.md
@@ -2,5 +2,6 @@
 "md-confluence-sync": minor
 ---
 
-Prepend Disclaimer banner to prevent manual edits. Remove lock from the article,
-so they can be labeled for deletion
+* Prepend Disclaimer banner to prevent manual edits. 
+* Remove lock from the article, so they can be labeled for deletion. 
+* Update prettier path to use the same glob pattern as mark 

--- a/actions/md-confluence-sync/action.yml
+++ b/actions/md-confluence-sync/action.yml
@@ -3,9 +3,10 @@ description: "Sync Markdown documentation to Confluence"
 
 inputs:
   files:
-    description:
-      "use specified markdown file(s) for converting to html. Supports file
-      globbing patterns"
+    description: |
+      Use specified markdown file(s) for converting to html. Supports file
+      globbing patterns. GLOB pattern is used for linting as well, so make 
+      sure to filter files with .md extension.
     required: true
   base-url:
     description: "Confluence base url e.g: https://example.com/wiki/"
@@ -45,12 +46,8 @@ runs:
     - name: Lint MD files using Prettier
       uses: smartcontractkit/.github/actions/ci-prettier@a738d4cfa4826d6f44dbebcc3724385f6de58d42 # ci-prettier@0.1.1
       with:
-        basic-auth: ${{ inputs.gc-basic-auth }}
         checkout-repo: "false"
-        gc-host: ${{ inputs.gc-host }}
-        gc-org-id: ${{ inputs.gc-org-id}}
-        prettier-command: pnpm prettier --check ${{ inputs.files }}/**/*.md
-        this-job-name: ${{ inputs.metrics-job-name }}
+        prettier-command: pnpm prettier --check ${{ inputs.files }}
 
     - name: Set up Go
       uses: actions/setup-go@v5.0.2

--- a/actions/md-confluence-sync/action.yml
+++ b/actions/md-confluence-sync/action.yml
@@ -62,7 +62,7 @@ runs:
       uses: actions/github-script@v7
       with:
         script: |
-          const repo = await github.repos.get({
+          const repo = await github.rest.repos.get({
             owner: context.repo.owner,
             repo: context.repo.repo
           });

--- a/actions/md-confluence-sync/action.yml
+++ b/actions/md-confluence-sync/action.yml
@@ -62,7 +62,7 @@ runs:
 
     - name: Get default branch
       id: get_default_branch
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           const repo = await github.repos.get({

--- a/actions/md-confluence-sync/action.yml
+++ b/actions/md-confluence-sync/action.yml
@@ -60,6 +60,18 @@ runs:
       run: |
         go install github.com/kovetskiy/mark@11.1.0
 
+    - name: Get default branch
+      id: get_default_branch
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const repo = await github.repos.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo
+          });
+          return repo.data.default_branch;
+        result-encoding: string
+
     - name: Sync docs
       env:
         FILES: ${{ inputs.files }}
@@ -70,5 +82,6 @@ runs:
         PARENT: ${{ inputs.parent }}
         MARK_DEBUG: ${{ inputs.debug }}
         MARK_DRY_RUN: ${{ inputs.dry-run }}
+        DEFAULT_BRANCH: ${{ steps.get_default_branch.outputs.result }}
       shell: bash
       run: ${{ github.action_path }}/mark-sync.sh

--- a/actions/md-confluence-sync/mark-sync.sh
+++ b/actions/md-confluence-sync/mark-sync.sh
@@ -36,14 +36,52 @@ if [[ -z "${PARENT:-}" ]]; then
   exit 1
 fi
 
-# Mermaid diagrams are rendered locally and inlined into the HTML artifact as PNGs.
-mark -f "$FILES" \
-  --edit-lock \
-  --title-from-h1 \
-  -u "$USER" \
-  -p "$TOKEN" \
-  -b "$BASE_URL" \
-  --space "$SPACE" \
-  --parents "$PARENT" \
-  --mermaid-provider mermaid-go \
-  --ci
+if [[ -z "${DEFAULT_BRANCH:-}" ]]; then
+  echo "DEFAULT_BRANCH is not set. Exiting."
+  exit 1
+fi
+
+
+
+# Prepends disclaimer banner
+function prepend_disclaimer_banner() {
+  # Enable recursive globbing
+  shopt -s globstar
+
+  # Loop over each file matching the glob expression
+  for file in $FILES; do
+    edit_url="https://github.com/$GITHUB_REPOSITORY/blob/$DEFAULT_BRANCH/$file"
+    # The syntax for disclaimer banner is based on this https://github.com/kovetskiy/mark?tab=readme-ov-file#insert-colored-text-box
+    disclaimer_banner="<!-- Macro: :disclaimer-box:([^:]+):([^:]*):(.+):
+     Template: ac:box
+     Icon: true
+     Name: \${1}
+     Title: \${2}
+     Body: \${3} -->
+
+:disclaimer-box:note:Caution:This page is managed in github! Do not edit here! [Edit in Github](${edit_url}):
+"
+
+    # Prepend the text block to the file using a temporary file
+    { echo "$disclaimer_banner"; cat "$file"; } > temp_file && mv temp_file "$file"
+  done
+
+  # Disable globstar after we're done (optional)
+  shopt -u globstar
+}
+
+function publish_to_confluence() {
+  # Mermaid diagrams are rendered locally and inlined into the HTML artifact as PNGs.
+  mark -f "$FILES" \
+    --title-from-h1 \
+    -u "$USER" \
+    -p "$TOKEN" \
+    -b "$BASE_URL" \
+    --space "$SPACE" \
+    --parents "$PARENT" \
+    --mermaid-provider mermaid-go \
+    --ci
+}
+
+prepend_disclaimer_banner
+publish_to_confluence

--- a/actions/md-confluence-sync/mark-sync.sh
+++ b/actions/md-confluence-sync/mark-sync.sh
@@ -37,7 +37,7 @@ if [[ -z "${PARENT:-}" ]]; then
 fi
 
 if [[ -z "${DEFAULT_BRANCH:-}" ]]; then
-  echo "DEFAULT_BRANCH is not set. Exiting."
+  echo "::error::DEFAULT_BRANCH is not set. Exiting."
   exit 1
 fi
 


### PR DESCRIPTION
As per discussion in slack we need to remove edit-lock to unblock the deletion flow, which relies on adding `delete_pls` label

## Testing
Tested here with `dry_run=true`:
https://github.com/smartcontractkit/crib/actions/runs/11794836268/job/32853275890

Tested with `dry_run=false`:
https://github.com/smartcontractkit/crib/actions/runs/11794890547/job/32853457605