### PR TITLE
Remove renovate pinning GHA to shas

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,11 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "username": "app-token-issuer-releng-renovate[bot]",
   "gitAuthor": "App Token Issuer Releng Renovate Bot <376532+app-token-issuer-releng-renovate[bot]@users.noreply.github.com>",
-  "extends": [
-    "config:base",
-    "helpers:pinGitHubActionDigests",
-    ":dependencyDashboard"
-  ],
+  "extends": ["config:base", ":dependencyDashboard"],
   "repositories": ["smartcontractkit/.github"],
   "onboarding": false,
   "requireConfig": "optional",


### PR DESCRIPTION
We don't need renovate creating PRs like https://github.com/smartcontractkit/.github/pull/679 since we allow official GH actions to use semver.