### PR TITLE
Adding a check to ensure that Envoy proxy is up and running

### DIFF
--- a/.changeset/chilled-wombats-tickle.md
+++ b/.changeset/chilled-wombats-tickle.md
@@ -1,0 +1,5 @@
+---
+"setup-gap": minor
+---
+
+Adding a check to ensure that Envoy proxy is up and running.

--- a/actions/setup-gap/action.yml
+++ b/actions/setup-gap/action.yml
@@ -184,3 +184,23 @@ runs:
           -v "${GITHUB_ACTION_PATH}/envoy.yaml":/etc/envoy/envoy.yaml \
           "${ENVOY_PROXY_IMAGE}" \
           /usr/local/bin/envoy -c /etc/envoy/envoy.yaml
+
+    - name: Verify Envoy Proxy
+      if: inputs.use-k8s == 'true'
+      shell: bash
+      env:
+        PROXY_PORT: ${{ inputs.proxy-port }}
+      run: |
+        # Check if the Envoy proxy is up and running on HTTPS port
+        for attempt in {1..10}; do
+          if curl --cacert "${PATH_CERTS_DIR}/ca.crt" https://localhost:${PROXY_PORT} > /dev/null 2>&1; then
+            echo "Envoy proxy is up, and the HTTPS connection is successful."
+            exit 0
+          else
+            echo "Waiting for the Envoy proxy to start... Attempt ${attempt}/10"
+            sleep 3
+          fi
+        done
+
+        echo "Timed out waiting for the Envoy proxy to start."
+        exit 1


### PR DESCRIPTION
## What 

See title. 

## Why 

We would like to ensure that the proxy is up and running. I know that the docker run command should fail if the container exits with a non-zero status, but it would also be nice to verify and confirm that it's up and running.

## Test 

```
Status: Downloaded newer image for envoyproxy/envoy:v1.31.0
2c3d6402e01bc3a935bad0cf38c6f8134c228e71806629a6d4e139d679a87dd4
Run # Check if the Envoy proxy is up and running on HTTPS port 
Waiting for the Envoy proxy to start... Attempt 1/10
Envoy proxy is up, and the HTTPS connection is successful.
```