### PR TITLE
Adding step in setup-go to use GATI Token in pulling private repos

### DIFF
--- a/actions/ctf-run-tests/action.yml
+++ b/actions/ctf-run-tests/action.yml
@@ -162,6 +162,9 @@ inputs:
     required: false
     description: Do not use a go cache
     default: "false"
+  gati_token:
+    required: false
+    description: Token provided by GATI to pull from private repos
 
 runs:
   using: composite
@@ -169,7 +172,7 @@ runs:
     # Setup Tools and libraries
     - name: Setup environment
       if: inputs.run_setup == 'true'
-      uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@49cb1613e96c9ce17f7290e4dabd38f43aa9bd4d # ctf-setup-run-tests-environment@0.0.0
+      uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@2c41e20994aa9c0ae1af1ab467c64ac4acb15f2d # ctf-setup-run-tests-environment@0.0.0
       with:
         test_download_vendor_packages_command:
           ${{ inputs.test_download_vendor_packages_command }}
@@ -186,6 +189,7 @@ runs:
         QA_KUBECONFIG: ${{ inputs.QA_KUBECONFIG }}
         should_tidy: ${{ inputs.should_tidy }}
         no_cache: ${{ inputs.no_cache }}
+        gati_token: ${{ inputs.gati_token }}
 
     - name: Replace chainlink/integration-tests deps
       if: ${{ inputs.dep_chainlink_integration_tests }}

--- a/actions/ctf-setup-go/action.yml
+++ b/actions/ctf-setup-go/action.yml
@@ -47,7 +47,7 @@ runs:
         go-version-file: ${{ inputs.go_mod_path }}
         check-latest: true
         cache: false
-        
+
     - name: Setup Go with private repo access
       shell: bash
       if: ${{ inputs.gati_token != '' }}

--- a/actions/ctf-setup-go/action.yml
+++ b/actions/ctf-setup-go/action.yml
@@ -33,6 +33,9 @@ inputs:
   test_download_vendor_packages_command:
     required: false
     description: The command to download the go modules
+  gati_token:
+    required: false
+    description: GATI token used to pull private repos
 
 runs:
   using: composite
@@ -44,6 +47,13 @@ runs:
         go-version-file: ${{ inputs.go_mod_path }}
         check-latest: true
         cache: false
+        
+    - name: Setup Go with private repo access
+      shell: bash
+      if: ${{ inputs.gati_token != '' }}
+      run: |
+        git config --global url."https://x-access-token:${{ inputs.gati_token }}@github.com/".insteadOf "https://github.com/"
+        go env -w GOPRIVATE=github.com/smartcontractkit/*
 
     - name: Set go cache keys
       shell: bash

--- a/actions/ctf-setup-run-tests-environment/action.yml
+++ b/actions/ctf-setup-run-tests-environment/action.yml
@@ -61,6 +61,9 @@ inputs:
     required: false
     description: Do not use a go cache
     default: "false"
+  gati_token:
+    required: false
+    description: Token provided by GATI to pull from private repos
 
 runs:
   using: composite
@@ -68,7 +71,7 @@ runs:
     # Go setup and caching
     - name: Setup Go
       if: inputs.go_necessary == 'true'
-      uses: smartcontractkit/.github/actions/ctf-setup-go@b0d756c57fcdbcff187e74166562a029fdd5d1b9 # ctf-setup-go@0.0.0
+      uses: smartcontractkit/.github/actions/ctf-setup-go@5a90069d860edbaddc296a139b13e2e97bf463ab # ctf-setup-go@0.0.0
       with:
         go_version: ${{ inputs.go_version }}
         go_mod_path: ${{ inputs.go_mod_path }}
@@ -78,6 +81,7 @@ runs:
         no_cache: ${{ inputs.no_cache }}
         test_download_vendor_packages_command:
           ${{ inputs.test_download_vendor_packages_command }}
+        gati_token: ${{ inputs.gati_token }}
 
     # Setup AWS cred and K8s context
     - name: Configure AWS Credentials


### PR DESCRIPTION
### Description
We have a repository ([chainlink-starknet](https://github.com/smartcontractkit/chainlink-starknet/tree/develop)) that uses [chainlink-testing-framework](https://github.com/smartcontractkit/chainlink-starknet/blob/develop/.github/workflows/integration-tests-smoke.yml#L187) to run it's integration tests. We recently added a dependency on [guauntlet-plus-plus](https://github.com/smartcontractkit/gauntlet-plus-plus) which is a private repo. This is causing our Github CI/CD steps to [fail](https://github.com/smartcontractkit/chainlink-starknet/actions/runs/11859007343/job/33051597179?pr=548) on the step that uses the [chainlink-testing-framework image](https://github.com/smartcontractkit/chainlink-starknet/blob/develop/.github/workflows/integration-tests-smoke.yml#L187). More specifically its failing on the [setup-go step](https://github.com/smartcontractkit/chainlink-github-actions/blob/v2.3.31/chainlink-testing-framework/run-tests/action.yml#L215) where it runs [Tidy and check files](https://github.com/smartcontractkit/chainlink-github-actions/blob/v2.3.31/chainlink-testing-framework/setup-go/action.yml#L83), since the workflow can't pull the private repo when running go mod tidy

After talking with the infra team they advised to use [GATI](https://smartcontract-it.atlassian.net/wiki/spaces/RE/pages/696909854/Github+App+Token+Issuer+GATI+-+Self+Service+Guide) while [setting git configs](https://chainlink-core.slack.com/archives/C038Q8K1HTR/p1731016579870599) in order to pull from private repos

### Changes
Added an extra step that takes in an optional GATI Token that sets git configs before running go mod tidy
Step runs on an if so it's backwards compatible


### Ticket
[NONEVM-642](https://smartcontract-it.atlassian.net/browse/NONEVM-642)

[NONEVM-642]: https://smartcontract-it.atlassian.net/browse/NONEVM-642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ