### PR TITLE
Enables E2E Test Telemetry in GHA

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -593,7 +593,7 @@ jobs:
     steps:
       - name: Collect Test Telemetry
         if: inputs.collect_test_telemetry
-        uses: catchpoint/workflow-telemetry-action@v2.0.0
+        uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2.0.0
       - name: Checkout repository
         uses: actions/checkout@v4.2.1
       - name: Install jq
@@ -894,7 +894,7 @@ jobs:
     steps:
       - name: Collect Test Telemetry
         if: inputs.collect_test_telemetry
-        uses: catchpoint/workflow-telemetry-action@v2.0.0
+        uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2.0.0
       - name: Checkout repository
         uses: actions/checkout@v4.2.1
       - name: Install jq

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -170,6 +170,13 @@ on:
         required: false
         type: boolean
         default: false
+      collect_test_telemetry:
+        description:
+          'Set to "true" to collect telemetry data for E2E tests, helpful for
+          debugging resource issues.'
+        required: false
+        type: boolean
+        default: false
     outputs:
       test_results:
         description: "Test results from all executed tests"
@@ -586,6 +593,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.1
+      - name: Collect Test Telemetry
+        if: inputs.collect_test_telemetry
+        uses: catchpoint/workflow-telemetry-action@v2.0.0
       - name: Install jq
         run: sudo apt-get install -y jq
 
@@ -663,7 +673,6 @@ jobs:
               echo "$key=$value" >> "$GITHUB_ENV"
             done
           fi
-
       - name: Run tests
         id: run_tests
         uses: smartcontractkit/.github/actions/ctf-run-tests@b8731364b119e88983e94b0c4da87fc27ddb41b8 # ctf-run-tests@0.0.0
@@ -885,6 +894,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.1
+      - name: Collect Test Telemetry
+        if: inputs.collect_test_telemetry
+        uses: catchpoint/workflow-telemetry-action@v2.0.0
       - name: Install jq
         run: sudo apt-get install -y jq
 

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -591,11 +591,11 @@ jobs:
         inputs.test_config_override_path }}
       TEST_ID: ${{ matrix.tests.id_sanitized || matrix.tests.id }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4.2.1
       - name: Collect Test Telemetry
         if: inputs.collect_test_telemetry
         uses: catchpoint/workflow-telemetry-action@v2.0.0
+      - name: Checkout repository
+        uses: actions/checkout@v4.2.1
       - name: Install jq
         run: sudo apt-get install -y jq
 
@@ -892,11 +892,11 @@ jobs:
         inputs.test_config_override_path }}
       TEST_ID: ${{ matrix.tests.id_sanitized || matrix.tests.id }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4.2.1
       - name: Collect Test Telemetry
         if: inputs.collect_test_telemetry
         uses: catchpoint/workflow-telemetry-action@v2.0.0
+      - name: Checkout repository
+        uses: actions/checkout@v4.2.1
       - name: Install jq
         run: sudo apt-get install -y jq
 


### PR DESCRIPTION
Setting the new input `collect_test_telemetry` to `true` will utilize the [workflow-telemetry-action](https://github.com/catchpoint/workflow-telemetry-action/tree/v2.0.0/) for E2E test runs.