### PR TITLE
[TT-1806] add support for team input 

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -170,6 +170,10 @@ on:
         required: false
         type: boolean
         default: false
+      team:
+        description: "Team to run the tests for (e.g. BIX, CCIP)"
+        required: false
+        type: string
     outputs:
       test_results:
         description: "Test results from all executed tests"
@@ -247,6 +251,7 @@ env:
     ${{ inputs.slack_notification_after_tests_channel_id || inputs.SLACK_CHANNEL
     || secrets.SLACK_CHANNEL }}
   SLACK_USER: ${{ inputs.SLACK_USER }}
+  CHAINLINK_USER_TEAM: ${{ inputs.team }}
   E2E_JD_IMAGE:
     ${{ secrets.PROD_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{
     secrets.AWS_REGION}}.amazonaws.com/job-distributor
@@ -440,6 +445,14 @@ jobs:
             exit 1
           fi
         shell: bash
+
+      - name: Check if team is required
+        if: ${{ steps.check-matrices.outputs.run-k8s-tests == 'true' }}
+        run: |
+          if [[ -z "${{ inputs.team }}" ]]; then
+            echo "Team is required for k8s tests"
+            exit 1
+          fi
 
       - name: Check if test secrets are required for any test
         shell: bash


### PR DESCRIPTION
and CHAINLINK_USER_TEAM env var in reusable e2e tests; you might ask why we need it? for tracking the costs and assigning them to teams.