### PR TITLE
Adding ECR login to crib-deploy-environment action

### DIFF
--- a/.changeset/small-chairs-care.md
+++ b/.changeset/small-chairs-care.md
@@ -1,0 +1,5 @@
+---
+"crib-deploy-environment": minor
+---
+
+Adding ECR login required for Helm.

--- a/.changeset/small-chairs-care.md
+++ b/.changeset/small-chairs-care.md
@@ -1,5 +1,5 @@
 ---
-"crib-deploy-environment": minor
+"crib-deploy-environment": major
 ---
 
 Adding ECR login required for Helm.

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -264,3 +264,7 @@ runs:
       env:
         SLACK_WEBHOOK_URL: ${{ inputs.crib-alert-slack-webhook }}
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+    - name: Collect Envoy proxy logs when debug is enabled
+      uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e # v2.2.2
+      if: inputs.enable-proxy-debug == 'true' || failure()

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -4,6 +4,9 @@ description:
   an ephemeral environment."
 
 inputs:
+  aws-ecr-private-registry:
+    description: "AWS ECR private registry."
+    required: true
   aws-region:
     description: "AWS region."
     required: true
@@ -78,7 +81,18 @@ inputs:
       costs to the correct product.
   k8s-api-endpoint:
     required: true
-    description: "Endpoint"
+    description: "The Kubernetes API server's endpoint hostname."
+  k8s-api-endpoint-port:
+    required: false
+    default: "443"
+    description: "The port number for accessing the Kubernetes API server."
+  enable-proxy-debug:
+    required: false
+    default: "false"
+    description:
+      "Enable or disable detailed Envoy proxy logs used for K8s API access. When
+      enabled, debug logs are generated locally, and container logs are streamed
+      to the console for troubleshooting."
 outputs:
   devspace-namespace:
     description: "Kubernetes namespace used to provision a CRIB environment."
@@ -88,16 +102,18 @@ runs:
   using: "composite"
   steps:
     - name: Setup GAP
-      uses: smartcontractkit/.github/actions/setup-gap@47a3b0cf4e87a031049eef2d951982c94db04cae # setup-gap@1.0.0
+      uses: smartcontractkit/.github/actions/setup-gap@eb0af287aedae819d71eed8eb3171d4ffb4a9587 # setup-gap@1.2.0
       with:
-        aws-role-arn: ${{ inputs.aws-role-arn }}
         aws-region: ${{ inputs.aws-region }}
+        aws-role-arn: ${{ inputs.aws-role-arn }}
+        enable-proxy-debug: ${{ inputs.enable-proxy-debug }}
+        k8s-api-endpoint-port: ${{ inputs.k8s-api-endpoint-port }}
+        k8s-api-endpoint: ${{ inputs.k8s-api-endpoint }}
         k8s-cluster-name: ${{ inputs.k8s-cluster-name }}
         use-k8s: true
         # Choose port that is less likely to be conflicting with other GAP
         # instances that runs in the same workflow
         proxy-port: 8888
-        k8s-api-endpoint: ${{ inputs.k8s-api-endpoint }}
 
     - name: Checkout crib repo
       uses: actions/checkout@v4.2.1
@@ -106,6 +122,13 @@ runs:
         ref: ${{ inputs.crib-repo-ref }}
         path: "${{ github.workspace }}/crib"
         token: ${{ inputs.github-token }}
+
+    - name: Login to AWS ECR for Helm
+      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+      env:
+        AWS_REGION: ${{ inputs.aws-region }}
+      with:
+        registries: ${{ inputs.aws-ecr-private-registry }}
 
     - name: Setup Nix
       uses: smartcontractkit/.github/actions/setup-nix@4df907a307d91761c15cdff65e508145bdbcfca3 # setup-nix@0.3.0
@@ -180,7 +203,6 @@ runs:
         DEVSPACE_INGRESS_BASE_DOMAIN: ${{ inputs.ingress-base-domain }}
         DEVSPACE_INGRESS_CIDRS: ${{ inputs.devspace-ingress-cidrs }}
         PROFILES: ${{ inputs.devspace-profiles }}
-        KUBECACHEDIR: /dev/null
         SETUP_AWS_PROFILE: false
         SETUP_EKS_CONFIG: false
       run: |
@@ -196,6 +218,7 @@ runs:
         nix develop -c ./cribbit.sh "$DEVSPACE_NAMESPACE"
 
         nix develop -c devspace run ${{ inputs.command }} ${{ inputs.command-args }}
+
     - name: Render notification template
       uses: actions/github-script@v7.0.1
       id: render-slack-template


### PR DESCRIPTION
## What 

- Adding ECR login to the crib-deploy-environment action, required for Helm. Deploying CRIB environments is not possible without this step. Previously, ECR login was only required for the aws-sigv4-proxy image, but now that it’s no longer used, an explicit login step is needed. 
- Bumping the setup-gap action version. The new version includes a fix for connection timeouts and supports passing extra inputs.
- Removed the `KUBECACHEDIR` environment variable, as it is not needed for GAP v2.
- Adding collect Envoy proxy logs step. We have the same step in `setup-gap` actions but it will collect only initial logs so we need it here as well. 

## Why

- Improvements and fixes in order to make CRIB using GAP v2 more reliable. 