### PR TITLE
[NONEVM-641] Starting Gauntlet Plus Plus Container on CTF Run Tests Start up

### DIFF
--- a/.changeset/fluffy-trainers-visit.md
+++ b/.changeset/fluffy-trainers-visit.md
@@ -1,0 +1,7 @@
+---
+"ctf-setup-gauntlet-plus-plus": major
+"ctf-setup-run-tests-environment": minor
+"ctf-run-tests": minor
+---
+
+Adding support to include pulling the gauntlet-plus-plus image from the prod ECR

--- a/actions/ctf-run-tests/action.yml
+++ b/actions/ctf-run-tests/action.yml
@@ -137,10 +137,10 @@ inputs:
   QA_AWS_ROLE_TO_ASSUME:
     required: true
     description: The AWS role to assume
-  QA_PROD_REGION:
+  PROD_AWS_REGION:
     required: false
     description: The AWS region to use for prod ECR
-  QA_PROD_ROLE_TO_ASSUME:
+  PROD_AWS_ROLE_TO_ASSUME:
     required: false
     description: The AWS role to assume for prod ECR
   PROD_AWS_ACCOUNT_NUMBER:
@@ -216,7 +216,11 @@ runs:
     # Setup Tools and libraries
     - name: Setup environment
       if: inputs.run_setup == 'true'
+<<<<<<< HEAD
       uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@ec165ce3098a51462f2bb6713cdc38eb58e89df2 # ctf-setup-run-tests-environment@v0.5.1
+=======
+      uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@6108e14f4e03b1567dac59ca78120d9d167f3b53 # ctf-setup-run-tests-environment@0.0.0
+>>>>>>> 6aeeedd (Version bump and input naming)
       with:
         test_download_vendor_packages_command:
           ${{ inputs.test_download_vendor_packages_command }}

--- a/actions/ctf-run-tests/action.yml
+++ b/actions/ctf-run-tests/action.yml
@@ -218,6 +218,7 @@ runs:
       if: inputs.run_setup == 'true'
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
       uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@ec165ce3098a51462f2bb6713cdc38eb58e89df2 # ctf-setup-run-tests-environment@v0.5.1
 =======
       uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@6108e14f4e03b1567dac59ca78120d9d167f3b53 # ctf-setup-run-tests-environment@0.0.0
@@ -225,6 +226,9 @@ runs:
 =======
       uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@540ca25cc965449220180c96df6350c344f6c2d6 # ctf-setup-run-tests-environment@0.0.0
 >>>>>>> cd2ee12 (bump)
+=======
+      uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@f1517ccb75e9192bcae9689b19606e16f85d0cfe # ctf-setup-run-tests-environment@0.0.0
+>>>>>>> b140c2c (bump)
       with:
         test_download_vendor_packages_command:
           ${{ inputs.test_download_vendor_packages_command }}

--- a/actions/ctf-run-tests/action.yml
+++ b/actions/ctf-run-tests/action.yml
@@ -220,6 +220,7 @@ runs:
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
       uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@ec165ce3098a51462f2bb6713cdc38eb58e89df2 # ctf-setup-run-tests-environment@v0.5.1
 =======
       uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@6108e14f4e03b1567dac59ca78120d9d167f3b53 # ctf-setup-run-tests-environment@0.0.0
@@ -233,6 +234,9 @@ runs:
 =======
       uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@b238ad45b8197cd7a4ea38bff1f0c3fad646489f # ctf-setup-run-tests-environment@0.0.0
 >>>>>>> 6ae9e5f (bump setup test env)
+=======
+      uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@df5058e120d1113b03e03c45c9845c5ceb762074 # ctf-setup-run-tests-environment@0.0.0
+>>>>>>> ce4d9a5 (Bumped version of setup-env)
       with:
         test_download_vendor_packages_command:
           ${{ inputs.test_download_vendor_packages_command }}

--- a/actions/ctf-run-tests/action.yml
+++ b/actions/ctf-run-tests/action.yml
@@ -221,6 +221,7 @@ runs:
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
       uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@ec165ce3098a51462f2bb6713cdc38eb58e89df2 # ctf-setup-run-tests-environment@v0.5.1
 =======
       uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@6108e14f4e03b1567dac59ca78120d9d167f3b53 # ctf-setup-run-tests-environment@0.0.0
@@ -237,6 +238,9 @@ runs:
 =======
       uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@df5058e120d1113b03e03c45c9845c5ceb762074 # ctf-setup-run-tests-environment@0.0.0
 >>>>>>> ce4d9a5 (Bumped version of setup-env)
+=======
+      uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@d4931fff2d0c0b97470136ad414e6a1823cf5535 # ctf-setup-run-tests-environment@0.0.0
+>>>>>>> 1b944d8 (bump run env setup)
       with:
         test_download_vendor_packages_command:
           ${{ inputs.test_download_vendor_packages_command }}

--- a/actions/ctf-run-tests/action.yml
+++ b/actions/ctf-run-tests/action.yml
@@ -137,6 +137,21 @@ inputs:
   QA_AWS_ROLE_TO_ASSUME:
     required: true
     description: The AWS role to assume
+  QA_PROD_REGION:
+    required: false
+    description: The AWS region to use for prod ECR
+  QA_PROD_ROLE_TO_ASSUME:
+    required: false
+    description: The AWS role to assume for prod ECR
+  PROD_AWS_ACCOUNT_NUMBER:
+    required: false
+    description: The AWS Account number for the prod AWS account
+  gauntlet_plus_plus_image:
+    required: false
+    description: Gauntlet-plus-plus image link
+  QA_KUBECONFIG:
+    required: false
+    description: The kubernetes configuration to use
   CGO_ENABLED:
     required: false
     description: Whether to have cgo enabled, defaults to enabled
@@ -217,6 +232,10 @@ runs:
         QA_AWS_ROLE_TO_ASSUME: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}
         should_tidy: ${{ inputs.should_tidy }}
         no_cache: ${{ inputs.no_cache }}
+        PROD_AWS_ROLE_TO_ASSUME: ${{ inputs.PROD_AWS_ROLE_TO_ASSUME }}
+        PROD_AWS_REGION: ${{ inputs.PROD_AWS_REGION }}
+        gauntlet_plus_plus_image: ${{ inputs.gauntlet_plus_plus_image }}
+        prod_aws_account_number: ${{ inputs.PROD_AWS_ACCOUNT_NUMBER }}
         gati_token: ${{ inputs.gati_token }}
         main-dns-zone: ${{ inputs.main-dns-zone }}
         k8s-cluster-name: ${{ inputs.k8s-cluster-name }}

--- a/actions/ctf-run-tests/action.yml
+++ b/actions/ctf-run-tests/action.yml
@@ -216,35 +216,7 @@ runs:
     # Setup Tools and libraries
     - name: Setup environment
       if: inputs.run_setup == 'true'
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-      uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@ec165ce3098a51462f2bb6713cdc38eb58e89df2 # ctf-setup-run-tests-environment@v0.5.1
-=======
-      uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@6108e14f4e03b1567dac59ca78120d9d167f3b53 # ctf-setup-run-tests-environment@0.0.0
->>>>>>> 6aeeedd (Version bump and input naming)
-=======
-      uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@540ca25cc965449220180c96df6350c344f6c2d6 # ctf-setup-run-tests-environment@0.0.0
->>>>>>> cd2ee12 (bump)
-=======
-      uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@f1517ccb75e9192bcae9689b19606e16f85d0cfe # ctf-setup-run-tests-environment@0.0.0
->>>>>>> b140c2c (bump)
-=======
-      uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@b238ad45b8197cd7a4ea38bff1f0c3fad646489f # ctf-setup-run-tests-environment@0.0.0
->>>>>>> 6ae9e5f (bump setup test env)
-=======
-      uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@df5058e120d1113b03e03c45c9845c5ceb762074 # ctf-setup-run-tests-environment@0.0.0
->>>>>>> ce4d9a5 (Bumped version of setup-env)
-=======
-      uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@d4931fff2d0c0b97470136ad414e6a1823cf5535 # ctf-setup-run-tests-environment@0.0.0
->>>>>>> 1b944d8 (bump run env setup)
-=======
-      uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@7eb75e8cf85f9d6237080b62668114cc00aaecfc # ctf-setup-run-tests-environment@0.0.0
->>>>>>> 4229fea (Bump)
+      uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@bf800f15fe032b9dc1230b0a041a1f179b8c2474 # ctf-setup-run-tests-environment@0.0.0
       with:
         test_download_vendor_packages_command:
           ${{ inputs.test_download_vendor_packages_command }}

--- a/actions/ctf-run-tests/action.yml
+++ b/actions/ctf-run-tests/action.yml
@@ -219,6 +219,7 @@ runs:
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
       uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@ec165ce3098a51462f2bb6713cdc38eb58e89df2 # ctf-setup-run-tests-environment@v0.5.1
 =======
       uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@6108e14f4e03b1567dac59ca78120d9d167f3b53 # ctf-setup-run-tests-environment@0.0.0
@@ -229,6 +230,9 @@ runs:
 =======
       uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@f1517ccb75e9192bcae9689b19606e16f85d0cfe # ctf-setup-run-tests-environment@0.0.0
 >>>>>>> b140c2c (bump)
+=======
+      uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@b238ad45b8197cd7a4ea38bff1f0c3fad646489f # ctf-setup-run-tests-environment@0.0.0
+>>>>>>> 6ae9e5f (bump setup test env)
       with:
         test_download_vendor_packages_command:
           ${{ inputs.test_download_vendor_packages_command }}

--- a/actions/ctf-run-tests/action.yml
+++ b/actions/ctf-run-tests/action.yml
@@ -222,6 +222,7 @@ runs:
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
       uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@ec165ce3098a51462f2bb6713cdc38eb58e89df2 # ctf-setup-run-tests-environment@v0.5.1
 =======
       uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@6108e14f4e03b1567dac59ca78120d9d167f3b53 # ctf-setup-run-tests-environment@0.0.0
@@ -241,6 +242,9 @@ runs:
 =======
       uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@d4931fff2d0c0b97470136ad414e6a1823cf5535 # ctf-setup-run-tests-environment@0.0.0
 >>>>>>> 1b944d8 (bump run env setup)
+=======
+      uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@7eb75e8cf85f9d6237080b62668114cc00aaecfc # ctf-setup-run-tests-environment@0.0.0
+>>>>>>> 4229fea (Bump)
       with:
         test_download_vendor_packages_command:
           ${{ inputs.test_download_vendor_packages_command }}

--- a/actions/ctf-run-tests/action.yml
+++ b/actions/ctf-run-tests/action.yml
@@ -217,10 +217,14 @@ runs:
     - name: Setup environment
       if: inputs.run_setup == 'true'
 <<<<<<< HEAD
+<<<<<<< HEAD
       uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@ec165ce3098a51462f2bb6713cdc38eb58e89df2 # ctf-setup-run-tests-environment@v0.5.1
 =======
       uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@6108e14f4e03b1567dac59ca78120d9d167f3b53 # ctf-setup-run-tests-environment@0.0.0
 >>>>>>> 6aeeedd (Version bump and input naming)
+=======
+      uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@540ca25cc965449220180c96df6350c344f6c2d6 # ctf-setup-run-tests-environment@0.0.0
+>>>>>>> cd2ee12 (bump)
       with:
         test_download_vendor_packages_command:
           ${{ inputs.test_download_vendor_packages_command }}

--- a/actions/ctf-run-tests/action.yml
+++ b/actions/ctf-run-tests/action.yml
@@ -216,7 +216,7 @@ runs:
     # Setup Tools and libraries
     - name: Setup environment
       if: inputs.run_setup == 'true'
-      uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@bf800f15fe032b9dc1230b0a041a1f179b8c2474 # ctf-setup-run-tests-environment@0.0.0
+      uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@bf800f15fe032b9dc1230b0a041a1f179b8c2474 # ctf-setup-run-tests-environment@v0.5.1
       with:
         test_download_vendor_packages_command:
           ${{ inputs.test_download_vendor_packages_command }}

--- a/actions/ctf-setup-gauntlet-plus-plus/action.yml
+++ b/actions/ctf-setup-gauntlet-plus-plus/action.yml
@@ -47,6 +47,7 @@ runs:
         role-duration-seconds: ${{ inputs.aws_role_duration_seconds }}
         mask-aws-account-id: true
     - name: Pull Gauntlet Plus Plus Image
+      shell: bash  # Specify the shell to be used
       run: |
         docker pull ${{ inputs.gauntlet_plus_plus_image }}
     

--- a/actions/ctf-setup-gauntlet-plus-plus/action.yml
+++ b/actions/ctf-setup-gauntlet-plus-plus/action.yml
@@ -30,15 +30,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Login to Amazon ECR
-      if: inputs.aws_registries && inputs.PROD_AWS_REGION
-      id: login-ecr
-      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
-      with:
-        registries: ${{ inputs.aws_account_number }}
-      env:
-        AWS_REGION: ${{ inputs.PROD_AWS_REGION }}
-  # Setup AWS cred and K8s context
+   # Setup AWS cred and K8s context
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
       with:
@@ -46,6 +38,14 @@ runs:
         role-to-assume: ${{ inputs.PROD_AWS_ROLE_TO_ASSUME }}
         role-duration-seconds: ${{ inputs.aws_role_duration_seconds }}
         mask-aws-account-id: true
+    - name: Login to Amazon ECR
+      if: inputs.aws_account_number && inputs.PROD_AWS_REGION
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+      with:
+        registries: ${{ inputs.aws_account_number }}
+      env:
+        AWS_REGION: ${{ inputs.PROD_AWS_REGION }}
     - name: Pull Gauntlet Plus Plus Image
       shell: bash  # Specify the shell to be used
       run: |

--- a/actions/ctf-setup-gauntlet-plus-plus/action.yml
+++ b/actions/ctf-setup-gauntlet-plus-plus/action.yml
@@ -1,0 +1,52 @@
+name: ctf-setup-gauntlet-plus-plus
+description: "Common gauntlet-plus-plus setup for CTF"
+
+inputs:
+  dockerhub_username:
+    description:
+      Username for Docker Hub to avoid rate limits when pulling public images
+    required: false
+  dockerhub_password:
+    description:
+      Password for Docker Hub to avoid rate limits when pulling public images
+    required: false
+  PROD_AWS_REGION:
+    required: true
+    description: The AWS region to use
+  PROD_AWS_ROLE_TO_ASSUME:
+    required: true
+    description: The AWS role to assume
+  gauntlet_plus_plus_image:
+    required: true
+    description: Gauntlet-plus-plus image link
+  aws_role_duration_seconds:
+    required: false
+    default: "3600"
+    description: The duration to be logged into the aws role for
+  aws_account_number:
+    required: true
+    description: AWS Account number that holds the gauntlet_plus_plus 
+
+runs:
+  using: composite
+  steps:
+    - name: Login to Amazon ECR
+      if: inputs.aws_registries && inputs.PROD_AWS_REGION
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+      with:
+        registries: ${{ inputs.aws_account_number }}
+      env:
+        AWS_REGION: ${{ inputs.PROD_AWS_REGION }}
+  # Setup AWS cred and K8s context
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+      with:
+        aws-region: ${{ inputs.PROD_AWS_REGION }}
+        role-to-assume: ${{ inputs.PROD_AWS_ROLE_TO_ASSUME }}
+        role-duration-seconds: ${{ inputs.aws_role_duration_seconds }}
+        mask-aws-account-id: true
+    - name: Pull Gauntlet Plus Plus Image
+      run: |
+        docker pull ${{ inputs.gauntlet_plus_plus_image }}
+    

--- a/actions/ctf-setup-gauntlet-plus-plus/action.yml
+++ b/actions/ctf-setup-gauntlet-plus-plus/action.yml
@@ -25,12 +25,12 @@ inputs:
     description: The duration to be logged into the aws role for
   aws_account_number:
     required: true
-    description: AWS Account number that holds the gauntlet_plus_plus 
+    description: AWS Account number that holds the gauntlet_plus_plus
 
 runs:
   using: composite
   steps:
-   # Setup AWS cred and K8s context
+    # Setup AWS cred and K8s context
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
       with:
@@ -47,7 +47,6 @@ runs:
       env:
         AWS_REGION: ${{ inputs.PROD_AWS_REGION }}
     - name: Pull Gauntlet Plus Plus Image
-      shell: bash  # Specify the shell to be used
+      shell: bash # Specify the shell to be used
       run: |
         docker pull ${{ inputs.gauntlet_plus_plus_image }}
-    

--- a/actions/ctf-setup-gauntlet-plus-plus/package.json
+++ b/actions/ctf-setup-gauntlet-plus-plus/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ctf-setup-gauntlet-plus-plus",
+  "version": "0.1.1",
+  "description": "Action that pulls the gauntlet-plus-plus image",
+  "private": true,
+  "scripts": {},
+  "author": "@smartcontractkit",
+  "license": "MIT",
+  "dependencies": {},
+  "repository": "https://github.com/smartcontractkit/.github"
+}

--- a/actions/ctf-setup-gauntlet-plus-plus/project.json
+++ b/actions/ctf-setup-gauntlet-plus-plus/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "ctf-setup-gauntlet-plus-plus",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "actions/ctf-setup-gauntlet-plus-plus",
+  "targets": {}
+}

--- a/actions/ctf-setup-run-tests-environment/action.yml
+++ b/actions/ctf-setup-run-tests-environment/action.yml
@@ -50,7 +50,7 @@ inputs:
   QA_AWS_ROLE_TO_ASSUME:
     required: true
     description: The AWS role to assume
-  PROD_REGION:
+  PROD_AWS_REGION:
     required: false
     description: The AWS region to use for prod ECR
   PROD_AWS_ROLE_TO_ASSUME:
@@ -67,7 +67,7 @@ inputs:
     required: false
     description: Do not use a go cache
     default: "false"
-  gauntlet-plus-plus-image:
+  gauntlet_plus_plus_image:
     required: false
     description: Gauntlet-plus-plus image link
   prod_aws_account_number:
@@ -139,7 +139,7 @@ runs:
         docker_password: ${{ inputs.docker_password }}
         PROD_AWS_REGION: ${{ inputs.PROD_AWS_REGION }}
         PROD_AWS_ROLE_TO_ASSUME: ${{ inputs.PROD_AWS_ROLE_TO_ASSUME }}
-        gauntlet_plus_plus_image: ${{ inputs.gauntlet-plus-plus-image }}
+        gauntlet_plus_plus_image: ${{ inputs.gauntlet_plus_plus_image }}
         aws_account_number: ${{ inputs.prod_aws_account_number }}
 
     # Setup AWS cred and K8s context

--- a/actions/ctf-setup-run-tests-environment/action.yml
+++ b/actions/ctf-setup-run-tests-environment/action.yml
@@ -133,7 +133,7 @@ runs:
     # Setup Gauntlet plus plus
     - name: Setup gauntlet plus plus
       if: inputs.gauntlet_plus_plus_image
-      uses: smartcontractkit/.github/actions/ctf-setup-gauntlet-plus-plus@c5420f0c8a0386c0ce7af20c09381384fb5fa1ca # ctf-setup-gauntlet-plus-plus@0.0.1
+      uses: smartcontractkit/.github/actions/ctf-setup-gauntlet-plus-plus@11b8e8eda31ec2711f0b9f4ee71547c6b740d2ff # ctf-setup-gauntlet-plus-plus@0.0.1
       with:
         dockerhub_username: ${{ inputs.docker_username }}
         dockerhub_password: ${{ inputs.docker_password }}
@@ -141,6 +141,7 @@ runs:
         PROD_AWS_ROLE_TO_ASSUME: ${{ inputs.PROD_AWS_ROLE_TO_ASSUME }}
         gauntlet_plus_plus_image: ${{ inputs.gauntlet_plus_plus_image }}
         aws_account_number: ${{ inputs.prod_aws_account_number }}
+
 
     # Setup AWS cred and K8s context
     - name: Configure AWS Credentials

--- a/actions/ctf-setup-run-tests-environment/action.yml
+++ b/actions/ctf-setup-run-tests-environment/action.yml
@@ -133,7 +133,7 @@ runs:
     # Setup Gauntlet plus plus
     - name: Setup gauntlet plus plus
       if: inputs.gauntlet-plus-plus-image
-      uses: smartcontractkit/.github/actions/ctf-setup-gauntlet-plus-plus@766e45ddea246a5375350b3b270545e9dd186dc5 # ctf-setup-gauntlet-plus-plus@0.0.1
+      uses: smartcontractkit/.github/actions/ctf-setup-gauntlet-plus-plus@c5420f0c8a0386c0ce7af20c09381384fb5fa1ca # ctf-setup-gauntlet-plus-plus@0.0.1
       with:
         docker_username: ${{ inputs.docker_username }}
         docker_password: ${{ inputs.docker_password }}

--- a/actions/ctf-setup-run-tests-environment/action.yml
+++ b/actions/ctf-setup-run-tests-environment/action.yml
@@ -58,6 +58,9 @@ inputs:
     required: false
     description: Do not use a go cache
     default: "false"
+  gauntlet-plus-plus-image:
+    required: false
+    description: Gauntlet-plus-plus image link
   gati_token:
     required: false
     description: Token provided by GATI to pull from private repos
@@ -115,6 +118,9 @@ runs:
           ${{ inputs.test_download_vendor_packages_command }}
         gati_token: ${{ inputs.gati_token }}
 
+    # Setup Gauntlet plus plus
+    - name: Setup gauntlet plus plus
+      if: inputs.
     # Setup AWS cred and K8s context
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1

--- a/actions/ctf-setup-run-tests-environment/action.yml
+++ b/actions/ctf-setup-run-tests-environment/action.yml
@@ -132,7 +132,7 @@ runs:
 
     # Setup Gauntlet plus plus
     - name: Setup gauntlet plus plus
-      if: inputs.gauntlet-plus-plus-image
+      if: inputs.gauntlet_plus_plus_image
       uses: smartcontractkit/.github/actions/ctf-setup-gauntlet-plus-plus@c5420f0c8a0386c0ce7af20c09381384fb5fa1ca # ctf-setup-gauntlet-plus-plus@0.0.1
       with:
         docker_username: ${{ inputs.docker_username }}

--- a/actions/ctf-setup-run-tests-environment/action.yml
+++ b/actions/ctf-setup-run-tests-environment/action.yml
@@ -72,7 +72,7 @@ inputs:
     description: Gauntlet-plus-plus image link
   prod_aws_account_number:
     required: false
-    description: AWS Account number that holds the gauntlet_plus_plus 
+    description: AWS Account number that holds the gauntlet_plus_plus
   gati_token:
     required: false
     description: Token provided by GATI to pull from private repos
@@ -141,7 +141,6 @@ runs:
         PROD_AWS_ROLE_TO_ASSUME: ${{ inputs.PROD_AWS_ROLE_TO_ASSUME }}
         gauntlet_plus_plus_image: ${{ inputs.gauntlet_plus_plus_image }}
         aws_account_number: ${{ inputs.prod_aws_account_number }}
-
 
     # Setup AWS cred and K8s context
     - name: Configure AWS Credentials

--- a/actions/ctf-setup-run-tests-environment/action.yml
+++ b/actions/ctf-setup-run-tests-environment/action.yml
@@ -133,7 +133,7 @@ runs:
     # Setup Gauntlet plus plus
     - name: Setup gauntlet plus plus
       if: inputs.gauntlet-plus-plus-image
-      uses: smartcontractkit/.github/actions/ctf-setup-gauntlet-plus-plus@d22636b73d294dfbe828f720efe27348c35d080f # ctf-setup-gauntlet-plus-plus@0.0.1
+      uses: smartcontractkit/.github/actions/ctf-setup-gauntlet-plus-plus@766e45ddea246a5375350b3b270545e9dd186dc5 # ctf-setup-gauntlet-plus-plus@0.0.1
       with:
         docker_username: ${{ inputs.docker_username }}
         docker_password: ${{ inputs.docker_password }}

--- a/actions/ctf-setup-run-tests-environment/action.yml
+++ b/actions/ctf-setup-run-tests-environment/action.yml
@@ -50,6 +50,15 @@ inputs:
   QA_AWS_ROLE_TO_ASSUME:
     required: true
     description: The AWS role to assume
+  QA_PROD_REGION:
+    required: false
+    description: The AWS region to use for prod ECR
+  QA_PROD_ROLE_TO_ASSUME:
+    required: false
+    description: The AWS role to assume for prod ECR
+  QA_KUBECONFIG:
+    required: false
+    description: The kubernetes configuration to use
   should_tidy:
     required: false
     description: Should we check go mod tidy
@@ -61,6 +70,9 @@ inputs:
   gauntlet-plus-plus-image:
     required: false
     description: Gauntlet-plus-plus image link
+  prod_aws_account_number:
+    required: false
+    description: AWS Account number that holds the gauntlet_plus_plus 
   gati_token:
     required: false
     description: Token provided by GATI to pull from private repos
@@ -120,7 +132,16 @@ runs:
 
     # Setup Gauntlet plus plus
     - name: Setup gauntlet plus plus
-      if: inputs.
+      if: inputs.gauntlet-plus-plus-image
+      uses: smartcontractkit/.github/actions/ctf-setup-gauntlet-plus-plus@4e65fe3bff04025815b53ba96e20447e386420f6 # ctf-setup-gauntlet-plus-plus@0.0.1
+      with:
+        docker_username: ${{ inputs.docker_username }}
+        docker_password: ${{ inputs.docker_password }}
+        PROD_AWS_REGION: ${{ inputs.PROD_AWS_REGION }}
+        PROD_AWS_ROLE_TO_ASSUME: ${{ inputs.PROD_AWS_ROLE_TO_ASSUME }}
+        gauntlet_plus_plus_image: ${{ inputs.gauntlet-plus-plus-image }}
+        aws_account_number: ${{ prod_aws_account_number }}
+        
     # Setup AWS cred and K8s context
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1

--- a/actions/ctf-setup-run-tests-environment/action.yml
+++ b/actions/ctf-setup-run-tests-environment/action.yml
@@ -50,10 +50,10 @@ inputs:
   QA_AWS_ROLE_TO_ASSUME:
     required: true
     description: The AWS role to assume
-  QA_PROD_REGION:
+  PROD_REGION:
     required: false
     description: The AWS region to use for prod ECR
-  QA_PROD_ROLE_TO_ASSUME:
+  PROD_AWS_ROLE_TO_ASSUME:
     required: false
     description: The AWS role to assume for prod ECR
   QA_KUBECONFIG:
@@ -140,7 +140,7 @@ runs:
         PROD_AWS_REGION: ${{ inputs.PROD_AWS_REGION }}
         PROD_AWS_ROLE_TO_ASSUME: ${{ inputs.PROD_AWS_ROLE_TO_ASSUME }}
         gauntlet_plus_plus_image: ${{ inputs.gauntlet-plus-plus-image }}
-        aws_account_number: ${{ prod_aws_account_number }}
+        aws_account_number: ${{ inputs.prod_aws_account_number }}
 
     # Setup AWS cred and K8s context
     - name: Configure AWS Credentials

--- a/actions/ctf-setup-run-tests-environment/action.yml
+++ b/actions/ctf-setup-run-tests-environment/action.yml
@@ -135,8 +135,8 @@ runs:
       if: inputs.gauntlet_plus_plus_image
       uses: smartcontractkit/.github/actions/ctf-setup-gauntlet-plus-plus@c5420f0c8a0386c0ce7af20c09381384fb5fa1ca # ctf-setup-gauntlet-plus-plus@0.0.1
       with:
-        docker_username: ${{ inputs.docker_username }}
-        docker_password: ${{ inputs.docker_password }}
+        dockerhub_username: ${{ inputs.docker_username }}
+        dockerhub_password: ${{ inputs.docker_password }}
         PROD_AWS_REGION: ${{ inputs.PROD_AWS_REGION }}
         PROD_AWS_ROLE_TO_ASSUME: ${{ inputs.PROD_AWS_ROLE_TO_ASSUME }}
         gauntlet_plus_plus_image: ${{ inputs.gauntlet_plus_plus_image }}

--- a/actions/ctf-setup-run-tests-environment/action.yml
+++ b/actions/ctf-setup-run-tests-environment/action.yml
@@ -133,7 +133,7 @@ runs:
     # Setup Gauntlet plus plus
     - name: Setup gauntlet plus plus
       if: inputs.gauntlet-plus-plus-image
-      uses: smartcontractkit/.github/actions/ctf-setup-gauntlet-plus-plus@4e65fe3bff04025815b53ba96e20447e386420f6 # ctf-setup-gauntlet-plus-plus@0.0.1
+      uses: smartcontractkit/.github/actions/ctf-setup-gauntlet-plus-plus@d22636b73d294dfbe828f720efe27348c35d080f # ctf-setup-gauntlet-plus-plus@0.0.1
       with:
         docker_username: ${{ inputs.docker_username }}
         docker_password: ${{ inputs.docker_password }}
@@ -141,7 +141,7 @@ runs:
         PROD_AWS_ROLE_TO_ASSUME: ${{ inputs.PROD_AWS_ROLE_TO_ASSUME }}
         gauntlet_plus_plus_image: ${{ inputs.gauntlet-plus-plus-image }}
         aws_account_number: ${{ prod_aws_account_number }}
-        
+
     # Setup AWS cred and K8s context
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,8 @@ importers:
 
   actions/ctf-run-tests-binary: {}
 
+  actions/ctf-setup-gauntlet-plus-plus: {}
+
   actions/ctf-setup-go: {}
 
   actions/ctf-setup-run-tests-environment: {}


### PR DESCRIPTION
### Description
As part of the effort to migrate the [chainlink-starknet](https://github.com/smartcontractkit/chainlink-starknet) E2E tests from legacy gauntlet to gauntlet++ we need to start an instance of Gpp on E2E test initialization. This ticket pulls the image from the Prod ECR which would allow the E2E tests to use for its container

### Changes
Added an extra action that pull the gauntlet-plus-plus image from the Prod ECR


### Ticket
[NONEVM-641](https://smartcontract-it.atlassian.net/browse/NONEVM-641)

[NONEVM-641]: https://smartcontract-it.atlassian.net/browse/NONEVM-641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ