### PR TITLE
Adding support for using a custom header for passing Github OIDC JWT Auth token

### DIFF
--- a/.changeset/violet-melons-fix.md
+++ b/.changeset/violet-melons-fix.md
@@ -1,0 +1,5 @@
+---
+"setup-gap": major
+---
+
+Adding support for using a custom header for passing Github OIDC JWT token.

--- a/actions/setup-gap/action.yml
+++ b/actions/setup-gap/action.yml
@@ -51,10 +51,6 @@ inputs:
     description:
       "The region for the EKS cluster, if different from aws-region input."
     required: false
-  envoy-proxy-image:
-    description: "Envoy Proxy image used to run Envoy proxy for GAP"
-    required: false
-    default: "envoyproxy/envoy:v1.32.0"
   k8s-api-endpoint:
     required: true
     description: "The Kubernetes API server's endpoint hostname."
@@ -62,6 +58,7 @@ inputs:
     required: false
     default: "443"
     description: "The port number for accessing the Kubernetes API server."
+  # local proxy inputs
   enable-proxy-debug:
     required: false
     default: "false"
@@ -69,6 +66,17 @@ inputs:
       "Enable or disable detailed Envoy proxy logs used for K8s API access. When
       enabled, debug logs are generated locally, and container logs are streamed
       to the console for troubleshooting."
+  envoy-github-oidc-token-header-name:
+    required: false
+    default: "x-authorization-github-jwt"
+    description:
+      "Specifies the name of the HTTP header used to pass the GitHub OIDC JWT
+      token. This header is automatically injected by the local proxy and must
+      not be the same as the default 'Authorization' header."
+  envoy-proxy-image:
+    description: "Envoy Proxy image used to run Envoy proxy for GAP"
+    required: false
+    default: "envoyproxy/envoy:v1.32.0"
 
 outputs:
   gh-jwt-token:
@@ -176,13 +184,15 @@ runs:
       if: inputs.use-k8s == 'true'
       shell: sh
       env:
-        PROXY_PORT: ${{ inputs.proxy-port }}
-        JWT_TOKEN: ${{ steps.get-jwt-token.outputs.token }}
-        K8S_API_ENDPOINT: ${{ inputs.k8s-api-endpoint }}
-        K8S_API_ENDPOINT_PORT: ${{ inputs.k8s-api-endpoint-port }}
-        ENVOY_PROXY_IMAGE: ${{ inputs.envoy-proxy-image }}
         ENABLE_PROXY_DEBUG: ${{ inputs.enable-proxy-debug }}
         ENVOY_LOG_LEVEL: "info"
+        ENVOY_PROXY_IMAGE: ${{ inputs.envoy-proxy-image }}
+        ENVOY_GITHUB_OIDC_TOKEN_HEDER_NAME:
+          ${{ inputs.envoy-github-oidc-token-header-name }}
+        JWT_TOKEN: ${{ steps.get-jwt-token.outputs.token }}
+        K8S_API_ENDPOINT_PORT: ${{ inputs.k8s-api-endpoint-port }}
+        K8S_API_ENDPOINT: ${{ inputs.k8s-api-endpoint }}
+        PROXY_PORT: ${{ inputs.proxy-port }}
       run: |
         # Generate Envoy config from template
         ls -l

--- a/actions/setup-gap/envoy.yaml.template
+++ b/actions/setup-gap/envoy.yaml.template
@@ -27,14 +27,9 @@ static_resources:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
                       inline_code: |
                         function envoy_on_request(request_handle)
-                          local auth_header = request_handle:headers():get("authorization")
-                          if auth_header then
-                            request_handle:headers():add("x-original-authorization", auth_header)
-                            request_handle:headers():remove("authorization")
-                          end
                           request_handle:headers():remove("host")
                           request_handle:headers():add("host", "${K8S_API_ENDPOINT}")
-                          request_handle:headers():add("authorization", "Bearer ${JWT_TOKEN}")
+                          request_handle:headers():add("${ENVOY_GITHUB_OIDC_TOKEN_HEDER_NAME}", "Bearer ${JWT_TOKEN}")
                         end
                   - name: envoy.filters.http.router
                     typed_config:


### PR DESCRIPTION
## What 

See title. 

## Why 

We would like to use a custom header to avoid interfering with the default Authorization header, which would require changes on the app side. Also, sorting out the list of the ENVs.