### PR TITLE
Adding support for using a custom header for passing Github OIDC JWT Auth token to crib-deploy-environment action

### DIFF
--- a/.changeset/friendly-berries-remember.md
+++ b/.changeset/friendly-berries-remember.md
@@ -1,0 +1,5 @@
+---
+"crib-deploy-environment": major
+---
+
+Adding support for using a custom header for passing Github OIDC JWT Auth token.

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -102,7 +102,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup GAP
-      uses: smartcontractkit/.github/actions/setup-gap@eb0af287aedae819d71eed8eb3171d4ffb4a9587 # setup-gap@1.2.0
+      uses: smartcontractkit/.github/actions/setup-gap@fd77e6fbbbac7e6a2f440df7deac80074fc7acb8 # setup-gap@2.0.0
       with:
         aws-region: ${{ inputs.aws-region }}
         aws-role-arn: ${{ inputs.aws-role-arn }}


### PR DESCRIPTION
## What 

See title. 

## Why 

Bumping the `setup-gap` action version: https://github.com/smartcontractkit/.github/pull/721