### PR TITLE
setting up go before running CRIB (ensures GOBIN is in place)

### DIFF
--- a/.changeset/long-carpets-unite.md
+++ b/.changeset/long-carpets-unite.md
@@ -1,0 +1,5 @@
+---
+"crib-deploy-environment": minor
+---
+
+setting up go before running CRIB to ensure GOBIN is properly set

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -139,6 +139,11 @@ runs:
       with:
         registries: ${{ inputs.aws-ecr-private-registry }}
 
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: "${{ github.workspace }}/crib/go.work"
+        cache-dependency-path: "${{ github.workspace }}/crib/**/*.sum"
+
     - name: Setup Nix
       uses: smartcontractkit/.github/actions/setup-nix@4df907a307d91761c15cdff65e508145bdbcfca3 # setup-nix@0.3.0
       with:


### PR DESCRIPTION
this should fix the issue related to the crib executable not being found in PATH, as well as caching dependencies

closes [CRIB-561 ](https://smartcontract-it.atlassian.net/browse/CRIB-561)