### PR TITLE
CRIB-562: setting up go before running CRIB to ensure GOBIN is properly set

### DIFF
--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -171,6 +171,7 @@ runs:
         DEVSPACE_IMAGE_TAG: "${{inputs.product-image-tag}}"
         DEVSPACE_INGRESS_BASE_DOMAIN: ${{ inputs.ingress-base-domain }}
         DEVSPACE_INGRESS_CIDRS: ${{ inputs.devspace-ingress-cidrs }}
+        GH_TOKEN: ${{ inputs.github-token }}
         PROFILES: ${{ inputs.devspace-profiles }}
         KUBECACHEDIR: /dev/null
         SETUP_AWS_PROFILE: false
@@ -182,12 +183,8 @@ runs:
         export DEVSPACE_NAMESPACE="${{ steps.generate-ns-name.outputs.devspace-namespace }}"
         echo "Using $DEVSPACE_NAMESPACE Kubernetes namespace"
 
-        # Kyverno needs some time to inject the RoleBinding
-        sleep 3
+        nix develop -c /bin/bash -c "devspace use namespace ${DEVSPACE_NAMESPACE} && devspace run ${{ inputs.command }} ${{ inputs.command-args }}"
 
-        nix develop -c ./cribbit.sh "$DEVSPACE_NAMESPACE"
-
-        nix develop -c devspace run ${{ inputs.command }} ${{ inputs.command-args }}
     - name: Render notification template
       uses: actions/github-script@v7.0.1
       id: render-slack-template

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -106,6 +106,11 @@ runs:
         path: "${{ github.workspace }}/crib"
         token: ${{ inputs.github-token }}
 
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: "${{ github.workspace }}/crib/go.work"
+        cache-dependency-path: "${{ github.workspace }}/crib/**/*.sum"
+
     - name: Setup Nix
       uses: smartcontractkit/.github/actions/setup-nix@4df907a307d91761c15cdff65e508145bdbcfca3 # setup-nix@0.3.0
       with:


### PR DESCRIPTION
this should fix the issue related to the crib executable not being found in PATH, as well as caching dependencies

had to be derived from tag `crib-deploy-environment@2.1.0` in order to fix https://github.com/smartcontractkit/chainlink/pull/15399 prior to moving it to GAP v2 (currently undergoing). THIS IS A SHORT TERM FIX, NOT MEANT TO BE MERGED OR DELETED.

tagged manually as `crib-deploy-environment@2.1.1`

UPDATE: commit `d4d9ce3fad044642d8d2f7ae5aca9f8c78b0073a` in this branch tagged as `crib-deploy-environment@2.1.2`