### PR TITLE
CRIB-411: removing redundant call to cribbit.sh

### DIFF
--- a/.changeset/happy-ties-return.md
+++ b/.changeset/happy-ties-return.md
@@ -1,0 +1,6 @@
+---
+"crib-deploy-environment": minor
+---
+
+removing unnecessary call to `cribbit.sh` (deprecated as of
+https://github.com/smartcontractkit/crib/pull/267)

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -227,12 +227,7 @@ runs:
         export DEVSPACE_NAMESPACE="${{ steps.generate-ns-name.outputs.devspace-namespace }}"
         echo "Using $DEVSPACE_NAMESPACE Kubernetes namespace"
 
-        # Kyverno needs some time to inject the RoleBinding
-        sleep 3
-
-        nix develop -c ./cribbit.sh "$DEVSPACE_NAMESPACE"
-
-        nix develop -c devspace run ${{ inputs.command }} ${{ inputs.command-args }}
+        nix develop -c /bin/bash -c "devspace use namespace ${DEVSPACE_NAMESPACE} && devspace run ${{ inputs.command }} ${{ inputs.command-args }}"
 
     - name: Render notification template
       uses: actions/github-script@v7.0.1


### PR DESCRIPTION
cribbit.sh is deprecated
Also, the CRIB CLI has the logic to ensure the namespace is ready (which includes waiting for the rolebinding creation), so no need to sleep before calling it anymore