### PR TITLE
added GH_TOKEN env var for crib-deploy-environment

### DIFF
--- a/.changeset/tiny-garlics-remain.md
+++ b/.changeset/tiny-garlics-remain.md
@@ -1,0 +1,5 @@
+---
+"crib-deploy-environment": minor
+---
+
+added GH_TOKEN env var so the github CLI can be used when spinning up CRIB in CI

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -216,6 +216,7 @@ runs:
         DEVSPACE_IMAGE_TAG: "${{inputs.product-image-tag}}"
         DEVSPACE_INGRESS_BASE_DOMAIN: ${{ inputs.ingress-base-domain }}
         DEVSPACE_INGRESS_CIDRS: ${{ inputs.devspace-ingress-cidrs }}
+        GH_TOKEN: ${{ inputs.github-token }}
         PROFILES: ${{ inputs.devspace-profiles }}
         SETUP_AWS_PROFILE: false
         SETUP_EKS_CONFIG: false


### PR DESCRIPTION
required by https://github.com/smartcontractkit/crib/pull/189