### PR TITLE
Use go version from cli/go.mod

### DIFF
--- a/.changeset/seven-pillows-admire.md
+++ b/.changeset/seven-pillows-admire.md
@@ -1,0 +1,6 @@
+---
+"crib-deploy-environment": minor
+---
+
+Derive go version from cli/go.mod instead of go.work, as go.work is being
+deleted from crib project

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -141,7 +141,7 @@ runs:
 
     - uses: actions/setup-go@v5
       with:
-        go-version-file: "${{ github.workspace }}/crib/go.work"
+        go-version-file: "${{ github.workspace }}/crib/cli/go.mod"
         cache-dependency-path: "${{ github.workspace }}/crib/**/*.sum"
 
     - name: Setup Nix


### PR DESCRIPTION
This is required for https://github.com/smartcontractkit/crib/pull/253 to work
Tested here: https://github.com/smartcontractkit/crib/actions/runs/12141161594