### PR TITLE
[TT-1862] Remove logstream e2e workflow

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -694,9 +694,6 @@ jobs:
           E2E_TEST_CHAINLINK_VERSION:
             ${{ matrix.tests.test_env_vars.E2E_TEST_CHAINLINK_VERSION ||
             env.DEFAULT_CHAINLINK_VERSION }}
-          E2E_TEST_LOGGING_RUN_ID: ${{ github.run_id }}
-          E2E_TEST_LOG_STREAM_LOG_TARGETS: ${{ vars.LOGSTREAM_LOG_TARGETS }}
-          E2E_TEST_LOG_COLLECT: ${{ vars.TEST_LOG_COLLECT }}
           E2E_TEST_LOKI_TENANT_ID: ${{ secrets.LOKI_TENANT_ID }}
           E2E_TEST_LOKI_ENDPOINT: ${{ secrets.LOKI_URL }}
           E2E_TEST_LOKI_BASIC_AUTH: ${{ secrets.LOKI_BASIC_AUTH }}
@@ -973,9 +970,6 @@ jobs:
           E2E_TEST_CHAINLINK_VERSION:
             ${{ matrix.tests.test_env_vars.E2E_TEST_CHAINLINK_VERSION ||
             env.DEFAULT_CHAINLINK_VERSION }}
-          E2E_TEST_LOGGING_RUN_ID: ${{ github.run_id }}
-          E2E_TEST_LOG_STREAM_LOG_TARGETS: ${{ vars.LOGSTREAM_LOG_TARGETS }}
-          E2E_TEST_LOG_COLLECT: ${{ vars.TEST_LOG_COLLECT }}
           E2E_TEST_LOKI_TENANT_ID: ${{ secrets.LOKI_TENANT_ID }}
           E2E_TEST_LOKI_ENDPOINT: ${{ secrets.LOKI_URL }}
           E2E_TEST_LOKI_BASIC_AUTH: ${{ secrets.LOKI_BASIC_AUTH }}

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -733,6 +733,8 @@ jobs:
           artifacts_location: |
             ./integration-tests/smoke/logs/
             ./integration-tests/smoke/db_dumps/
+            ./integration-tests/smoke/ccip/logs/
+            ./integration-tests/smoke/ccip/db_dumps/            
             /tmp/gotest.log
           publish_check_name: ${{ env.TEST_ID }}
           token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -243,6 +243,8 @@ jobs:
           artifacts_location: |
             ./integration-tests/smoke/logs/
             ./integration-tests/smoke/db_dumps/
+            ./integration-tests/smoke/ccip/logs/
+            ./integration-tests/smoke/ccip/db_dumps/
             /tmp/gotest.log
           token: ${{ secrets.GH_TOKEN }}
           go_mod_path: ./integration-tests/go.mod

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -229,9 +229,6 @@ jobs:
         uses: smartcontractkit/.github/actions/ctf-run-tests@b8731364b119e88983e94b0c4da87fc27ddb41b8 # ctf-run-tests@0.0.0
         env:
           CL_DATABASE_URL: ${{ env.DB_URL }}
-          E2E_TEST_LOGGING_RUN_ID: ${{ github.run_id }}
-          E2E_TEST_LOG_STREAM_LOG_TARGETS: ${{ vars.LOGSTREAM_LOG_TARGETS }}
-          E2E_TEST_LOG_COLLECT: ${{ vars.TEST_LOG_COLLECT }}
         with:
           test_command_to_run:
             ${{ matrix.tests.test_cmd }} ${{ matrix.tests.test_cmd_opts || '2>&1


### PR DESCRIPTION
This PR:
* removes `logstream` related variables from resuable e2e workflow
* adds default ccip smoke test folders to artifact location (currently they are never uploaded)