### PR TITLE
signaling the nix shell to build CLI only when changes were made to it

### DIFF
--- a/.changeset/cool-games-teach.md
+++ b/.changeset/cool-games-teach.md
@@ -1,0 +1,10 @@
+---
+"crib-deploy-environment": major
+---
+
+WHAT: Building CLI only when changes are detected.
+WHY: This is required so we can push new changes to the CLI and have them tested against the version we're actually pushing. This is backwards-incompatible because it requires the `pull-requests: read` permission
+
+### Action required
+
+When upgrading, make sure you add: `pull-requests: read` to your permission set. Otherwise you should see an error like `Error: Resource not accessible by integration`.

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -132,6 +132,13 @@ runs:
         path: "${{ github.workspace }}/crib"
         token: ${{ inputs.github-token }}
 
+    - name: Detect if the CLI was changed, only build if needed
+      uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          cli: './cli/**'
+
     - name: Login to AWS ECR for Helm
       uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
       env:
@@ -210,6 +217,7 @@ runs:
       env:
         CHAINLINK_CODE_DIR: "../"
         CRIB_CI_ENV: true
+        CLI_CHANGED: ${{ steps.filter.outputs.cli == 'true' }}
         CRIB_SKIP_DOCKER_ECR_LOGIN: true
         CRIB_SKIP_HELM_ECR_LOGIN: true
         DEVSPACE_IMAGE: "${{inputs.product-image}}"


### PR DESCRIPTION
Required in order to consistently run PRs in crib where CLI changes are pushed. This is a backwards-incompatible change, please refer to the changesets file for details