### PR TITLE
feat: use actions/cache for test hash index

### DIFF
--- a/.changeset/tame-radios-peel.md
+++ b/.changeset/tame-radios-peel.md
@@ -1,0 +1,5 @@
+---
+"go-conditional-tests": minor
+---
+
+feat: use actions cache to store the hash index

--- a/apps/go-conditional-tests/package.json
+++ b/apps/go-conditional-tests/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@actions/artifact": "^2.1.11",
+    "@actions/cache": "^4.0.0",
     "@actions/core": "^1.10.1",
     "@actions/github": "^6.0.0",
     "@actions/glob": "^0.4.0",

--- a/apps/go-conditional-tests/src/github.ts
+++ b/apps/go-conditional-tests/src/github.ts
@@ -1,168 +1,88 @@
 import * as core from "@actions/core";
 import * as github from "@actions/github";
+import * as cache from "@actions/cache";
+import * as fs from "fs";
+import * as path from "path";
 
-import {
-  CreateCommitOnBranchInput,
-  CreateCommitOnBranchPayload,
-} from "./generated/graphql.js";
-
-type Octokit = ReturnType<typeof github.getOctokit>;
-
-function getOctokit(): Octokit {
-  const token =
-    core.getInput("github-token") || (process.env.GITHUB_TOKEN as string);
-  if (!token) {
-    throw new Error("No Github token found");
-  }
-
-  return github.getOctokit(token);
+function getCacheKey(testSuite: string, branch: string, commitSha?: string) {
+  const key = `go-test-hashes-${testSuite}-${branch}`;
+  return commitSha ? `${key}-${commitSha.substring(0, 7)}` : key;
 }
 
-export async function getHashFile(
-  owner: string,
-  repo: string,
-  ref: string,
-  file: string,
+function getRestoreKeys(
+  testSuite: string,
+  branch: string,
+  targetBranch?: string,
+) {
+  // Order of precedence:
+  // 1. Exact match for current branch
+  // 2. Any match for current branch (most recent first)
+  // 3. Any match for target branch (most recent first) - PRs only
+  // 4. Any match for default branch (most recent first)
+  const keys = [`go-test-hashes-${testSuite}-${branch}`];
+
+  if (targetBranch) {
+    keys.push(`go-test-hashes-${testSuite}-${targetBranch}`);
+  }
+
+  if (github.context.payload.repository?.default_branch) {
+    keys.push(
+      `go-test-hashes-${testSuite}-${github.context.payload.repository.default_branch}`,
+    );
+  }
+
+  return keys;
+}
+
+export async function getTestHashIndex(
+  testSuite: string,
 ): Promise<{ [importPath: string]: string }> {
-  const octokit = getOctokit();
-  const hashFile = await getFile(octokit, owner, repo, file, ref);
-  if (!hashFile) {
-    core.warning("No hash file found");
+  const hashFile = `${testSuite}.json`;
+  const branch = github.context.ref.replace("refs/heads/", "");
+  const targetBranch = github.context.payload.pull_request?.base.ref;
+
+  // Primary key is exact match for current branch
+  const primaryKey = getCacheKey(testSuite, branch);
+  // Fallback keys in order of precedence
+  const restoreKeys = getRestoreKeys(testSuite, branch, targetBranch);
+
+  const hitKey = await cache.restoreCache([hashFile], primaryKey, restoreKeys);
+  if (!hitKey) {
+    core.info("No cache hit. Primary key: " + primaryKey);
+    core.debug("Restore keys: " + JSON.stringify(restoreKeys));
     return {};
   }
 
-  return JSON.parse(hashFile);
-}
-
-async function getFile(
-  octokit: Octokit,
-  owner: string,
-  repo: string,
-  path: string,
-  ref: string,
-) {
+  core.info(`Cache hit: ${hitKey}`);
   try {
-    if (path.startsWith("/")) path = path.substring(1);
-    if (path.startsWith("./")) path = path.substring(2);
-
-    if (path === "") {
-      core.error("Empty path provided to github.getFile. Returning empty.");
-      return;
-    }
-
-    core.info(
-      `Getting file through Github - ${owner}/${repo}@${ref}, file: ${path}`,
-    );
-
-    const response = await octokit.rest.repos.getContent({
-      owner,
-      repo,
-      path,
-      ref,
-    });
-
-    if ("content" in response.data) {
-      return Buffer.from(response.data.content, "base64").toString();
-    }
-    throw Error("No content found in getContent response");
-  } catch (error: any) {
-    const requestPath = `${owner}/${repo}/${path}@${ref}`;
-    if (error.status) {
-      core.error(
-        `Encountered Github Request Error while getting file - ${requestPath}. (${error.status} - ${error.message})`,
-      );
-    }
-    throw error;
+    const content = await fs.promises.readFile(hashFile, "utf8");
+    return JSON.parse(content);
+  } catch (error) {
+    core.warning(`Error reading cache file: ${error}`);
+    return {};
   }
 }
 
-export async function commitTestHashIndex(
-  owner: string,
-  repo: string,
-  branch: string,
-  path: string,
+export async function saveTestHashIndex(
+  testSuite: string,
   hashes: Record<string, string>,
-) {
-  core.info(`Committing test hashes to ${owner}/${repo}:${branch}`);
-  core.debug(`Hashes: ${JSON.stringify(hashes, null, 2)}`);
+): Promise<void> {
+  const hashFile = `${testSuite}.json`;
+  const branch = github.context.ref.replace("refs/heads/", "");
 
-  const octokit = getOctokit();
-  const contents = Buffer.from(JSON.stringify(hashes, null, 2)).toString(
-    "base64",
-  );
+  await fs.promises.writeFile(hashFile, JSON.stringify(hashes, null, 2));
 
-  const expectedHeadOid = await getRemoteHeadOid(octokit, {
-    branch,
-    owner,
-    repo,
-  });
+  // Use short SHA of current commit to force a new cache entry
+  const key = getCacheKey(testSuite, branch, github.context.sha);
 
-  const input: CreateCommitOnBranchInput = {
-    branch: {
-      branchName: branch,
-      repositoryNameWithOwner: `${owner}/${repo}`,
-    },
-    message: {
-      headline: `Update ${path}`,
-      body: "",
-    },
-    expectedHeadOid,
-    fileChanges: {
-      additions: [
-        {
-          path,
-          contents,
-        },
-      ],
-    },
-  };
-
-  const response = await createCommitOnBranch(octokit, input);
-  const commitUrl: string = response?.createCommitOnBranch?.commit?.url || "";
-  core.info(`Commit URL: ${commitUrl}`);
-  const commit = commitUrl.split("/").pop() || "";
-  return commit;
-}
-
-async function getRemoteHeadOid(
-  client: Octokit,
-  opts: Parameters<typeof client.rest.repos.getBranch>[0],
-) {
-  core.debug(
-    `Getting remote head oid for ${opts?.owner}/${opts?.repo}:${opts?.branch}`,
-  );
-  const res = await client.rest.repos.getBranch(opts);
-
-  return res.data.commit.sha;
-}
-
-/**
- * Sends a request to the GraphQL API to create a commit on a branch. This commit will be signed.
- * The mutation object requires the full contents of each file to be included in the commit.
- * @param octokit The Octokit client
- * @param input The input object for the create commit on branch mutation
- * @returns The response from the GraphQL API
- */
-async function createCommitOnBranch(
-  octokit: Octokit,
-  input: CreateCommitOnBranchInput,
-) {
-  core.debug(`Creating commit on branch ${input.branch.branchName}`);
-  const query = `
-    mutation($input: CreateCommitOnBranchInput!) {
-      createCommitOnBranch(input: $input) {
-        commit {
-          url
-        }
-      }
+  core.info(`Saving test hashes to cache. Key: ${key}`);
+  try {
+    await cache.saveCache([hashFile], key);
+  } catch (error) {
+    if (error instanceof cache.ReserveCacheError) {
+      core.info("Cache already reserved or being saved by another job");
+    } else {
+      throw error;
     }
-  `;
-
-  const response = await octokit.graphql<{
-    createCommitOnBranch: CreateCommitOnBranchPayload;
-  }>(query, {
-    input,
-  });
-
-  return response;
+  }
 }

--- a/apps/go-conditional-tests/src/main.ts
+++ b/apps/go-conditional-tests/src/main.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import { cpus } from "os";
 
 import * as core from "@actions/core";
+import * as github from "@actions/github";
 import { ExecaError } from "execa";
 
 import {
@@ -25,7 +26,6 @@ function setup() {
   const pipelineStep = core.getInput("pipeline-step");
   const moduleDirectory = core.getInput("module-directory") || ".";
   const buildFlagsString = core.getInput("build-flags");
-  const hashesBranch = core.getInput("hashes-branch");
   const testSuite = core.getInput("test-suite") || "placeholder-test-suite";
   const buildDirectory = process.env.RUNNER_TEMP || `/tmp/cl/${testSuite}`;
 
@@ -34,6 +34,8 @@ function setup() {
   const forceUpdateIndexString = core.getInput("force-update-index") || "false";
   const runAllTestsString = core.getInput("run-all-tests") || "false";
   const collectCoverageString = core.getInput("collect-coverage") || "false";
+
+  const defaultBranch = github.context.payload.repository?.default_branch;
 
   const stepsDirectory = path.join(buildDirectory, "steps");
   const coverageDirectory = path.join(buildDirectory, "coverage");
@@ -77,12 +79,12 @@ function setup() {
     coverageDirectory,
     buildFlags,
     maxBuildConcurrency,
-    hashesBranch,
     hashesFile: `${testSuite}.json`,
     testSuite,
     runAllTests,
     maxRunConcurrency,
     collectCoverage,
+    defaultBranch,
     forceUpdateIndex,
   };
 }

--- a/apps/go-conditional-tests/src/pipeline/hash.ts
+++ b/apps/go-conditional-tests/src/pipeline/hash.ts
@@ -2,7 +2,7 @@ import { createReadStream } from "fs";
 import { createHash } from "crypto";
 import { pipeline } from "stream/promises";
 
-import { getHashFile } from "../github.js";
+import { getTestHashIndex } from "../github.js";
 import {
   HashedCompiledPackages,
   DiffedHashedCompiledPackages,
@@ -19,7 +19,7 @@ export async function hashFile(filePath: string): Promise<string> {
 export function comparePackagesToIndex(
   runAllTests: boolean,
   packages: HashedCompiledPackages,
-  hashIndex: Awaited<ReturnType<typeof getHashFile>>,
+  hashIndex: Awaited<ReturnType<typeof getTestHashIndex>>,
 ): DiffedHashedCompiledPackages {
   const diffedHashedCompiledPkgs: DiffedHashedCompiledPackages = {};
   for (const [importPath, pkg] of Object.entries(packages)) {

--- a/apps/go-conditional-tests/test/github.test.ts
+++ b/apps/go-conditional-tests/test/github.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as core from "@actions/core";
+import * as github from "@actions/github";
+import * as cache from "@actions/cache";
+import * as fs from "fs";
+
+import { getTestHashIndex, saveTestHashIndex } from "../src/github.js";
+
+// Mock dependencies
+vi.mock("@actions/core", () => ({
+  info: vi.fn(),
+  debug: vi.fn(),
+  warning: vi.fn(),
+}));
+
+vi.mock("@actions/cache", () => ({
+  restoreCache: vi.fn(),
+  saveCache: vi.fn(),
+  ReserveCacheError: class ReserveCacheError extends Error {},
+}));
+
+vi.mock("fs", () => ({
+  promises: {
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+  },
+}));
+
+// Setup github context mock
+vi.mock("@actions/github", () => ({
+  context: {
+    ref: "refs/heads/feature",
+    sha: "abcdef1234567890",
+    payload: {
+      pull_request: undefined,
+      repository: {
+        default_branch: "main",
+      },
+    },
+  },
+}));
+
+describe("getTestHashIndex", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return empty object when no cache hit", async () => {
+    (cache.restoreCache as any).mockResolvedValue(null);
+
+    const result = await getTestHashIndex("unit");
+
+    expect(result).toEqual({});
+    expect(core.info).toHaveBeenCalledWith(
+      expect.stringContaining("No cache hit"),
+    );
+  });
+
+  it("should handle PR context with target branch", async () => {
+    // @ts-expect-error - mock partial payload
+    vi.mocked(github.context.payload, { partial: true }).pull_request = {
+      base: { ref: "main" },
+    };
+    (cache.restoreCache as any).mockResolvedValue("some-cache-key");
+    (fs.promises.readFile as any).mockResolvedValue('{"pkg1": "hash1"}');
+
+    await getTestHashIndex("unit");
+
+    expect(cache.restoreCache).toHaveBeenCalledWith(
+      ["unit.json"],
+      expect.stringContaining("go-test-hashes-unit-feature"),
+      expect.arrayContaining([
+        "go-test-hashes-unit-feature",
+        "go-test-hashes-unit-main",
+        "go-test-hashes-unit-main",
+      ]),
+    );
+  });
+
+  it("should handle file read errors", async () => {
+    (cache.restoreCache as any).mockResolvedValue("some-cache-key");
+    (fs.promises.readFile as any).mockRejectedValue(new Error("read error"));
+
+    const result = await getTestHashIndex("unit");
+
+    expect(result).toEqual({});
+    expect(core.warning).toHaveBeenCalledWith(
+      expect.stringContaining("Error reading cache file"),
+    );
+  });
+});
+
+describe("saveTestHashIndex", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should save cache with commit SHA", async () => {
+    const hashes = { pkg1: "hash1" };
+
+    await saveTestHashIndex("unit", hashes);
+
+    // Check file was written
+    expect(fs.promises.writeFile).toHaveBeenCalledWith(
+      "unit.json",
+      JSON.stringify(hashes, null, 2),
+    );
+
+    // Check cache was saved with correct key
+    expect(cache.saveCache).toHaveBeenCalledWith(
+      ["unit.json"],
+      "go-test-hashes-unit-feature-abcdef1",
+    );
+  });
+
+  it("should handle cache reservation errors", async () => {
+    (cache.saveCache as any).mockRejectedValue(
+      new cache.ReserveCacheError("already reserved"),
+    );
+
+    await saveTestHashIndex("unit", { pkg1: "hash1" });
+
+    expect(core.info).toHaveBeenCalledWith(
+      expect.stringContaining("Cache already reserved"),
+    );
+  });
+
+  it("should throw non-reservation errors", async () => {
+    (cache.saveCache as any).mockRejectedValue(new Error("network error"));
+
+    await expect(saveTestHashIndex("unit", { pkg1: "hash1" })).rejects.toThrow(
+      "network error",
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -396,6 +396,9 @@ importers:
       '@actions/artifact':
         specifier: ^2.1.11
         version: 2.1.11
+      '@actions/cache':
+        specifier: ^4.0.0
+        version: 4.0.0
       '@actions/core':
         specifier: ^1.10.1
         version: 1.10.1
@@ -407,7 +410,7 @@ importers:
         version: 0.4.0
       '@octokit/plugin-throttling':
         specifier: ^8.2.0
-        version: 8.2.0(@octokit/core@3.6.0)
+        version: 8.2.0(@octokit/core@5.2.0)
       '@octokit/types':
         specifier: ^13.5.0
         version: 13.5.0
@@ -587,8 +590,14 @@ packages:
   '@actions/artifact@2.1.11':
     resolution: {integrity: sha512-V/N/3yM3oLxozq2dpdGqbd/39UbDOR54bF25vYsvn3QZnyZERSzPjTAAwpGzdcwESye9G7vnuhPiKQACEuBQpg==}
 
+  '@actions/cache@4.0.0':
+    resolution: {integrity: sha512-WIuxjnZ44lNYtIS4fqSaYvF00hORdy3cSin+jx8xNgBVGWnNIAiCBHjlwusVQlcgExoQC9pHXGrDsZyZr7rCDQ==}
+
   '@actions/core@1.10.1':
     resolution: {integrity: sha512-3lBR9EDAY+iYIpTnTIXmWcNbX3T2kCkAEQGIQx4NVQ0575nk2k3GRZDTPQG+vVtS2izSLmINlxXf0uLtnrTP+g==}
+
+  '@actions/core@1.11.1':
+    resolution: {integrity: sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==}
 
   '@actions/exec@1.1.1':
     resolution: {integrity: sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==}
@@ -598,6 +607,9 @@ packages:
 
   '@actions/github@6.0.0':
     resolution: {integrity: sha512-alScpSVnYmjNEXboZjarjukQEzgCRmjMv6Xj47fsdnqGS73bjJNDpiiXmp8jr0UZLdUB6d9jW63IcmddUP+l0g==}
+
+  '@actions/glob@0.1.2':
+    resolution: {integrity: sha512-SclLR7Ia5sEqjkJTPs7Sd86maMDw43p769YxBOxvPvEWuPEhpAnBsQfENOpXjFYMmhCqd127bmf+YdvJqVqR4A==}
 
   '@actions/glob@0.4.0':
     resolution: {integrity: sha512-+eKIGFhsFa4EBwaf/GMyzCdWrXWymGXfFmZU3FHQvYS8mPcHtTtZONbkcqqUMzw9mJ/pImEBFET1JNifhqGsAQ==}
@@ -625,6 +637,10 @@ packages:
   '@ardatan/sync-fetch@0.0.1':
     resolution: {integrity: sha512-xhlTqH0m31mnsG0tIP4ETgfSB6gXDaYYsUWTrlUV93fFQPI9dd8hE0Ot6MHLCtqgB32hwJAC3YZMWlXZw7AleA==}
     engines: {node: '>=14'}
+
+  '@azure/abort-controller@1.1.0':
+    resolution: {integrity: sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==}
+    engines: {node: '>=12.0.0'}
 
   '@azure/abort-controller@2.1.2':
     resolution: {integrity: sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==}
@@ -669,6 +685,9 @@ packages:
   '@azure/logger@1.1.4':
     resolution: {integrity: sha512-4IXXzcCdLdlXuCG+8UKEwLA1T1NHqUfanhXYHiQTn+6sfWCZXduqbtXDGceg3Ce5QxTGo7EqmbV6Bi+aqKuClQ==}
     engines: {node: '>=18.0.0'}
+
+  '@azure/ms-rest-js@2.7.0':
+    resolution: {integrity: sha512-ngbzWbqF+NmztDOpLBVDxYM+XLcUj7nKhxGbSU9WtIsXfRB//cf2ZbAG5HkOrhU9/wd/ORRB6lM/d69RKVjiyA==}
 
   '@azure/storage-blob@12.25.0':
     resolution: {integrity: sha512-oodouhA3nCCIh843tMMbxty3WqfNT+Vgzj3Xo5jqR9UPnzq3d7mzLjlHAYz7lW+b4km3SIgz+NAgztvhm7Z6kQ==}
@@ -4199,6 +4218,10 @@ packages:
     resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
     engines: {node: '>=14'}
 
+  form-data@2.5.2:
+    resolution: {integrity: sha512-GgwY0PS7DbXqajuGf4OYlsrIu3zgxD6Vvql43IBhm6MahqA5SK/7mwhtNj2AdH2z35YR34ujJ7BN+3fFC3jP5Q==}
+    engines: {node: '>= 0.12'}
+
   form-data@4.0.0:
     resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
     engines: {node: '>= 6'}
@@ -5776,6 +5799,9 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  sax@1.4.1:
+    resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
+
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
@@ -6175,6 +6201,9 @@ packages:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
 
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
   tslib@2.6.3:
     resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
 
@@ -6559,6 +6588,14 @@ packages:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
 
+  xml2js@0.5.0:
+    resolution: {integrity: sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==}
+    engines: {node: '>=4.0.0'}
+
+  xmlbuilder@11.0.1:
+    resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
+    engines: {node: '>=4.0'}
+
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
@@ -6656,10 +6693,33 @@ snapshots:
       - supports-color
       - ts-proto
 
+  '@actions/cache@4.0.0':
+    dependencies:
+      '@actions/core': 1.11.1
+      '@actions/exec': 1.1.1
+      '@actions/glob': 0.1.2
+      '@actions/http-client': 2.2.0
+      '@actions/io': 1.1.3
+      '@azure/abort-controller': 1.1.0
+      '@azure/ms-rest-js': 2.7.0
+      '@azure/storage-blob': 12.25.0
+      '@protobuf-ts/plugin': 2.9.4
+      semver: 6.3.1
+      twirp-ts: 2.5.0(@protobuf-ts/plugin@2.9.4)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+      - ts-proto
+
   '@actions/core@1.10.1':
     dependencies:
       '@actions/http-client': 2.2.0
       uuid: 8.3.2
+
+  '@actions/core@1.11.1':
+    dependencies:
+      '@actions/exec': 1.1.1
+      '@actions/http-client': 2.2.0
 
   '@actions/exec@1.1.1':
     dependencies:
@@ -6680,6 +6740,11 @@ snapshots:
       '@octokit/core': 5.2.0
       '@octokit/plugin-paginate-rest': 9.1.2(@octokit/core@5.2.0)
       '@octokit/plugin-rest-endpoint-methods': 10.1.2(@octokit/core@5.2.0)
+
+  '@actions/glob@0.1.2':
+    dependencies:
+      '@actions/core': 1.11.1
+      minimatch: 3.1.2
 
   '@actions/glob@0.4.0':
     dependencies:
@@ -6732,6 +6797,10 @@ snapshots:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
+
+  '@azure/abort-controller@1.1.0':
+    dependencies:
+      tslib: 2.6.3
 
   '@azure/abort-controller@2.1.2':
     dependencies:
@@ -6804,6 +6873,19 @@ snapshots:
   '@azure/logger@1.1.4':
     dependencies:
       tslib: 2.6.3
+
+  '@azure/ms-rest-js@2.7.0':
+    dependencies:
+      '@azure/core-auth': 1.9.0
+      abort-controller: 3.0.0
+      form-data: 2.5.2
+      node-fetch: 2.7.0
+      tslib: 1.14.1
+      tunnel: 0.0.6
+      uuid: 8.3.2
+      xml2js: 0.5.0
+    transitivePeerDependencies:
+      - encoding
 
   '@azure/storage-blob@12.25.0':
     dependencies:
@@ -9888,12 +9970,6 @@ snapshots:
       '@octokit/types': 12.6.0
       bottleneck: 2.19.5
 
-  '@octokit/plugin-throttling@8.2.0(@octokit/core@3.6.0)':
-    dependencies:
-      '@octokit/core': 3.6.0
-      '@octokit/types': 12.6.0
-      bottleneck: 2.19.5
-
   '@octokit/plugin-throttling@8.2.0(@octokit/core@5.2.0)':
     dependencies:
       '@octokit/core': 5.2.0
@@ -11755,6 +11831,13 @@ snapshots:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
 
+  form-data@2.5.2:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+      safe-buffer: 5.2.1
+
   form-data@4.0.0:
     dependencies:
       asynckit: 0.4.0
@@ -13580,6 +13663,8 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  sax@1.4.1: {}
+
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
@@ -14014,6 +14099,8 @@ snapshots:
       json5: 2.2.3
       minimist: 1.2.8
       strip-bom: 3.0.0
+
+  tslib@1.14.1: {}
 
   tslib@2.6.3: {}
 
@@ -14480,6 +14567,13 @@ snapshots:
   ws@8.17.1: {}
 
   xml-name-validator@5.0.0: {}
+
+  xml2js@0.5.0:
+    dependencies:
+      sax: 1.4.1
+      xmlbuilder: 11.0.1
+
+  xmlbuilder@11.0.1: {}
 
   xmlchars@2.2.0: {}
 


### PR DESCRIPTION
### Changes

Use the `@action/cache` dependency to handle the hash indexes rather than committing the index to an orphaned branch.

### Motivation

- More secure as it doesn't people with write access to modify the hash index.
- Faster as it essentially caches results of test runs for each branch as well. This allows the hash comparison happen against the most recent hash index of the PR branch, rather than develop, allowing for fewer package runs.

---

RE-3313