### PR TITLE
fix: gha-workflow-validator action reference validation bug

### DIFF
--- a/.changeset/sweet-pens-decide.md
+++ b/.changeset/sweet-pens-decide.md
@@ -1,0 +1,6 @@
+---
+"gha-workflow-validator": patch
+---
+
+fix: action reference validation bug producing false positives for lines which
+contain "uses:" substring, but is not an action reference

--- a/actions/gha-workflow-validator/dist/index.js
+++ b/actions/gha-workflow-validator/dist/index.js
@@ -24174,9 +24174,11 @@ function extractActionReferenceFromLine(line) {
   if (trimmedLine.startsWith("#")) {
     return;
   }
-  const trimSubString = "uses:";
-  const usesIndex = trimmedLine.indexOf(trimSubString);
-  if (usesIndex === -1) {
+  const possibleTrimmedPrefixes = ["- uses: ", "uses: "];
+  const trimSubString = possibleTrimmedPrefixes.find(
+    (prefix) => trimmedLine.startsWith(prefix)
+  );
+  if (!trimSubString) {
     return;
   }
   const trimmedUses = line.substring(line.indexOf(trimSubString) + trimSubString.length).trim();

--- a/actions/gha-workflow-validator/src/__tests__/action-reference-validation.test.ts
+++ b/actions/gha-workflow-validator/src/__tests__/action-reference-validation.test.ts
@@ -31,13 +31,18 @@ describe(ActionReferenceValidation.name, () => {
     expect(result).toEqual({ filename: "foo.yml", lineValidations: [] });
   });
 
-  it("should validate no action references", async () => {
+  it("should validate no action references (statuses:write) ", async () => {
     const octokit = getTestOctokit(nockBack.currentMode);
     const subject = new ActionReferenceValidation(octokit);
     const noWorkflowChanges: ParsedFile = {
       filename: ".github/workflows/test.yml",
       lines: [
-        { lineNumber: 1, content: "line 1", operation: "add", ignored: false },
+        {
+          lineNumber: 1,
+          content: "        statuses: write",
+          operation: "add",
+          ignored: false,
+        },
         { lineNumber: 2, content: "line 2", operation: "add", ignored: false },
       ],
     };

--- a/actions/gha-workflow-validator/src/validations/action-reference-validations.ts
+++ b/actions/gha-workflow-validator/src/validations/action-reference-validations.ts
@@ -226,12 +226,16 @@ export function extractActionReferenceFromLine(
     return;
   }
 
-  // example line:
+  // example line (after trimming):
   // - uses: actions/checkout@v4.2.1
-  const trimSubString = "uses:";
-  const usesIndex = trimmedLine.indexOf(trimSubString);
+  // or
+  // uses: actions/checkout@v4.2.1
+  const possibleTrimmedPrefixes = ["- uses: ", "uses: "];
+  const trimSubString = possibleTrimmedPrefixes.find((prefix) =>
+    trimmedLine.startsWith(prefix),
+  );
 
-  if (usesIndex === -1) {
+  if (!trimSubString) {
     // Not an action reference
     return;
   }


### PR DESCRIPTION
### Changes

- Fix bug for lines which contain `uses:` substring but are not action references (for example `statuses: write`)
- Add unit test

---

RE-3321