### PR TITLE
Removing default empty values for cost attribution labels

### DIFF
--- a/.changeset/red-candles-rest.md
+++ b/.changeset/red-candles-rest.md
@@ -1,0 +1,5 @@
+---
+"crib-deploy-environment": patch
+---
+
+Removing default empty values for cost atributtion labels

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -72,13 +72,11 @@ inputs:
     required: false
     description: Useful for testing updates in CRIB
   chainlink-team:
-    default: ""
     required: true
     description: |
       Specify a relevant value for tagging resources and attributing
       costs to the correct team.
   chainlink-product:
-    default: ""
     required: true
     description: |
       Specify a relevant value for tagging resources and attributing


### PR DESCRIPTION

## What 

See title. 

## Why 

Since these are required inputs makes no sense to use default empty values. 