### PR TITLE
Removing the JWT ENV variable and output parameter

### DIFF
--- a/.changeset/selfish-dancers-give.md
+++ b/.changeset/selfish-dancers-give.md
@@ -1,0 +1,5 @@
+---
+"setup-gap": patch
+---
+
+Removing unused JWT ENV and output parameter

--- a/actions/setup-gap/action.yml
+++ b/actions/setup-gap/action.yml
@@ -78,11 +78,6 @@ inputs:
     required: false
     default: "envoyproxy/envoy:v1.32.0"
 
-outputs:
-  gh-jwt-token:
-    description: "GitHub JWT token to be used for GAP requests"
-    value: ${{ steps.get-jwt-token.outputs.token }}
-
 runs:
   using: composite
   steps:
@@ -179,7 +174,6 @@ runs:
         ENVOY_PROXY_IMAGE: ${{ inputs.envoy-proxy-image }}
         ENVOY_GITHUB_OIDC_TOKEN_HEDER_NAME:
           ${{ inputs.envoy-github-oidc-token-header-name }}
-        JWT_TOKEN: ${{ steps.get-jwt-token.outputs.token }}
         K8S_API_ENDPOINT_PORT: ${{ inputs.k8s-api-endpoint-port }}
         K8S_API_ENDPOINT: ${{ inputs.k8s-api-endpoint }}
         PROXY_PORT: ${{ inputs.proxy-port }}


### PR DESCRIPTION
## What 

See title. 

## Why 

We no longer use this ENV/output since we fetch the token dynamically, and it is used only for the K8s API proxy. 
https://github.com/smartcontractkit/.github/blob/main/actions/setup-gap/envoy.yaml.template#L67
For other services, it needs to be fetched from GitHub OIDC, and this needs to be implemented on the application side.

I forgot to clean that up here: https://github.com/smartcontractkit/.github/pull/727

