### PR TITLE
crib-deploy-environment now deploy crib v1.2.0 by default

### DIFF
--- a/.changeset/big-buses-shake.md
+++ b/.changeset/big-buses-shake.md
@@ -1,0 +1,5 @@
+---
+"crib-deploy-environment": minor
+---
+
+upgraded default crib-repo-ref to v1.2.0

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -68,7 +68,7 @@ inputs:
       for example: https://hooks.slack.com/services/aaa/bbb
     required: false
   crib-repo-ref:
-    default: "v1.0.0"
+    default: "v1.2.0"
     required: false
     description: Useful for testing updates in CRIB
   chainlink-team:


### PR DESCRIPTION
v1.2.0 is the current latest stable release of crib