### PR TITLE
Upgrade local Envoy proxy image for GAP to v1.32.3

### DIFF
--- a/.changeset/three-points-hunt.md
+++ b/.changeset/three-points-hunt.md
@@ -1,0 +1,5 @@
+---
+"setup-gap": patch
+---
+
+Upgrade local Envoy proxy image for GAP to v1.32.3

--- a/actions/setup-gap/action.yml
+++ b/actions/setup-gap/action.yml
@@ -84,7 +84,7 @@ inputs:
   envoy-proxy-image:
     description: "Envoy Proxy image used to run Envoy proxy for GAP"
     required: false
-    default: "envoyproxy/envoy:v1.32.0"
+    default: "envoyproxy/envoy:v1.32.3"
 outputs:
   local-proxy-port:
     description: "The port the local proxy will listen on."


### PR DESCRIPTION
## What  
Update to the latest patches.  

## Why  
To ensure the system is up-to-date with the latest fixes and improvements.  
