### PR TITLE
Bumping the crib-repo-ref to use latest CLI version

### DIFF
--- a/.changeset/healthy-queens-wave.md
+++ b/.changeset/healthy-queens-wave.md
@@ -1,0 +1,5 @@
+---
+"crib-deploy-environment": patch
+---
+
+Adding support for labeling NS for cost attribution

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -72,7 +72,7 @@ inputs:
       for example: https://hooks.slack.com/services/aaa/bbb
     required: false
   crib-repo-ref:
-    default: "v1.2.0"
+    default: "v1.4.0"
     required: false
     description: Useful for testing updates in CRIB
   chainlink-team:


### PR DESCRIPTION
## What 

See title. 

## Why 

Use the latest version of the CRIB CLI. 