### PR TITLE
bumping crib-repo-ref version to latest CRIB release

### DIFF
--- a/.changeset/famous-beers-deliver.md
+++ b/.changeset/famous-beers-deliver.md
@@ -1,0 +1,6 @@
+---
+"crib-deploy-environment": major
+---
+
+CRIB now spins up all dependencies using the existing `nginx` ingressClass
+instead of `alb`, for cost-savings

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -72,7 +72,7 @@ inputs:
       for example: https://hooks.slack.com/services/aaa/bbb
     required: false
   crib-repo-ref:
-    default: "v1.4.0"
+    default: "v2.0.0"
     required: false
     description: Useful for testing updates in CRIB
   chainlink-team:


### PR DESCRIPTION
## What 

See title. 

## Why 

Use the latest version of the CRIB CLI. A major bump is done to align with the CRIB major release