### PR TITLE
Bumping the ctf-setup-run-tests-environment version in the ctf-run-tests GH action

### DIFF
--- a/.changeset/red-masks-jam.md
+++ b/.changeset/red-masks-jam.md
@@ -1,0 +1,5 @@
+---
+"ctf-run-tests": minor
+---
+
+Bumping the ctf-setup-run-tests-environment version in the ctf-run-tests GH action.

--- a/actions/ctf-run-tests/action.yml
+++ b/actions/ctf-run-tests/action.yml
@@ -165,6 +165,15 @@ inputs:
   gati_token:
     required: false
     description: Token provided by GATI to pull from private repos
+  main-dns-zone:
+    required: true
+    description:
+      The primary DNS zone used in the hostname of the Kubernetes API endpoint.
+  k8s-cluster-name:
+    required: true
+    description:
+      The name of the Kubernetes cluster to be used in the `kubectl`
+      configuration for accessing the desired cluster.
 
 runs:
   using: composite
@@ -172,7 +181,7 @@ runs:
     # Setup Tools and libraries
     - name: Setup environment
       if: inputs.run_setup == 'true'
-      uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@2c41e20994aa9c0ae1af1ab467c64ac4acb15f2d # ctf-setup-run-tests-environment@0.0.0
+      uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@f2b2edb1a25dc1272132ea3cc5e226eadc3ddece # ctf-setup-run-tests-environment@v0.2.0
       with:
         test_download_vendor_packages_command:
           ${{ inputs.test_download_vendor_packages_command }}
@@ -190,6 +199,8 @@ runs:
         should_tidy: ${{ inputs.should_tidy }}
         no_cache: ${{ inputs.no_cache }}
         gati_token: ${{ inputs.gati_token }}
+        main-dns-zone: ${{ inputs.main-dns-zone }}
+        k8s-cluster-name: ${{ inputs.k8s-cluster-name }}
 
     - name: Replace chainlink/integration-tests deps
       if: ${{ inputs.dep_chainlink_integration_tests }}
@@ -312,6 +323,10 @@ runs:
       with:
         name: ${{ inputs.artifacts_name }}
         path: ${{ inputs.artifacts_location }}
+
+    - name: Collect local GAP (Envoy) proxy logs on failure
+      uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e # v2.2.2
+      if: failure()
 
     - name: cleanup
       if: always()


### PR DESCRIPTION
## What 

See title. 

## Why 

Because this new version uses GAP v2. 