### PR TITLE
Upgrade Envoy image for setup-gap to v1.33.0

### DIFF
--- a/.changeset/tidy-queens-grow.md
+++ b/.changeset/tidy-queens-grow.md
@@ -1,0 +1,5 @@
+---
+"setup-gap": patch
+---
+
+Upgrade Envoy image for setup-gap to v1.33.0

--- a/actions/setup-gap/action.yml
+++ b/actions/setup-gap/action.yml
@@ -72,7 +72,7 @@ inputs:
   envoy-proxy-image:
     description: "Envoy Proxy image used to run Envoy proxy for GAP"
     required: false
-    default: "envoyproxy/envoy:v1.32.3"
+    default: "envoyproxy/envoy:v1.33.0"
   proxy-port:
     description: "The port the proxy will listen on. Defaults to 8080."
     required: false


### PR DESCRIPTION
## What 

See title 

## Why 

Use the latest image that brings new features and fixes. 