### PR TITLE
Use the latest version of the setup-gap action

### DIFF
--- a/.changeset/heavy-parents-ring.md
+++ b/.changeset/heavy-parents-ring.md
@@ -1,0 +1,7 @@
+---
+"ctf-setup-run-tests-environment": patch
+"policy-bot-config-validator": patch
+"crib-deploy-environment": patch
+---
+
+Use the latest version of setup-gap action

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -128,7 +128,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup GAP
-      uses: smartcontractkit/.github/actions/setup-gap@867223d86ac02cc16762ca8fef2c169c7974e5e3 # setup-gap@3.3.0
+      uses: smartcontractkit/.github/actions/setup-gap@495d349ba13c395defc974be85747dae450eb3d7 # setup-gap@3.5.1
       with:
         aws-region: ${{ inputs.aws-region }}
         aws-role-arn: ${{ inputs.aws-role-arn }}

--- a/actions/ctf-setup-run-tests-environment/action.yml
+++ b/actions/ctf-setup-run-tests-environment/action.yml
@@ -99,7 +99,7 @@ runs:
         mask-aws-account-id: true
 
     - name: Configure local GAP proxy for accessing (Kubernetes) services
-      uses: smartcontractkit/.github/actions/setup-gap@62cce85edc60ba1f42ab9851f887f76ecce792df # setup-gap@v3.4.0
+      uses: smartcontractkit/.github/actions/setup-gap@495d349ba13c395defc974be85747dae450eb3d7 # setup-gap@3.5.1
       with:
         aws-role-duration-seconds: 3600 # 1 hour
         aws-role-arn: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}

--- a/actions/policy-bot-config-validator/action.yml
+++ b/actions/policy-bot-config-validator/action.yml
@@ -84,7 +84,7 @@ runs:
 
     - name: Setup GAP
       if: inputs.setup-gap == 'true'
-      uses: smartcontractkit/.github/actions/setup-gap@62cce85edc60ba1f42ab9851f887f76ecce792df # setup-gap@3.4.0
+      uses: smartcontractkit/.github/actions/setup-gap@495d349ba13c395defc974be85747dae450eb3d7 # setup-gap@3.5.1
       with:
         aws-region: ${{ inputs.aws-region }}
         aws-role-arn: ${{ inputs.aws-role-arn }}


### PR DESCRIPTION
## What 

See title. 

## Why 

This version uses the latest Envoy version for the local proxy and has the change for adding a new custom header for routing: https://github.com/smartcontractkit/.github/pull/806