### PR TITLE
Fix the CA cert generate step in the setup-gap GHA

### DIFF
--- a/.changeset/slow-keys-provide.md
+++ b/.changeset/slow-keys-provide.md
@@ -1,0 +1,5 @@
+---
+"setup-gap": patch
+---
+
+Make sure we always Generate SSL cert because we need to it for local proxy.

--- a/actions/setup-gap/action.yml
+++ b/actions/setup-gap/action.yml
@@ -120,7 +120,6 @@ runs:
       # certificate signed by a trusted CA. Because this is for local TLS we can generate a CA, generate a server
       # certificate, sign the server certificate with the CA, and update the CA in the kubeconfig to trust it.
       # Also useful for other use-cases where a local TLS connection is required.
-      if: inputs.use-k8s == 'true' || inputs.use-tls == 'true'
       shell: bash
       env:
         GAP_NAME: ${{ inputs.gap-name }}


### PR DESCRIPTION
## What

See title.

## Why 

We always need the cert, even if we don't use K8s we need it for the dynamic proxy TLS listener.

