### PR TITLE
Fixing the x-repository header handling to avoid breaking the Lua filter

### DIFF
--- a/.changeset/great-files-joke.md
+++ b/.changeset/great-files-joke.md
@@ -1,0 +1,5 @@
+---
+"setup-gap": patch
+---
+
+Fixing the x-repository header handling to avoid breaking the Lua filter.

--- a/actions/setup-gap/envoy.yaml.template
+++ b/actions/setup-gap/envoy.yaml.template
@@ -146,7 +146,11 @@ static_resources:
                             request_handle:headers():remove("host")
                             request_handle:headers():add("host", "gap-k8s-api.${MAIN_DNS_ZONE}")
                             -- Used to match with correct Route, ex: smartcontractkit/repo-name-here
-                            request_handle:headers():add("x-repository", "${GITHUB_REPOSITORY}")
+                            if not request_handle:headers():get("x-repository") then
+                                request_handle:headers():add("x-repository", "${GITHUB_REPOSITORY}")
+                            else
+                                request_handle:logInfo("Skipping addition of 'x-repository' header as it is already present")
+                            end
                         end
                   - name: envoy.filters.http.router
                     typed_config:
@@ -361,7 +365,11 @@ static_resources:
                                 request_handle:logInfo("dynamic-proxy: Host does not match DNS zone or JWT token is not available. Skipping JWT addition.")
                             end
                             -- Used to match with correct Route, ex: smartcontractkit/repo-name-here
-                            request_handle:headers():add("x-repository", "${GITHUB_REPOSITORY}")
+                            if not request_handle:headers():get("x-repository") then
+                                request_handle:headers():add("x-repository", "${GITHUB_REPOSITORY}")
+                            else
+                                request_handle:logInfo("Skipping addition of 'x-repository' header as it is already present")
+                            end
                         end
                   - name: envoy.filters.http.router
                     typed_config:


### PR DESCRIPTION
## What

This pull request includes changes to improve the handling of the `x-repository` header in the `setup-gap` action. The updates ensure that the header is only added if it is not already present, preventing potential conflicts and improving log information.

Changes to header handling:

* [`.changeset/great-files-joke.md`](diffhunk://#diff-2050b87b16c3224620b6cc768bf6282e9d5b3d3cdc4f1654ed8734a4470bdca4R1-R5): Added a changeset entry to document the fix for `x-repository` header handling.
* [`actions/setup-gap/envoy.yaml.template`](diffhunk://#diff-79a9c5a425c3bc6f7414be4ef96f2a0724c806e4673c295ed564d0fdcdb99341R149-R153): Updated the Lua filter to check for the presence of the `x-repository` header before adding it. If the header is already present, a log message is generated instead. [[1]](diffhunk://#diff-79a9c5a425c3bc6f7414be4ef96f2a0724c806e4673c295ed564d0fdcdb99341R149-R153) [[2]](diffhunk://#diff-79a9c5a425c3bc6f7414be4ef96f2a0724c806e4673c295ed564d0fdcdb99341R368-R372)
 
