### PR TITLE
Remove role assumption requirement for non-k8s apiserver needs

### DIFF
--- a/.changeset/make-role-optional.md
+++ b/.changeset/make-role-optional.md
@@ -1,0 +1,5 @@
+---
+"setup-gap": patch
+---
+
+Fix the `setup-gap` action to work without passing an AWS IAM Role ARN argument when no k8s API server access is needed.

--- a/actions/setup-gap/action.yml
+++ b/actions/setup-gap/action.yml
@@ -104,6 +104,8 @@ runs:
   using: composite
   steps:
     - name: Assume role
+      # We only need to assume a role if we intend to use k8s API server access via the proxy
+      if: inputs.use-k8s == 'true'
       uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}


### PR DESCRIPTION
We only need to run the `Assume role` action when we want to access a k8s API server through the local envoy proxy. For other workflows, we should be able to skip the role assumption (and the requirement to pass a role ARN as an argument).

This PR makes the `setup-gap` action skip the `Assume role` step unless an explicit `use-k8s: true` argument is passed to it.

