### PR TITLE
Add all subdomains of the selected dns zone as cert SANs

### DIFF
--- a/.changeset/wildcard-sans.md
+++ b/.changeset/wildcard-sans.md
@@ -1,0 +1,11 @@
+---
+"setup-gap": patch
+---
+
+Add all wildcard subdomains of a zone, e.g. `*.<DNS-ZONE>` to the SANs of the self-signed certs provided by the local proxy.
+This allows any client to utilize any service even if they can't submit custom host headers or use insecure connections.
+
+Usage:
+
+1. Re-route a specific domain to go to localhost: `echo "127.0.0.1 my-service.my-dns-zone" | sudo tee -a /etc/hosts`
+2. Afterwards, any client can use `https://my-service.my-dns-zone` to access a service, without setting up insecure connectivity or overriding host headers.

--- a/actions/setup-gap/action.yml
+++ b/actions/setup-gap/action.yml
@@ -150,6 +150,7 @@ runs:
       shell: bash
       env:
         CERT_VALIDITY_DAYS: ${{ inputs.cert-validity-days}}
+        MAIN_DNS_ZONE: ${{ inputs.main-dns-zone }}
       run: |
         echo "::debug::Generating server key and certificate signing request (CSR)"
         openssl ecparam -genkey -name prime256v1 -out "${PATH_CERTS_DIR}/server.key"
@@ -160,7 +161,7 @@ runs:
           -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
 
         echo "::debug::Generating SAN extension file"
-        echo -e "subjectAltName=DNS:localhost,IP:127.0.0.1" > "${PATH_CERTS_DIR}/san.ext"
+        echo -e "subjectAltName=DNS:localhost,IP:127.0.0.1,DNS:*.${MAIN_DNS_ZONE}" > "${PATH_CERTS_DIR}/san.ext"
 
         echo "::debug::Signing server certificate with CA"
         openssl x509 -req -in "${PATH_CERTS_DIR}/server.csr" \


### PR DESCRIPTION
By adding all subdomains of the selected dns zone as cert SANs, clients that can't be configured with custom host headers or insecure connections can still utilize the proxy.

If you set, e.g. `127.0.0.1 my-service.my-dns-zone` in the GHA runner's `/etc/hosts` file, any client can then directly connect to e.g. `https://my-service.my-dns-zone` with full functionality.