### PR TITLE
Ensure the local proxy always sets the JWT header even if it's provided by the client

### DIFF
--- a/.changeset/smooth-weeks-add.md
+++ b/.changeset/smooth-weeks-add.md
@@ -1,0 +1,6 @@
+---
+"setup-gap": patch
+---
+
+Ensure the local proxy always sets the JWT header even if it's provided by the
+client

--- a/actions/setup-gap/envoy.yaml.template
+++ b/actions/setup-gap/envoy.yaml.template
@@ -138,6 +138,8 @@ static_resources:
                         function envoy_on_request(request_handle)
                             refresh_token_if_needed(request_handle)
                             if jwt_token then
+                                -- Remove the existing header if it already exists
+                                request_handle:headers():remove("${GITHUB_OIDC_TOKEN_HEADER_NAME}")
                                 request_handle:headers():add("${GITHUB_OIDC_TOKEN_HEADER_NAME}", "Bearer " .. jwt_token)
                                 request_handle:logInfo("k8s-api: GitHub JWT OIDC token added successfully to the header: ${GITHUB_OIDC_TOKEN_HEADER_NAME}.")
                             else
@@ -358,6 +360,8 @@ static_resources:
                             refresh_token_if_needed(request_handle)
                             local host = request_handle:headers():get(":authority")
                             if jwt_token and host:match(main_dns_zone .. "$") then
+                                -- Remove the existing header if it already exists
+                                request_handle:headers():remove("${GITHUB_OIDC_TOKEN_HEADER_NAME}")
                                 request_handle:headers():add("${GITHUB_OIDC_TOKEN_HEADER_NAME}", "Bearer " .. jwt_token)
                                 request_handle:logInfo("dynamic-proxy: GitHub JWT OIDC token added successfully to the header: ${GITHUB_OIDC_TOKEN_HEADER_NAME}.")
                             else


### PR DESCRIPTION

## What 

Change the LUA script to enforce the value of the JWT token if the request is going through the local proxy.

## Why 
For example, if there is already a header with a JWT token passed by the client, the LUA filter should delete it and append its own value. This is needed to:

- Ensure the LUA script doesn't crash when attempting to add a header that already exists (logic to handle it properly).

- Ensure the TTL of the JWT hasn't expired (e.g., the local client fetched it but doesn't refresh it, etc.).