### PR TITLE
Bumping the setup-gap GHA version in crib-deploy-environment GHA

### DIFF
--- a/.changeset/loud-ligers-exercise.md
+++ b/.changeset/loud-ligers-exercise.md
@@ -1,0 +1,5 @@
+---
+"crib-deploy-environment": patch
+---
+
+Bumping the setup-gap GHA version in crib-deploy-environment GHA

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -125,7 +125,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup GAP
-      uses: smartcontractkit/.github/actions/setup-gap@495d349ba13c395defc974be85747dae450eb3d7 # setup-gap@3.5.1
+      uses: smartcontractkit/.github/actions/setup-gap@4cd62b20cf1e625b8c5ceb23bc30e3c2d8973454 # setup-gap@3.5.5
       with:
         aws-region: ${{ inputs.aws-region }}
         aws-role-arn: ${{ inputs.aws-role-arn }}


### PR DESCRIPTION
## What 

See title. 

## Why

Use the latest version with some fixes.