### PR TITLE
Set the default port for the dynamic proxy to 443

### DIFF
--- a/.changeset/smart-rules-hunt.md
+++ b/.changeset/smart-rules-hunt.md
@@ -1,0 +1,5 @@
+---
+"setup-gap": minor
+---
+
+Set the default port for the dynamic proxy to 443

--- a/actions/setup-gap/action.yml
+++ b/actions/setup-gap/action.yml
@@ -85,9 +85,9 @@ inputs:
     required: false
     default: "info"
   dynamic-proxy-port:
-    description: "The port the dynamic proxy will listen on. Defaults to 9090."
+    description: "The port the dynamic proxy will listen on. Defaults to 443."
     required: false
-    default: "9090"
+    default: "443"
   main-dns-zone:
     description:
       "The DNS zone is used for exposing services. It is required when using the


### PR DESCRIPTION
## What 

See title. 

## Why 

The majority of workflows use 443 as the default. This doesn't conflict with anything because traffic has to be explicitly routed through it.