### PR TITLE
[TT-1847] Optional GATI token fetching step in reusable workflow

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -742,7 +742,7 @@ jobs:
           aws-role-arn: ${{ secrets.OPTIONAL_GATI_AWS_ROLE_ARN }}
           aws-lambda-url: ${{ secrets.OPTIONAL_GATI_LAMBDA_URL }}
           aws-region: ${{ secrets.AWS_REGION }}
-          aws-role-duration-seconds: "720"
+          aws-role-duration-seconds: "1800"
 
       - name: Run tests
         id: run_tests

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -223,6 +223,8 @@ on:
         required: true
       GH_TOKEN:
         required: true
+      GATI_GH_TOKEN:
+        required: false
       AWS_REGION:
         required: true
       AWS_OIDC_IAM_ROLE_VALIDATION_PROD_ARN:
@@ -244,6 +246,11 @@ on:
         required: true
       MAIN_DNS_ZONE_PUBLIC_SDLC:
         required: true
+      # Passing these will get GATI token and set it as env var GATI_TOKEN for the tests
+      OPTIONAL_GATI_AWS_ROLE_ARN:
+        required: false
+      OPTIONAL_GATI_LAMBDA_URL:
+        required: false
 
 env:
   CHAINLINK_IMAGE:
@@ -277,7 +284,6 @@ env:
   E2E_RMN_AFN2PROXY_IMAGE:
     ${{ secrets.PROD_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{
     secrets.AWS_REGION}}.amazonaws.com/afn2proxy
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
 jobs:
   validate-inputs:
@@ -724,6 +730,20 @@ jobs:
           aws_region: ${{ secrets.QA_AWS_REGION }}
           aws_role_to_assume: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
 
+      - name: Setup GitHub token using GATI
+        id: setup-optional-gati-token
+        env:
+          OPTIONAL_GATI_AWS_ROLE_ARN: ${{ secrets.OPTIONAL_GATI_AWS_ROLE_ARN }}
+          OPTIONAL_GATI_LAMBDA_URL: ${{ secrets.OPTIONAL_GATI_LAMBDA_URL }}
+        if:
+          ${{ env.OPTIONAL_GATI_AWS_ROLE_ARN && env.OPTIONAL_GATI_LAMBDA_URL }}
+        uses: smartcontractkit/.github/actions/setup-github-token@ef78fa97bf3c77de6563db1175422703e9e6674f # setup-github-token@0.2.1
+        with:
+          aws-role-arn: ${{ secrets.OPTIONAL_GATI_AWS_ROLE_ARN }}
+          aws-lambda-url: ${{ secrets.OPTIONAL_GATI_LAMBDA_URL }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-role-duration-seconds: "720"
+
       - name: Run tests
         id: run_tests
         uses: smartcontractkit/.github/actions/ctf-run-tests@5a52473d754eb3cfde41449437e320167bbbddf2 # ctf-run-tests@v0.4.1
@@ -747,6 +767,8 @@ jobs:
           INTERNAL_DOCKER_REPO:
             ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{
             secrets.QA_AWS_REGION }}.amazonaws.com
+          GATI_TOKEN:
+            ${{ steps.setup-optional-gati-token.outputs.access-token || ''}}
         with:
           test_command_to_run:
             ${{ matrix.tests.test_cmd }} ${{ matrix.tests.test_cmd_opts || '2>&1

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -765,7 +765,7 @@ jobs:
           INTERNAL_DOCKER_REPO:
             ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{
             secrets.QA_AWS_REGION }}.amazonaws.com
-          GITHUB_TOKEN:
+          GITHUB_API_TOKEN:
             ${{ steps.setup-optional-gati-token.outputs.access-token || ''}}
         with:
           test_command_to_run:

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -277,6 +277,7 @@ env:
   E2E_RMN_AFN2PROXY_IMAGE:
     ${{ secrets.PROD_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{
     secrets.AWS_REGION}}.amazonaws.com/afn2proxy
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
 jobs:
   validate-inputs:

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -223,8 +223,6 @@ on:
         required: true
       GH_TOKEN:
         required: true
-      GATI_GH_TOKEN:
-        required: false
       AWS_REGION:
         required: true
       AWS_OIDC_IAM_ROLE_VALIDATION_PROD_ARN:

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -767,7 +767,7 @@ jobs:
           INTERNAL_DOCKER_REPO:
             ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{
             secrets.QA_AWS_REGION }}.amazonaws.com
-          GATI_TOKEN:
+          GITHUB_TOKEN:
             ${{ steps.setup-optional-gati-token.outputs.access-token || ''}}
         with:
           test_command_to_run:


### PR DESCRIPTION
Why?
To be able to pass a GATI-generated GH token to tests.