### PR TITLE
RE-3420: Remove go-setup caching errors

### DIFF
--- a/actions/setup-golang/action.yml
+++ b/actions/setup-golang/action.yml
@@ -27,7 +27,7 @@ runs:
   steps:
     - name: Setup tar default options
       shell: bash
-      # Do not overwrite existing files when extracting files from an cache archive.
+      # Do not overwrite existing files when extracting files from a cache archive.
       # Since actions/cache does not support this option, we set it here as a default.
       run: echo "TAR_OPTIONS=--skip-old-files" >> $GITHUB_ENV
 

--- a/actions/setup-golang/action.yml
+++ b/actions/setup-golang/action.yml
@@ -25,6 +25,12 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Setup tar default options
+      shell: bash
+      # Do not overwrite existing files when extracting files from an cache archive.
+      # Since actions/cache does not support this option, we set it here as a default.
+      run: echo "TAR_OPTIONS=--skip-old-files" >> $GITHUB_ENV
+
     - name: Set up Go
       uses: actions/setup-go@v5.0.2
       with:


### PR DESCRIPTION
This pull request includes a small change to the `actions/setup-golang/action.yml` file. The change sets a default option for the `tar` command to avoid overwriting existing files when extracting files from a cache archive.

* [`actions/setup-golang/action.yml`](diffhunk://#diff-4bbc52cfa3a89bc7512f94ffb0868dfb8a88af866ff42b2483f4da7e90b3b56eR28-R33): Added a step to set `TAR_OPTIONS=--skip-old-files` in the environment to prevent overwriting existing files during extraction.

## The issue

If some go dependencies already exist in the runner, when we try to extract the cache `tar` will return errors for all files that currently exist in the runner and cannot override with the ones from the cache. This can result in a lot of bloat in the GHA logs from errors that we cannot do nothing about. 

Although there is currently a solution https://github.com/smartcontractkit/chainlink/commit/a744ed66541a3bd9b5edb2977ce5e03fa55e6356, this is not ideal when we want to be able to cache the go modules in order to speed up build times as we do when using this custom `setup-go` action.
