### PR TITLE
RE-3420: Select the correct go-version

### DIFF
--- a/.changeset/healthy-shrimps-punch.md
+++ b/.changeset/healthy-shrimps-punch.md
@@ -1,0 +1,5 @@
+---
+"setup-golang": minor
+---
+
+install toolchain version if it exists

--- a/actions/setup-golang/action.yml
+++ b/actions/setup-golang/action.yml
@@ -31,10 +31,22 @@ runs:
       # Since actions/cache does not support this option, we set it here as a default.
       run: echo "TAR_OPTIONS=--skip-old-files" >> $GITHUB_ENV
 
+    - name: Get Go Version
+      shell: bash
+      id: go-version
+      run: |
+        version=$(sed -ne '/^toolchain /s/^toolchain go//p' ${{ inputs.go-version-file }})
+        if [ -z "$version" ]; then
+          version=$(sed -ne '/^go /s/^go //p' ${{ inputs.go-version-file }})
+          echo "Toolchain version not found in ${{ inputs.go-version-file }}, using go directive instead."
+        fi
+        echo "Go Version: $version"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
     - name: Set up Go
       uses: actions/setup-go@v5.0.2
       with:
-        go-version-file: ${{ inputs.go-version-file }}
+        go-version: ${{ steps.go-version.outputs.version }}
         cache: ${{ inputs.use-go-cache }}
         cache-dependency-path: ${{ inputs.go-cache-dep-path }}
 

--- a/actions/setup-golang/action.yml
+++ b/actions/setup-golang/action.yml
@@ -25,11 +25,11 @@ inputs:
 runs:
   using: composite
   steps:
-    # - name: Setup tar default options
-    #   shell: bash
-    #   # Do not overwrite existing files when extracting files from a cache archive.
-    #   # Since actions/cache does not support this option, we set it here as a default.
-    #   run: echo "TAR_OPTIONS=--skip-old-files" >> $GITHUB_ENV
+    - name: Setup tar default options
+      shell: bash
+      # Do not overwrite existing files when extracting files from a cache archive.
+      # Since actions/cache does not support this option, we set it here as a default.
+      run: echo "TAR_OPTIONS=--skip-old-files" >> $GITHUB_ENV
 
     - name: Get Go Version
       shell: bash

--- a/actions/setup-golang/action.yml
+++ b/actions/setup-golang/action.yml
@@ -25,11 +25,11 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Setup tar default options
-      shell: bash
-      # Do not overwrite existing files when extracting files from a cache archive.
-      # Since actions/cache does not support this option, we set it here as a default.
-      run: echo "TAR_OPTIONS=--skip-old-files" >> $GITHUB_ENV
+    # - name: Setup tar default options
+    #   shell: bash
+    #   # Do not overwrite existing files when extracting files from a cache archive.
+    #   # Since actions/cache does not support this option, we set it here as a default.
+    #   run: echo "TAR_OPTIONS=--skip-old-files" >> $GITHUB_ENV
 
     - name: Get Go Version
       shell: bash


### PR DESCRIPTION
This pull request includes a change to the `actions/setup-golang/action.yml` file to implement a fix in order to install the toolchain version if it exists as was introduced by this commit https://github.com/smartcontractkit/chainlink/commit/a744ed66541a3bd9b5edb2977ce5e03fa55e6356 