### PR TITLE
chore: pin all actions/* references to major version

### DIFF
--- a/.changeset/big-bikes-beam.md
+++ b/.changeset/big-bikes-beam.md
@@ -1,0 +1,39 @@
+---
+"cicd-build-publish-artifacts-go": patch
+"cicd-build-publish-artifacts-ts": patch
+"guard-from-missing-changesets": patch
+"cicd-build-publish-charts": patch
+"cicd-build-publish-docker": patch
+"llm-action-error-reporter": patch
+"crib-deploy-environment": patch
+"guard-tag-from-branch": patch
+"cleanup-old-branches": patch
+"ctf-build-test-image": patch
+"ctf-run-tests-binary": patch
+"slack-notify-git-ref": patch
+"md-confluence-sync": patch
+"wait-for-workflows": patch
+"ci-benchmarking": patch
+"ci-sonarqube-go": patch
+"ci-sonarqube-ts": patch
+"cicd-changesets": patch
+"ctf-build-image": patch
+"ctf-build-tests": patch
+"ci-kubeconform": patch
+"ci-lint-charts": patch
+"setup-renovate": patch
+"update-actions": patch
+"ctf-run-tests": patch
+"llm-pr-writer": patch
+"ci-lint-misc": patch
+"ctf-setup-go": patch
+"setup-golang": patch
+"ci-prettier": patch
+"ci-test-sol": patch
+"ci-lint-go": patch
+"ci-lint-ts": patch
+"ci-test-go": patch
+"ci-test-ts": patch
+---
+
+chore: pin actions/\* dependencies to major version tag

--- a/actions/ci-benchmarking/action.yml
+++ b/actions/ci-benchmarking/action.yml
@@ -53,10 +53,10 @@ runs:
   using: "composite"
   steps:
     - name: Checkout Code
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
 
     - name: Setup Go Environment
-      uses: actions/setup-go@v5.0.2
+      uses: actions/setup-go@v5
       with:
         go-version: "stable"
 

--- a/actions/ci-kubeconform/action.yml
+++ b/actions/ci-kubeconform/action.yml
@@ -45,12 +45,12 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 
     - name: Install Go
-      uses: actions/setup-go@v5.0.2
+      uses: actions/setup-go@v5
       with:
         go-version-file: ${{ inputs.go-version-file }}
 

--- a/actions/ci-lint-charts/action.yml
+++ b/actions/ci-lint-charts/action.yml
@@ -30,7 +30,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/ci-lint-go/action.yml
+++ b/actions/ci-lint-go/action.yml
@@ -73,7 +73,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 
@@ -108,7 +108,7 @@ runs:
         envFile: ${{ inputs.env-files }}
 
     - name: Setup go
-      uses: actions/setup-go@v5.0.2
+      uses: actions/setup-go@v5
       with:
         go-version-file: ${{ inputs.go-version-file }}
         cache: ${{ inputs.use-go-cache }}
@@ -131,7 +131,7 @@ runs:
 
     - name: Store lint report artifact
       if: always()
-      uses: actions/upload-artifact@v4.4.3
+      uses: actions/upload-artifact@v4
       with:
         name: golangci-lint-report
         path: ${{ inputs.go-directory }}/golangci-lint-report.xml

--- a/actions/ci-lint-misc/action.yml
+++ b/actions/ci-lint-misc/action.yml
@@ -17,7 +17,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/ci-lint-ts/action.yml
+++ b/actions/ci-lint-ts/action.yml
@@ -34,7 +34,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 
@@ -59,7 +59,7 @@ runs:
 
     - name: Store lint result artifacts
       if: always()
-      uses: actions/upload-artifact@v4.4.3
+      uses: actions/upload-artifact@v4
       with:
         name: ts-lint-results
         path: ./eslint-report.json

--- a/actions/ci-prettier/action.yml
+++ b/actions/ci-prettier/action.yml
@@ -36,7 +36,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/ci-sonarqube-go/action.yml
+++ b/actions/ci-sonarqube-go/action.yml
@@ -50,18 +50,18 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 
     - name: Download all reports (no test-report-workflow)
       id: all
       if: inputs.test-report-workflow == ''
-      uses: actions/download-artifact@v4.1.8 # v4.1.8
+      uses: actions/download-artifact@v4
 
     - name: Download all reports (no lint-report-workflow)
       if: steps.all.outcome != 'success' && inputs.lint-report-workflow == ''
-      uses: actions/download-artifact@v4.1.8 # v4.1.8
+      uses: actions/download-artifact@v4
 
     - name: Download test-report artifact using workflow file name
       if: inputs.test-report-workflow != ''

--- a/actions/ci-sonarqube-ts/action.yml
+++ b/actions/ci-sonarqube-ts/action.yml
@@ -54,18 +54,18 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 
     - name: Download all reports (no test-report-workflow)
       id: all
       if: inputs.test-report-workflow == ''
-      uses: actions/download-artifact@v4.1.8 # v4.1.8
+      uses: actions/download-artifact@v4
 
     - name: Download all reports (no lint-report-workflow)
       if: steps.all.outcome != 'success' && inputs.lint-report-workflow == ''
-      uses: actions/download-artifact@v4.1.8 # v4.1.8
+      uses: actions/download-artifact@v4
 
     - name: Download test-report artifact using workflow file name
       if: inputs.test-report-workflow != ''

--- a/actions/ci-test-go/action.yml
+++ b/actions/ci-test-go/action.yml
@@ -98,7 +98,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 
@@ -163,7 +163,7 @@ runs:
 
     - name: Store test report artifacts
       if: always()
-      uses: actions/upload-artifact@v4.4.3
+      uses: actions/upload-artifact@v4
       with:
         name: go-test-results
         path: |
@@ -172,7 +172,7 @@ runs:
 
     - name: Store race coverage report
       if: ${{ inputs.enable-go-test-race == 'true' }}
-      uses: actions/upload-artifact@v4.4.3
+      uses: actions/upload-artifact@v4
       with:
         name: go-test-race-results
         path: race/*.txt

--- a/actions/ci-test-sol/action.yml
+++ b/actions/ci-test-sol/action.yml
@@ -55,7 +55,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/ci-test-ts/action.yml
+++ b/actions/ci-test-ts/action.yml
@@ -34,7 +34,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 
@@ -60,7 +60,7 @@ runs:
 
     - name: Store test result artifacts
       if: always()
-      uses: actions/upload-artifact@v4.4.3
+      uses: actions/upload-artifact@v4
       with:
         name: ts-test-results
         path: |

--- a/actions/cicd-build-publish-artifacts-go/action.yml
+++ b/actions/cicd-build-publish-artifacts-go/action.yml
@@ -110,7 +110,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
         ref: ${{ inputs.checkout-ref }}
@@ -140,7 +140,7 @@ runs:
           "https://github.com/"
 
     - name: Setup go
-      uses: actions/setup-go@v5.0.2
+      uses: actions/setup-go@v5
       with:
         go-version-file: ${{ inputs.go-version-file }}
         cache: ${{ inputs.use-go-cache }}

--- a/actions/cicd-build-publish-artifacts-ts/action.yml
+++ b/actions/cicd-build-publish-artifacts-ts/action.yml
@@ -70,7 +70,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/cicd-build-publish-charts/action.yml
+++ b/actions/cicd-build-publish-charts/action.yml
@@ -48,7 +48,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/cicd-build-publish-docker/action.yml
+++ b/actions/cicd-build-publish-docker/action.yml
@@ -72,7 +72,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/cicd-changesets/action.yml
+++ b/actions/cicd-changesets/action.yml
@@ -99,7 +99,7 @@ runs:
         url: ${{ inputs.aws-lambda-url }}
 
     - name: Checkout repo
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
         token: ${{ steps.get-gh-token.outputs.access-token }}

--- a/actions/cleanup-old-branches/action.yml
+++ b/actions/cleanup-old-branches/action.yml
@@ -42,7 +42,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -197,7 +197,7 @@ runs:
         websockets-services: ${{ env.WEBSOCKETS_SERVICES }}
 
     - name: Checkout crib repo
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
       with:
         repository: "smartcontractkit/crib"
         ref: ${{ inputs.crib-repo-ref }}
@@ -302,7 +302,7 @@ runs:
         nix develop -c /bin/bash -c "devspace use namespace ${DEVSPACE_NAMESPACE} && devspace run ${{ inputs.command }} ${{ inputs.command-args }}"
 
     - name: Render notification template
-      uses: actions/github-script@v7.0.1
+      uses: actions/github-script@v7
       id: render-slack-template
       if:
         failure() && inputs.crib-alert-slack-webhook != '' && inputs.send-alerts

--- a/actions/ctf-build-image/action.yml
+++ b/actions/ctf-build-image/action.yml
@@ -67,11 +67,11 @@ runs:
   steps:
     - name: Checkout Chainlink repo
       if: ${{ inputs.should_checkout == 'true' }}
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
       with:
         repository: ${{ inputs.cl_repo }}
         ref: ${{ inputs.cl_ref }}
-    - uses: actions/setup-go@v5.0.2
+    - uses: actions/setup-go@v5
       env:
         GOPRIVATE: ${{ inputs.GOPRIVATE }}
       with:

--- a/actions/ctf-build-test-image/action.yml
+++ b/actions/ctf-build-test-image/action.yml
@@ -70,7 +70,7 @@ runs:
         echo "short_sha=${short_sha}" >> "$GITHUB_OUTPUT"
     - name: Checkout chainlink-testing-framework
       if: steps.version.outputs.is_semantic == 'false'
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
       with:
         repository: smartcontractkit/chainlink-testing-framework
         ref: main

--- a/actions/ctf-build-tests/action.yml
+++ b/actions/ctf-build-tests/action.yml
@@ -92,7 +92,7 @@ runs:
         echo "Built binary at ./integration-tests/tests"
 
     - name: Publish Binary
-      uses: actions/upload-artifact@v4.4.3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.binary_name }}
         path: ./integration-tests/tests

--- a/actions/ctf-run-tests-binary/action.yml
+++ b/actions/ctf-run-tests-binary/action.yml
@@ -111,7 +111,7 @@ runs:
     # Download any external artifacts
     - name: Download Artifacts
       if: inputs.download_contract_artifacts_path != 'none'
-      uses: actions/download-artifact@v4.1.8
+      uses: actions/download-artifact@v4
       with:
         name: artifacts
         path: ${{ inputs.download_contract_artifacts_path }}
@@ -141,7 +141,7 @@ runs:
 
     - name: Publish Artifacts
       if: failure()
-      uses: actions/upload-artifact@v4.4.3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifacts_name }}
         path: ${{ inputs.artifacts_location }}

--- a/actions/ctf-run-tests/action.yml
+++ b/actions/ctf-run-tests/action.yml
@@ -216,7 +216,7 @@ runs:
     # Download any external artifacts
     - name: Download Artifacts
       if: inputs.download_contract_artifacts_path != 'none'
-      uses: actions/download-artifact@v4.1.8
+      uses: actions/download-artifact@v4
       with:
         name: artifacts
         path: ${{ inputs.download_contract_artifacts_path }}
@@ -315,7 +315,7 @@ runs:
 
     - name: Publish Artifacts
       if: failure()
-      uses: actions/upload-artifact@v4.4.3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifacts_name }}
         path: ${{ inputs.artifacts_location }}

--- a/actions/ctf-setup-go/action.yml
+++ b/actions/ctf-setup-go/action.yml
@@ -41,7 +41,7 @@ runs:
   using: composite
   steps:
     - name: Setup Go
-      uses: actions/setup-go@v5.0.2
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ inputs.go_version }}
         go-version-file: ${{ inputs.go_mod_path }}

--- a/actions/guard-from-missing-changesets/action.yml
+++ b/actions/guard-from-missing-changesets/action.yml
@@ -16,7 +16,7 @@ runs:
   steps:
     - name: Checkout full repo
       if: inputs.checkout == 'true'
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
     - name: Install changesets
       shell: bash
       run: ${{ github.action_path }}/scripts/install-changesets.sh

--- a/actions/guard-tag-from-branch/action.yml
+++ b/actions/guard-tag-from-branch/action.yml
@@ -30,7 +30,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/llm-action-error-reporter/action.yml
+++ b/actions/llm-action-error-reporter/action.yml
@@ -43,7 +43,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout calling repo
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
 
     - name: Check if this run is invoked from a pull request event
       shell: bash
@@ -68,7 +68,7 @@ runs:
 
     - name: Checkout action repo
       if: ${{ env.SKIP_ACTION == 'false' }}
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
       with:
         repository: smartcontractkit/.github
         ref: ${{ inputs.workflow-ref }}
@@ -214,7 +214,7 @@ runs:
           // Create new comment if COMMENT_ID is empty
           if ((!commentId || commentId.trim() === '')) {
             // but only if the parent workflow failed or if the parent workflow succeeded and skip-on-success is false
-            if (process.env.WORKFLOW_STATUS === 'failure' 
+            if (process.env.WORKFLOW_STATUS === 'failure'
               || (process.env.WORKFLOW_STATUS === 'success' && process.env.SKIP_ON_SUCCESS === 'false')) {
               const newComment = await github.rest.issues.createComment({
                 owner: context.repo.owner,

--- a/actions/llm-pr-writer/action.yml
+++ b/actions/llm-pr-writer/action.yml
@@ -53,13 +53,13 @@ runs:
 
     - name: Checkout calling repo
       if: ${{ env.SKIP_ACTION == 'false' }}
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 
     - name: Checkout action repo
       if: ${{ env.SKIP_ACTION == 'false' }}
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
       with:
         repository: smartcontractkit/.github
         ref: ${{ inputs.workflow-ref }}

--- a/actions/md-confluence-sync/action.yml
+++ b/actions/md-confluence-sync/action.yml
@@ -5,7 +5,7 @@ inputs:
   files:
     description: |
       Use specified markdown file(s) for converting to html. Supports file
-      globbing patterns. GLOB pattern is used for linting as well, so make 
+      globbing patterns. GLOB pattern is used for linting as well, so make
       sure to filter files with .md extension.
     required: true
   base-url:
@@ -39,7 +39,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 
@@ -50,7 +50,7 @@ runs:
         prettier-command: pnpm prettier --check ${{ inputs.files }}
 
     - name: Set up Go
-      uses: actions/setup-go@v5.0.2
+      uses: actions/setup-go@v5
 
     - name: Setup tools
       shell: bash

--- a/actions/setup-golang/action.yml
+++ b/actions/setup-golang/action.yml
@@ -44,7 +44,7 @@ runs:
         echo "version=$version" >> "$GITHUB_OUTPUT"
 
     - name: Set up Go
-      uses: actions/setup-go@v5.0.2
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ steps.go-version.outputs.version }}
         cache: ${{ inputs.use-go-cache }}

--- a/actions/setup-renovate/action.yml
+++ b/actions/setup-renovate/action.yml
@@ -48,7 +48,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/slack-notify-git-ref/action.yml
+++ b/actions/slack-notify-git-ref/action.yml
@@ -47,7 +47,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
     - name: Validate inputs

--- a/actions/update-actions/action.yml
+++ b/actions/update-actions/action.yml
@@ -37,7 +37,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v4.2.1
+      uses: actions/checkout@v4
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/wait-for-workflows/action.yml
+++ b/actions/wait-for-workflows/action.yml
@@ -33,7 +33,7 @@ runs:
   steps:
     - name: wait-for-workflows
       id: wfw
-      uses: actions/github-script@v7.0.1
+      uses: actions/github-script@v7
       env:
         MAX_TIMEOUT: ${{ inputs.max-timeout }}
         POLLING_INTERVAL: ${{ inputs.polling-interval }}


### PR DESCRIPTION
### Changes

Change all pinned actions/* actions to their major version tag instead.

### Motivation

Github likes to break things, and updating dependencies is a pain.