### PR TITLE
Bumping the setup-gap version in ctf-setup-run-tests-environment GHA

### DIFF
--- a/.changeset/funny-penguins-hope.md
+++ b/.changeset/funny-penguins-hope.md
@@ -1,0 +1,5 @@
+---
+"ctf-setup-run-tests-environment": minor
+---
+
+Use the latest version of the setup-gap GHA

--- a/actions/ctf-setup-run-tests-environment/action.yml
+++ b/actions/ctf-setup-run-tests-environment/action.yml
@@ -99,7 +99,7 @@ runs:
         mask-aws-account-id: true
 
     - name: Configure local GAP proxy for accessing (Kubernetes) services
-      uses: smartcontractkit/.github/actions/setup-gap@495d349ba13c395defc974be85747dae450eb3d7 # setup-gap@3.5.1
+      uses: smartcontractkit/.github/actions/setup-gap@b969c2d42c15e937e2f94cc0e050f39cd5369f4f # setup-gap@4.0.0
       with:
         aws-role-duration-seconds: 3600 # 1 hour
         aws-role-arn: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}


### PR DESCRIPTION
## What 

See title. 

## Why 

Use the latest version that introduces a local proxy for websockets. 