### PR TITLE
TT-1987 ctf-setup-go

### DIFF
--- a/.changeset/fluffy-fishes-end.md
+++ b/.changeset/fluffy-fishes-end.md
@@ -1,0 +1,5 @@
+---
+"ctf-setup-go": minor
+---
+
+Fix the cache restoration errors

--- a/actions/ctf-setup-go/action.yml
+++ b/actions/ctf-setup-go/action.yml
@@ -40,6 +40,12 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Setup tar default options
+      shell: bash
+      # Do not overwrite existing files when extracting files from a cache archive.
+      # Since actions/cache does not support this option, we set it here as a default.
+      run: echo "TAR_OPTIONS=--skip-old-files" >> $GITHUB_ENV
+
     - name: Get Go Version
       shell: bash
       if: ${{ inputs.go_mod_path }}

--- a/actions/ctf-setup-go/action.yml
+++ b/actions/ctf-setup-go/action.yml
@@ -66,7 +66,6 @@ runs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ steps.export-go-version.outputs.go_version }}
-        go-version-file: ${{ inputs.go_mod_path }}
         check-latest: true
         cache: false
 

--- a/actions/ctf-setup-go/action.yml
+++ b/actions/ctf-setup-go/action.yml
@@ -65,7 +65,7 @@ runs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ inputs.go_version }}
+        go-version: ${{ steps.export-go-version.outputs.go_version }}
         go-version-file: ${{ inputs.go_mod_path }}
         check-latest: true
         cache: false

--- a/actions/ctf-setup-go/action.yml
+++ b/actions/ctf-setup-go/action.yml
@@ -40,6 +40,28 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Get Go Version
+      shell: bash
+      if: ${{ inputs.go_mod_path }}
+      id: go-version
+      run: |
+        version=$(sed -ne '/^toolchain /s/^toolchain go//p' ${{ inputs.go-go_mod_path }})
+        if [ -z "$version" ]; then
+          version=$(sed -ne '/^go /s/^go //p' ${{ inputs.go_mod_path }})
+          echo "Toolchain version not found in ${{ inputs.go_mod_path }}, using go directive instead."
+        fi
+        echo "Go Version: $version"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+    - name: Export Go version
+      id: export-go-version
+      shell: bash
+      run: |
+        if [[ "${{ inputs.go_mod_path }}" == "" ]]; then
+          echo "No go mod path provided, using go version provided"
+          echo "go_version=${{ inputs.go_version }}" >> "$GITHUB_OUTPUT"
+        else
+          echo "go_version=${{ steps.go-version.outputs.version }}" >> "$GITHUB_OUTPUT"
+        fi
     - name: Setup Go
       uses: actions/setup-go@v5
       with:

--- a/actions/ctf-setup-go/action.yml
+++ b/actions/ctf-setup-go/action.yml
@@ -45,7 +45,7 @@ runs:
       if: ${{ inputs.go_mod_path }}
       id: go-version
       run: |
-        version=$(sed -ne '/^toolchain /s/^toolchain go//p' ${{ inputs.go-go_mod_path }})
+        version=$(sed -ne '/^toolchain /s/^toolchain go//p' ${{ inputs.go_mod_path }})
         if [ -z "$version" ]; then
           version=$(sed -ne '/^go /s/^go //p' ${{ inputs.go_mod_path }})
           echo "Toolchain version not found in ${{ inputs.go_mod_path }}, using go directive instead."

--- a/actions/ctf-setup-go/action.yml
+++ b/actions/ctf-setup-go/action.yml
@@ -46,6 +46,8 @@ runs:
       # Since actions/cache does not support this option, we set it here as a default.
       run: echo "TAR_OPTIONS=--skip-old-files" >> $GITHUB_ENV
 
+    # This change is based on the modifications done by @erikburt in the `chainlink` repo
+    # https://github.com/smartcontractkit/chainlink/pull/15645
     - name: Get Go Version
       shell: bash
       if: ${{ inputs.go_mod_path }}
@@ -68,6 +70,7 @@ runs:
         else
           echo "go_version=${{ steps.go-version.outputs.version }}" >> "$GITHUB_OUTPUT"
         fi
+
     - name: Setup Go
       uses: actions/setup-go@v5
       with:


### PR DESCRIPTION
This changes are meant to fix the wall of errors related to cache restoration we see every time we run smoke,integration tests.

1. We add the `Get Go Version` and the `Export Go version` steps in order to fix the main cause of the issue. See more here https://smartcontract-it.atlassian.net/browse/TT-1987 
2. We remove the `go-version-file` param from the `Setup Go` step, because we can have only one of `go-version-file` and `go-version`. See more here https://chainlink-core.slack.com/archives/C049X3353K2/p1738771824123779?thread_ts=1738764531.723059&cid=C049X3353K2
3. We add the `Setup tar default options` in order to remove the errors which are caused by previous runs of the cache. See more here https://chainlink-core.slack.com/archives/C038Q8K1HTR/p1738775301296369?thread_ts=1738773161.738519&cid=C038Q8K1HTR