### PR TITLE
Bumping the goreleaser GHA version to v6.2.1

### DIFF
--- a/.changeset/many-toys-joke.md
+++ b/.changeset/many-toys-joke.md
@@ -1,0 +1,5 @@
+---
+"cicd-build-publish-artifacts-go": minor
+---
+
+Bumping the goreleaser GHA version to v6.2.1

--- a/actions/cicd-build-publish-artifacts-go/action.yml
+++ b/actions/cicd-build-publish-artifacts-go/action.yml
@@ -200,7 +200,7 @@ runs:
         GITHUB_TOKEN: ${{ github.token }} # ${{ steps.get-gh-token.outputs.access-token }}
 
     - name: Run goreleaser release
-      uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811 # v5.1.0
+      uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # v6.2.1
       with:
         version: ${{ inputs.goreleaser-version }}
         distribution: ${{ inputs.goreleaser-dist }}


### PR DESCRIPTION
## What 

See title. 

## Why 

![image](https://github.com/user-attachments/assets/171676fc-0b17-4e53-921c-0aad2e72c119)
