### PR TITLE
chore: upgrade ci-test-go version of setup-golang

### DIFF
--- a/.changeset/itchy-owls-scream.md
+++ b/.changeset/itchy-owls-scream.md
@@ -1,0 +1,5 @@
+---
+"ci-test-go": patch
+---
+
+chore: bump setup-golang dependency to v0.3.1

--- a/actions/ci-test-go/action.yml
+++ b/actions/ci-test-go/action.yml
@@ -139,7 +139,7 @@ runs:
       working-directory: ${{ inputs.docker-compose-workdir }}
 
     - name: Setup go
-      uses: smartcontractkit/.github/actions/setup-golang@c5e1a1a754f459440b084c6661538b8635dcb33a # setup-golang@0.2.0
+      uses: smartcontractkit/.github/actions/setup-golang@01d931b0455a754d12e7143cc54a5a3521a8f6f6 # setup-golang@0.3.1
       with:
         go-version-file: ${{ inputs.go-version-file }}
         use-go-cache: ${{ inputs.use-go-cache }}


### PR DESCRIPTION
### Changes

Use newer version of `setup-golang` as the older version depends on a deprecated version of `actions/cache`.

---

RE-3330