### PR TITLE
chore: upgrade setup-nodejs version of ci-prettier

### DIFF
--- a/.changeset/perfect-panthers-hide.md
+++ b/.changeset/perfect-panthers-hide.md
@@ -1,0 +1,5 @@
+---
+"ci-prettier": patch
+---
+
+chore: bump setup-nodejs dependency to v0.2.3

--- a/actions/ci-prettier/action.yml
+++ b/actions/ci-prettier/action.yml
@@ -48,7 +48,7 @@ runs:
         fi
 
     - name: Setup nodejs
-      uses: smartcontractkit/.github/actions/setup-nodejs@5b1046c28343660ecb84844c6fa95a66d1cdb52e # setup-nodejs@0.2.1
+      uses: smartcontractkit/.github/actions/setup-nodejs@43fe7fdc5d678b962d777a4af76719792f9a4354 # setup-nodejs@0.2.3
       with:
         node-version-file: ${{ inputs.node-version-file }}
         pnpm-version: ${{ inputs.pnpm-version }}


### PR DESCRIPTION
### Changes

Use newer version of `setup-nodejs` as the older version depends on a deprecated version of `actions/cache`.

---

RE-3330