### PR TITLE
increase ns name uniqueness for crib in CI

### DIFF
--- a/.changeset/mighty-tigers-develop.md
+++ b/.changeset/mighty-tigers-develop.md
@@ -1,0 +1,5 @@
+---
+"crib-deploy-environment": patch
+---
+
+increased generated ns name by 1 char (attempt to increase uniqueness)

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -155,7 +155,7 @@ runs:
         REPO_NAME=$(basename "$GITHUB_REPOSITORY")
         BRANCH_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
 
-        echo "devspace-namespace=${NS_NAME_PREFIX}-$(uuidgen | cut -c1-5)" | tee -a "$GITHUB_OUTPUT"
+        echo "devspace-namespace=${NS_NAME_PREFIX}-$(uuidgen | cut -c1-6)" | tee -a "$GITHUB_OUTPUT"
         echo "pr-number=${PR_NUMBER}" | tee -a "$GITHUB_OUTPUT"
         echo "workflow-job=${WORKFLOW_JOB}" | tee -a "$GITHUB_OUTPUT"
         echo "repo-name=${REPO_NAME}" | tee -a "$GITHUB_OUTPUT"


### PR DESCRIPTION
A few errors such as `namespace already exists` have been observed recently, this is an attempt to mitigate this issue without incurring in increasing DNS names too much.