### PR TITLE
Improving GAP GHA configuration in the ctf-setup-run-tests-environment GHA

### DIFF
--- a/.changeset/flat-baboons-nail.md
+++ b/.changeset/flat-baboons-nail.md
@@ -1,0 +1,5 @@
+---
+"ctf-setup-run-tests-environment": minor
+---
+
+Improving the inputs and GAP configuration.

--- a/actions/ctf-setup-run-tests-environment/action.yml
+++ b/actions/ctf-setup-run-tests-environment/action.yml
@@ -61,19 +61,29 @@ inputs:
   gati_token:
     required: false
     description: Token provided by GATI to pull from private repos
+  enable-gap:
+    required: false
+    default: "true"
+    description: Configure and enable GAP for accessing internal services.
   main-dns-zone:
-    required: true
+    required: false
+    default: ""
     description:
       The primary DNS zone used in the hostname of the Kubernetes API endpoint.
-  k8s-cluster-name:
-    required: true
-    description:
-      The name of the Kubernetes cluster to be used in the `kubectl`
-      configuration for accessing the desired cluster.
+      Required if GAP is enabled.
 
 runs:
   using: composite
   steps:
+    - name: Validate GAP inputs
+      shell: bash
+      if: inputs.enable-gap == 'true'
+      run: |
+        if [ -z "${{ inputs.main-dns-zone }}" ]; then
+          echo "Error: main-dns-zone is required when enable-gap is true."
+          exit 1
+        fi
+
     # Go setup and caching
     - name: Setup Go
       if: inputs.go_necessary == 'true'
@@ -99,15 +109,15 @@ runs:
         mask-aws-account-id: true
 
     - name: Configure local GAP proxy for accessing (Kubernetes) services
-      uses: smartcontractkit/.github/actions/setup-gap@b969c2d42c15e937e2f94cc0e050f39cd5369f4f # setup-gap@4.0.0
+      uses: smartcontractkit/.github/actions/setup-gap@858d6785a9cce58359f5d6f9481902f2d0a331ac # setup-gap@4.0.1
+      if: inputs.enable-gap == 'true'
       with:
         aws-role-duration-seconds: 3600 # 1 hour
         aws-role-arn: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}
         aws-region: ${{ inputs.QA_AWS_REGION }}
-        k8s-cluster-name: ${{ inputs.k8s-cluster-name }}
         gap-name: k8s
         use-k8s: true
-        proxy-port: 8080
+        proxy-port: 9339
         main-dns-zone: ${{ inputs.main-dns-zone }}
 
     # Login to AWS ECR registries if needed

--- a/actions/ctf-setup-run-tests-environment/action.yml
+++ b/actions/ctf-setup-run-tests-environment/action.yml
@@ -71,6 +71,11 @@ inputs:
     description:
       The primary DNS zone used in the hostname of the Kubernetes API endpoint.
       Required if GAP is enabled.
+  k8s-cluster-name:
+    required: false
+    description:
+      The name of the Kubernetes cluster to be used in the `kubectl`
+      configuration for accessing the desired cluster.
 
 runs:
   using: composite
@@ -83,7 +88,10 @@ runs:
           echo "Error: main-dns-zone is required when enable-gap is true."
           exit 1
         fi
-
+        if [ -z "${{ inputs.k8s-cluster-name }}" ]; then
+          echo "Error: k8s-cluster-name is required when enable-gap is true."
+          exit 1
+        fi
     # Go setup and caching
     - name: Setup Go
       if: inputs.go_necessary == 'true'
@@ -112,13 +120,14 @@ runs:
       uses: smartcontractkit/.github/actions/setup-gap@858d6785a9cce58359f5d6f9481902f2d0a331ac # setup-gap@4.0.1
       if: inputs.enable-gap == 'true'
       with:
-        aws-role-duration-seconds: 3600 # 1 hour
-        aws-role-arn: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}
         aws-region: ${{ inputs.QA_AWS_REGION }}
+        aws-role-arn: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}
+        aws-role-duration-seconds: 3600 # 1 hour
         gap-name: k8s
-        use-k8s: true
-        proxy-port: 9339
+        k8s-cluster-name: ${{ inputs.k8s-cluster-name }}
         main-dns-zone: ${{ inputs.main-dns-zone }}
+        proxy-port: 9339
+        use-k8s: true
 
     # Login to AWS ECR registries if needed
     - name: Login to Amazon ECR

--- a/actions/ctf-setup-run-tests-environment/action.yml
+++ b/actions/ctf-setup-run-tests-environment/action.yml
@@ -73,6 +73,7 @@ inputs:
       Required if GAP is enabled.
   k8s-cluster-name:
     required: false
+    default: ""
     description:
       The name of the Kubernetes cluster to be used in the `kubectl`
       configuration for accessing the desired cluster.


### PR DESCRIPTION
## What 

See title. 

## Why 

Not all tests need GAP and access to internal services. Also, we need a flag to disable GAP, as this action is being used for different tests and environments. 
