### PR TITLE
Adding a flag for enabling local proxy debug logs

### DIFF
--- a/.changeset/many-apes-count.md
+++ b/.changeset/many-apes-count.md
@@ -1,0 +1,5 @@
+---
+"ctf-setup-run-tests-environment": patch
+---
+
+Adding a flag for enabling local proxy debug logs

--- a/actions/ctf-setup-run-tests-environment/action.yml
+++ b/actions/ctf-setup-run-tests-environment/action.yml
@@ -77,6 +77,13 @@ inputs:
     description:
       The name of the Kubernetes cluster to be used in the `kubectl`
       configuration for accessing the desired cluster.
+  enable-proxy-debug:
+    description:
+      "Enable or disable detailed Envoy proxy logs used for K8s API access. When
+      enabled, debug logs are generated locally, and container logs are streamed
+      to the console for troubleshooting."
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -129,6 +136,7 @@ runs:
         main-dns-zone: ${{ inputs.main-dns-zone }}
         proxy-port: 9339
         use-k8s: true
+        enable-proxy-debug: ${{ inputs.enable-proxy-debug }}
 
     # Login to AWS ECR registries if needed
     - name: Login to Amazon ECR


### PR DESCRIPTION
## What 

See title. 

## Why 

We would like to be able to control this. 