### PR TITLE
RE-3425: Use dynamic name for the envoy container name

### DIFF
--- a/.changeset/strong-forks-collect.md
+++ b/.changeset/strong-forks-collect.md
@@ -1,0 +1,6 @@
+---
+"setup-gap": minor
+---
+
+Adds ALPN support, uses dynamic container name and ensures the HOST header will
+always direct traffic to port 443 for the dynamic forward proxy

--- a/actions/setup-gap/action.yml
+++ b/actions/setup-gap/action.yml
@@ -267,6 +267,7 @@ runs:
     - name: Run local Envoy proxy
       shell: sh
       env:
+        GAP_NAME: "gap-${{ inputs.gap-name }}"
         DYNAMIC_PROXY_PORT: ${{ inputs.dynamic-proxy-port }}
         ENABLE_PROXY_DEBUG: ${{ inputs.enable-proxy-debug }}
         GITHUB_OIDC_TOKEN_HEADER_NAME:
@@ -313,7 +314,7 @@ runs:
 
         echo "Validating Envoy config..."
         if ! docker run --rm \
-            --name "gap" \
+            --name "${GAP_NAME}" \
             -p "${DYNAMIC_PROXY_PORT}:${DYNAMIC_PROXY_PORT}" \
             -p "${PROXY_PORT}:${PROXY_PORT}" \
             -p "${WEBSOCKETS_PROXY_PORT}:${WEBSOCKETS_PROXY_PORT}" \
@@ -330,7 +331,7 @@ runs:
 
         echo "Starting the local Envoy proxy..."
         docker run --rm -d \
-          --name "gap" \
+          --name "${GAP_NAME}" \
           -p "${DYNAMIC_PROXY_PORT}:${DYNAMIC_PROXY_PORT}" \
           -p "${PROXY_PORT}:${PROXY_PORT}" \
           -p "${WEBSOCKETS_PROXY_PORT}:${WEBSOCKETS_PROXY_PORT}" \

--- a/actions/setup-gap/envoy.yaml.gotmpl
+++ b/actions/setup-gap/envoy.yaml.gotmpl
@@ -99,6 +99,7 @@ static_resources:
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
               common_tls_context:
+                alpn_protocols: "h2,http/1.1"
                 tls_params:
                   tls_minimum_protocol_version: TLSv1_2
                 tls_certificates:
@@ -264,6 +265,7 @@ static_resources:
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
               common_tls_context:
+                alpn_protocols: "h2,http/1.1"
                 tls_params:
                   tls_minimum_protocol_version: TLSv1_2
                 tls_certificates:
@@ -343,6 +345,7 @@ static_resources:
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
           common_tls_context:
+            alpn_protocols: "h2,http/1.1"
             validation_context:
               trusted_ca:
                 filename: /etc/ssl/certs/ca-certificates.crt
@@ -367,6 +370,8 @@ static_resources:
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
           sni: "gap-ws-echo.{{ getenv "MAIN_DNS_ZONE" }}"
+          common_tls_context:
+            alpn_protocols: "h2,http/1.1"
 
     {{- if getenv "WEBSOCKETS_SERVICES" }}
       {{- $services := getenv "WEBSOCKETS_SERVICES" | strings.Split "," }}
@@ -391,5 +396,7 @@ static_resources:
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
           sni: "{{ . }}.{{ getenv "MAIN_DNS_ZONE" }}"
+          common_tls_context:
+            alpn_protocols: "h2,http/1.1"
       {{- end }}
     {{- end }}

--- a/actions/setup-gap/envoy.yaml.gotmpl
+++ b/actions/setup-gap/envoy.yaml.gotmpl
@@ -130,7 +130,7 @@ static_resources:
                               host_selection_retry_max_attempts: 5
                               retry_back_off:
                                 base_interval: "10s"
-                                max_interval: "5s"
+                                max_interval: "300s"
                           typed_per_filter_config:
                             envoy.filters.http.dynamic_forward_proxy:
                               '@type': type.googleapis.com/envoy.extensions.filters.http.dynamic_forward_proxy.v3.PerRouteConfig
@@ -231,7 +231,7 @@ static_resources:
                               host_selection_retry_max_attempts: 5
                               retry_back_off:
                                 base_interval: "30s"
-                                max_interval: "5s"
+                                max_interval: "300s"
                     {{- end }}
                   {{- end }}
 

--- a/actions/setup-gap/envoy.yaml.gotmpl
+++ b/actions/setup-gap/envoy.yaml.gotmpl
@@ -344,8 +344,6 @@ static_resources:
         name: envoy.transport_sockets.tls
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-          common_tls_context:
-            alpn_protocols: "h2,http/1.1"
             validation_context:
               trusted_ca:
                 filename: /etc/ssl/certs/ca-certificates.crt
@@ -370,8 +368,6 @@ static_resources:
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
           sni: "gap-ws-echo.{{ getenv "MAIN_DNS_ZONE" }}"
-          common_tls_context:
-            alpn_protocols: "h2,http/1.1"
 
     {{- if getenv "WEBSOCKETS_SERVICES" }}
       {{- $services := getenv "WEBSOCKETS_SERVICES" | strings.Split "," }}
@@ -396,7 +392,5 @@ static_resources:
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
           sni: "{{ . }}.{{ getenv "MAIN_DNS_ZONE" }}"
-          common_tls_context:
-            alpn_protocols: "h2,http/1.1"
       {{- end }}
     {{- end }}

--- a/actions/setup-gap/envoy.yaml.gotmpl
+++ b/actions/setup-gap/envoy.yaml.gotmpl
@@ -129,8 +129,8 @@ static_resources:
                               num_retries: 5
                               host_selection_retry_max_attempts: 5
                               retry_back_off:
-                                base_interval: "10s"
-                                max_interval: "300s"
+                                base_interval: "1s"
+                                max_interval: "5s"
                           typed_per_filter_config:
                             envoy.filters.http.dynamic_forward_proxy:
                               '@type': type.googleapis.com/envoy.extensions.filters.http.dynamic_forward_proxy.v3.PerRouteConfig
@@ -230,8 +230,8 @@ static_resources:
                               num_retries: 5
                               host_selection_retry_max_attempts: 5
                               retry_back_off:
-                                base_interval: "30s"
-                                max_interval: "300s"
+                                base_interval: "1s"
+                                max_interval: "5s"
                     {{- end }}
                   {{- end }}
 

--- a/actions/setup-gap/envoy.yaml.gotmpl
+++ b/actions/setup-gap/envoy.yaml.gotmpl
@@ -344,6 +344,7 @@ static_resources:
         name: envoy.transport_sockets.tls
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+          common_tls_context:
             validation_context:
               trusted_ca:
                 filename: /etc/ssl/certs/ca-certificates.crt

--- a/actions/setup-gap/envoy.yaml.gotmpl
+++ b/actions/setup-gap/envoy.yaml.gotmpl
@@ -135,17 +135,17 @@ static_resources:
                             envoy.filters.http.dynamic_forward_proxy:
                               '@type': type.googleapis.com/envoy.extensions.filters.http.dynamic_forward_proxy.v3.PerRouteConfig
                 http_filters:
+                  - name: envoy.filters.http.lua
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+                      default_source_code:
+                        filename: /etc/envoy/github_oidc.lua
                   - name: envoy.filters.http.dynamic_forward_proxy
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.dynamic_forward_proxy.v3.FilterConfig
                       dns_cache_config:
                         name: dynamic_forward_proxy_cache_config
                         dns_lookup_family: V4_ONLY
-                  - name: envoy.filters.http.lua
-                    typed_config:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-                      default_source_code:
-                        filename: /etc/envoy/github_oidc.lua
                   - name: envoy.filters.http.router
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/actions/setup-gap/envoy.yaml.gotmpl
+++ b/actions/setup-gap/envoy.yaml.gotmpl
@@ -332,7 +332,6 @@ static_resources:
     - name: dynamic_forward_proxy_cluster
       lb_policy: CLUSTER_PROVIDED
       connect_timeout: 5s
-      type: STRICT_DNS
       http2_protocol_options: {}
       cluster_type:
         name: envoy.clusters.dynamic_forward_proxy

--- a/actions/setup-gap/envoy.yaml.gotmpl
+++ b/actions/setup-gap/envoy.yaml.gotmpl
@@ -129,7 +129,7 @@ static_resources:
                               num_retries: 5
                               host_selection_retry_max_attempts: 5
                               retry_back_off:
-                                base_interval: "1s"
+                                base_interval: "10s"
                                 max_interval: "5s"
                           typed_per_filter_config:
                             envoy.filters.http.dynamic_forward_proxy:
@@ -230,7 +230,7 @@ static_resources:
                               num_retries: 5
                               host_selection_retry_max_attempts: 5
                               retry_back_off:
-                                base_interval: "1s"
+                                base_interval: "30s"
                                 max_interval: "5s"
                     {{- end }}
                   {{- end }}

--- a/actions/setup-gap/envoy.yaml.gotmpl
+++ b/actions/setup-gap/envoy.yaml.gotmpl
@@ -332,6 +332,7 @@ static_resources:
     - name: dynamic_forward_proxy_cluster
       lb_policy: CLUSTER_PROVIDED
       connect_timeout: 5s
+      type: STRICT_DNS
       http2_protocol_options: {}
       cluster_type:
         name: envoy.clusters.dynamic_forward_proxy

--- a/actions/setup-gap/github_oidc.lua.gotmpl
+++ b/actions/setup-gap/github_oidc.lua.gotmpl
@@ -114,6 +114,15 @@ function refresh_token_if_needed(request_handle)
     end
 end
 
+-- Function to ensure that the host header's port will be 443
+local function ensure_port_443(request_handle)
+    local host = request_handle:headers():get(":authority")
+    if host and host:find(escaped_main_dns_zone .. ":%d+$") then
+        request_handle:headers():remove(":authority")
+        request_handle:headers():add(":authority", host:gsub(":%d+$", ":443"))
+    end
+end
+
 -- Function to add headers to the request
 local function add_headers(request_handle)
     -- Remove the existing header if it already exists
@@ -128,6 +137,9 @@ local function add_headers(request_handle)
     else
         request_handle:logInfo(log_prefix .. "Skipping addition of '" .. GITHUB_REPOSITORY_HEADER .. "' header as it is already present")
     end
+
+    -- Ensure that the host header's port will be 443
+    ensure_port_443(request_handle)
 end
 
 -- Main function for Envoy request interception


### PR DESCRIPTION
This pull request includes several changes to enable using multiple local envoy proxies on the same workflow for the CLD repo. The most important changes include updating environment variable usage, modifying the Envoy configuration, and adding a new Lua function to ensure the correct port is used in the host header.

### Enhancements to Envoy proxy setup:

* [`actions/setup-gap/action.yml`](diffhunk://#diff-05506e3c2ffb5cb85e06ba106d4539bf50fe47316b49d832b8833a794efa8fceR270): Updated the `GAP_NAME` environment variable and replaced hardcoded `"gap"` with `${GAP_NAME}` in Docker run commands to dynamically set the container name. [[1]](diffhunk://#diff-05506e3c2ffb5cb85e06ba106d4539bf50fe47316b49d832b8833a794efa8fceR270) [[2]](diffhunk://#diff-05506e3c2ffb5cb85e06ba106d4539bf50fe47316b49d832b8833a794efa8fceL316-R317) [[3]](diffhunk://#diff-05506e3c2ffb5cb85e06ba106d4539bf50fe47316b49d832b8833a794efa8fceL333-R334). Fixes [issue](https://github.com/smartcontractkit/chainlink-deployments/actions/runs/13434740316/job/37534376378?pr=785)
* [`actions/setup-gap/envoy.yaml.gotmpl`](diffhunk://#diff-9212a8936590043adb397ef45bd99134e0a5c0bc4e5149aa5f526a134088136cR102): Added `alpn_protocols` to the `common_tls_context` to support "h2,http/1.1". Fixes [issue](https://github.com/smartcontractkit/chainlink-deployments/actions/runs/13435063471/job/37535394495?pr=785#step:19:751) 
* [`actions/setup-gap/github_oidc.lua.gotmpl`](diffhunk://#diff-9ab32261595f607173415c9435f801a8d2a9ccc75de28e9d6b86eaf64141ada7R117-R125): Added a new function `ensure_port_443` to ensure the host header's port is set to 443 and integrated this function into the existing `add_headers` function. [[1]](diffhunk://#diff-9ab32261595f607173415c9435f801a8d2a9ccc75de28e9d6b86eaf64141ada7R117-R125) [[2]](diffhunk://#diff-9ab32261595f607173415c9435f801a8d2a9ccc75de28e9d6b86eaf64141ada7R140-R142). This is required in order to ensure that we are hitting GAPv2 on the correct port. Fixes [issue](https://github.com/smartcontractkit/chainlink-deployments/actions/runs/13437405831/job/37543376827#step:19:3280)
* Reordered the `envoy.filters.http.lua` filter to ensure correct processing order with first changing the `HOST` port to 443 and then performing a DNS check to ensure that hosts will be saved with the correct port in envoys cache [[1]](diffhunk://#diff-9212a8936590043adb397ef45bd99134e0a5c0bc4e5149aa5f526a134088136cR102) [[2]](diffhunk://#diff-9212a8936590043adb397ef45bd99134e0a5c0bc4e5149aa5f526a134088136cR138-L147) [[3]](diffhunk://#diff-9212a8936590043adb397ef45bd99134e0a5c0bc4e5149aa5f526a134088136cR268).  Fixes [issue](https://github.com/smartcontractkit/chainlink-deployments/actions/runs/13437405831/job/37543376827#step:19:3280)

## Tested

- CLD workflow is passing with both RPC proxy and JD local proxies running on the same workflow: https://github.com/smartcontractkit/chainlink-deployments/actions/runs/13438914685/job/37555951235
- Releng GAP workflows are passing ensuring no regression https://github.com/smartcontractkit/releng-test/pull/70

