### PR TITLE
Reusable workflow no proxy

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -866,6 +866,9 @@ jobs:
           go_coverage_dest_dir: ${{ github.workspace }}/.covdata
           main-dns-zone: ${{ secrets.MAIN_DNS_ZONE_PUBLIC_SDLC }}
           k8s-cluster-name: ${{ secrets.AWS_K8S_CLUSTER_NAME_SDLC }}
+          enable-gap:
+            ${{ secrets.MAIN_DNS_ZONE_PUBLIC_SDLC }} != '' && ${{
+            secrets.AWS_K8S_CLUSTER_NAME_SDLC }} != ''
 
       - name: Show Otel-Collector logs
         if:

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -239,8 +239,10 @@ on:
       # Used in some tests to send slack notifications
       SLACK_CHANNEL:
         required: false
+      # Required only for k8s tests
       AWS_K8S_CLUSTER_NAME_SDLC:
         required: false
+      # Required only for k8s tests
       MAIN_DNS_ZONE_PUBLIC_SDLC:
         required: false
       # Passing these will get GATI token and set it as env var GATI_TOKEN for the tests
@@ -866,6 +868,8 @@ jobs:
           go_coverage_dest_dir: ${{ github.workspace }}/.covdata
           main-dns-zone: ${{ secrets.MAIN_DNS_ZONE_PUBLIC_SDLC }}
           k8s-cluster-name: ${{ secrets.AWS_K8S_CLUSTER_NAME_SDLC }}
+          # enable GAP only if tests explicitly set k8s-related secrets
+          # since GAP is required only, when running tests in k8s
           enable-gap:
             ${{ secrets.MAIN_DNS_ZONE_PUBLIC_SDLC }} != '' && ${{
             secrets.AWS_K8S_CLUSTER_NAME_SDLC }} != ''

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -803,7 +803,7 @@ jobs:
 
       - name: Run tests
         id: run_tests
-        uses: smartcontractkit/.github/actions/ctf-run-tests@b5bad2031cbc00db18a42f09cdde0bc12db99e23 # ctf-run-tests@v0.5.0
+        uses: smartcontractkit/.github/actions/ctf-run-tests@0cf9be26805b7569e931322d0a6e7bfcccc62e25 # ctf-run-tests@v0.5.0
         env:
           DETACH_RUNNER: true
           E2E_TEST_CHAINLINK_VERSION:
@@ -1101,7 +1101,7 @@ jobs:
 
       - name: Run tests
         id: run_tests
-        uses: smartcontractkit/.github/actions/ctf-run-tests@725dd141dd77cc87dad420e9484416fc4ae26be2 # ctf-run-tests@v0.5.0
+        uses: smartcontractkit/.github/actions/ctf-run-tests@0cf9be26805b7569e931322d0a6e7bfcccc62e25 # ctf-run-tests@v0.5.0
         env:
           DETACH_RUNNER: true
           RR_MEM: ${{ matrix.tests.remote_runner_memory }}
@@ -1239,7 +1239,7 @@ jobs:
             --github-workflow-run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             --splunk-url "${{ secrets.FLAKEGUARD_SPLUNK_ENDPOINT }}" \
             --splunk-token "${{ secrets.FLAKEGUARD_SPLUNK_HEC }}" \
-            --splunk-event "${{ github.event_name }}"            
+            --splunk-event "${{ github.event_name }}"
 
           EXIT_CODE=$?
           if [ "$EXIT_CODE" -eq 2 ]; then
@@ -1250,7 +1250,7 @@ jobs:
 
           # Print out the summary file
           echo -e "\nFlakeguard Summary:"
-          jq .summary_data ./flakeguard-report/all-test-results.json          
+          jq .summary_data ./flakeguard-report/all-test-results.json
 
           # Read the summary from the generated report
           summary=$(jq -c '.summary_data' ./flakeguard-report/all-test-results.json)
@@ -1312,7 +1312,7 @@ jobs:
             --repo-url "https://github.com/${{ github.repository }}" \
             --action-run-id "${{ github.run_id }}" \
             --max-pass-ratio "$GH_INPUTS_MAX_PASS_RATIO"
-                      
+
           EXIT_CODE=$?
           if [ "$EXIT_CODE" -eq 2 ]; then
             echo "ERROR: Flakeguard encountered an error while generating reports"

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -240,9 +240,9 @@ on:
       SLACK_CHANNEL:
         required: false
       AWS_K8S_CLUSTER_NAME_SDLC:
-        required: true
+        required: false
       MAIN_DNS_ZONE_PUBLIC_SDLC:
-        required: true
+        required: false
       # Passing these will get GATI token and set it as env var GATI_TOKEN for the tests
       OPTIONAL_GATI_AWS_ROLE_ARN:
         required: false

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -805,7 +805,7 @@ jobs:
 
       - name: Run tests
         id: run_tests
-        uses: smartcontractkit/.github/actions/ctf-run-tests@0cf9be26805b7569e931322d0a6e7bfcccc62e25 # ctf-run-tests@v0.5.0
+        uses: smartcontractkit/.github/actions/ctf-run-tests@0cf9be26805b7569e931322d0a6e7bfcccc62e25 # ctf-run-tests@v0.6.1
         env:
           DETACH_RUNNER: true
           E2E_TEST_CHAINLINK_VERSION:

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -1108,7 +1108,7 @@ jobs:
 
       - name: Run tests
         id: run_tests
-        uses: smartcontractkit/.github/actions/ctf-run-tests@0cf9be26805b7569e931322d0a6e7bfcccc62e25 # ctf-run-tests@v0.5.0
+        uses: smartcontractkit/.github/actions/ctf-run-tests@91995e4dd053581696702eec503ce2d2c8b8e753 # ctf-run-tests@0.6.1
         env:
           DETACH_RUNNER: true
           RR_MEM: ${{ matrix.tests.remote_runner_memory }}

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -238,7 +238,7 @@ jobs:
           fi
       - name: Run tests
         id: run_tests
-        uses: smartcontractkit/.github/actions/ctf-run-tests@0cf9be26805b7569e931322d0a6e7bfcccc62e25 # ctf-run-tests@v0.5.0
+        uses: smartcontractkit/.github/actions/ctf-run-tests@0cf9be26805b7569e931322d0a6e7bfcccc62e25 # ctf-run-tests@v0.6.1
         env:
           CL_DATABASE_URL: ${{ env.DB_URL }}
         with:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -238,7 +238,7 @@ jobs:
           fi
       - name: Run tests
         id: run_tests
-        uses: smartcontractkit/.github/actions/ctf-run-tests@725dd141dd77cc87dad420e9484416fc4ae26be2 # ctf-run-tests@v0.5.0
+        uses: smartcontractkit/.github/actions/ctf-run-tests@0cf9be26805b7569e931322d0a6e7bfcccc62e25 # ctf-run-tests@v0.5.0
         env:
           CL_DATABASE_URL: ${{ env.DB_URL }}
         with:


### PR DESCRIPTION
Use a version of `ctf-run-tests` action that makes GAP optional, since it's not needed by Docker tests. And if enabled it results in printing of all Docker container logs to the console when test fails, which crashes the UI.