### PR TITLE
feat: signed-commits support custom tag separator

### DIFF
--- a/.changeset/chilled-bobcats-compete.md
+++ b/.changeset/chilled-bobcats-compete.md
@@ -1,0 +1,5 @@
+---
+"cicd-changesets": patch
+---
+
+feat: allow for custom git tag separators in monorepos

--- a/.changeset/cold-hairs-invite.md
+++ b/.changeset/cold-hairs-invite.md
@@ -1,0 +1,5 @@
+---
+"changesets-signed-commits": minor
+---
+
+feat: allow for custom git tag separators in monorepos

--- a/actions/cicd-changesets/action.yml
+++ b/actions/cicd-changesets/action.yml
@@ -55,6 +55,14 @@ inputs:
     description: ""
     required: false
     default: "false"
+  changesets-tag-separator:
+    description: |
+      What character to use to separate the package name and version in the tag.
+      For example:
+        - Using `@`, the resulting git tag will be <package>@<version>
+        - Using `/`, the resulting git tag will be <package>/<version>
+    required: false
+    default: "@"
   pr-title:
     description: "title of the PR"
     required: false
@@ -130,6 +138,7 @@ runs:
         setupGitUser: false
         title: ${{ inputs.pr-title }}
         prDraft: ${{ inputs.pr-draft }}
+        tagSeparator: ${{ inputs.changesets-tag-separator }}
 
     - name: Check changesets output
       shell: bash

--- a/actions/signed-commits/action.yml
+++ b/actions/signed-commits/action.yml
@@ -40,6 +40,15 @@ inputs:
       `publish` or not"
     required: false
     default: "true"
+  tagSeparator:
+    description: |
+      What character to use to separate the package name and version in the tag.
+      For example:
+        - Using `@`, the resulting git tag will be <package>@<version>
+        - Using `/`, the resulting git tag will be <package>/<version>
+    required: false
+    default: "@"
+
 outputs:
   published:
     description:

--- a/actions/signed-commits/src/git/github-git/repo-tags.ts
+++ b/actions/signed-commits/src/git/github-git/repo-tags.ts
@@ -10,11 +10,11 @@ export interface GitTag {
  * We replace annotated tags with lightweight ones because we cannot sign annotated tags, but
  * lightweight tags pointing to signed commits will show up as verified in GitHub.
  */
-export async function pushTags(cwd?: string) {
+export async function pushTags(tagSeparator: string, cwd?: string) {
   const onlyLocalTags = await getLocalRemoteTagDiff(cwd);
 
   await deleteTags(onlyLocalTags, cwd);
-  const createdTags = await createLightweightTags(onlyLocalTags, cwd);
+  const createdTags = await createLightweightTags(tagSeparator, onlyLocalTags, cwd);
   await execWithOutput("git", ["push", "origin", "--tags"], { cwd });
 
   return createdTags;
@@ -52,10 +52,13 @@ export async function getLocalTags(cwd?: string): Promise<GitTag[]> {
 }
 
 export async function createLightweightTags(
+  tagSeparator: string,
   tags: GitTag[],
   cwd?: string,
 ): Promise<GitTag[]> {
   const createdTags = tags.map(async (tag) => {
+    // Default tag separator is @
+    tag.name = tag.name.replace("@", tagSeparator);
     await execWithOutput("git", ["tag", tag.name, tag.ref], { cwd });
 
     return tag;

--- a/actions/signed-commits/src/index.ts
+++ b/actions/signed-commits/src/index.ts
@@ -7,10 +7,17 @@ import readChangesetState from "./read-changeset-state";
 const getOptionalInput = (name: string) => core.getInput(name) || undefined;
 
 (async () => {
-  let githubToken = process.env.GITHUB_TOKEN;
-
+  const githubToken = process.env.GITHUB_TOKEN;
   if (!githubToken) {
     core.setFailed("Please add the GITHUB_TOKEN to the changesets action");
+    return;
+  }
+
+  const tagSeparator = core.getInput("tagSeparator");
+  if (tagSeparator !== "@" && tagSeparator !== "/") {
+    core.setFailed(
+      `Tag separator must be either '@' or '/', ${tagSeparator} is not supported`,
+    );
     return;
   }
 
@@ -20,8 +27,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
     process.chdir(inputCwd);
   }
 
-  let setupGitUser = core.getBooleanInput("setupGitUser");
-
+  const setupGitUser = core.getBooleanInput("setupGitUser");
   if (setupGitUser) {
     core.info("setting git user");
     await gitUtils.setupUser();
@@ -88,6 +94,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
         script: publishScript,
         githubToken,
         createGithubReleases: core.getBooleanInput("createGithubReleases"),
+        tagSeparator: tagSeparator,
       });
 
       if (result.published) {


### PR DESCRIPTION
### Changes

- signed-commits: Allow for customizing the separator of git tags  from`changesets`. Default is `@`, now allows you to use `/`.
- cicd-changesets: exposing above functionality

---

RE-3546