### PR TITLE
chore: bump signed-commits to 1.4.0

### DIFF
--- a/.changeset/cold-ladybugs-talk.md
+++ b/.changeset/cold-ladybugs-talk.md
@@ -1,0 +1,5 @@
+---
+"cicd-changesets": patch
+---
+
+deps: bump changesets-signed-commits to v1.4.0

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -91,6 +91,8 @@ jobs:
           pnpm-version: "^9.0.0"
           git-user: app-token-issuer-releng-renovate[bot]
           git-email: app-token-issuer-releng-renovate[bot]@users.noreply.github.com
+          # changesets inputs
+          changesets-tag-separator: "/"
           # aws inputs
           aws-region: ${{ secrets.AWS_REGION }}
           aws-role-arn: ${{ secrets.AWS_OIDC_IAM_ROLE_ARN_GATI }}

--- a/actions/cicd-changesets/action.yml
+++ b/actions/cicd-changesets/action.yml
@@ -128,7 +128,7 @@ runs:
 
     - name: Run changesets
       id: changesets
-      uses: smartcontractkit/.github/actions/signed-commits@ff80d56f5301dc8a65f66c4d47d746ee956beed9 # changesets-signed-commits@1.2.3
+      uses: smartcontractkit/.github/actions/signed-commits@81d53d6ed52fdd02ce7f6cf14634f06419b3a6e6 # changesets-signed-commits@1.4.0
       env:
         GITHUB_TOKEN: ${{ steps.get-gh-token.outputs.access-token }}
       with:


### PR DESCRIPTION
### Changes

- Updating `cicd-changesets` to use `signed-commits` `v1.4.0`. These are changes from #919.

---

RE-3546