### PR TITLE
Add docker cache scope using runner arch as a suffix for cache isolation

### DIFF
--- a/.changeset/rude-baboons-teach.md
+++ b/.changeset/rude-baboons-teach.md
@@ -1,0 +1,5 @@
+---
+"build-push-docker": minor
+---
+
+Add docker cache scope suffixed with runner arch

--- a/.github/workflows/reusable-docker-build-publish.yml
+++ b/.github/workflows/reusable-docker-build-publish.yml
@@ -292,7 +292,7 @@ jobs:
 
       - name: Docker image build
         id: build
-        uses: smartcontractkit/.github/actions/build-push-docker@re-3518/docker-cache # TODO
+        uses: smartcontractkit/.github/actions/build-push-docker@24d50bf6739d561b95fde0c671f08ed9ea3837b8 # build-push-docker@0.2.0
         with:
           platform: ${{ format('linux/{0}', matrix.arch) }}
           docker-registry-url:

--- a/.github/workflows/reusable-docker-build-publish.yml
+++ b/.github/workflows/reusable-docker-build-publish.yml
@@ -292,7 +292,7 @@ jobs:
 
       - name: Docker image build
         id: build
-        uses: smartcontractkit/.github/actions/build-push-docker@24d50bf6739d561b95fde0c671f08ed9ea3837b8 # build-push-docker@0.2.0
+        uses: smartcontractkit/.github/actions/build-push-docker@re-3518/docker-cache # TODO
         with:
           platform: ${{ format('linux/{0}', matrix.arch) }}
           docker-registry-url:

--- a/actions/build-push-docker/action.yml
+++ b/actions/build-push-docker/action.yml
@@ -14,8 +14,8 @@ inputs:
     description: |
       Source of Docker build cache.
 
-      ",scope=buildkit-$\{{ runner.arch }}" (ignore \ escape) is appended to
-      whichver value is provided for this input.
+      ",scope=buildkit-<runner arch>" is appended to this input in order to set
+      caching for the specific runner architecture.
     required: false
     default: "type=gha,timeout=10m"
   # See: https://github.com/moby/buildkit#github-actions-cache-experimental
@@ -23,8 +23,8 @@ inputs:
     description: |
       Destination of Docker build cache.
 
-      ",scope=buildkit-$\{{ runner.arch }}" (ignore \ escape) is appended to
-      whichver value is provided for this input.
+      ",scope=buildkit-<runner arch>" is appended to this input in order to set
+      caching for the specific runner architecture.
     required: false
     default: "type=gha,timeout=10m,mode=max,ignore-error=false"
   docker-registry-url:

--- a/actions/build-push-docker/action.yml
+++ b/actions/build-push-docker/action.yml
@@ -11,14 +11,22 @@ inputs:
     required: false
   # See: https://github.com/moby/buildkit#github-actions-cache-experimental
   docker-build-cache-from:
-    description: "Source of Docker build cache."
+    description: |
+      Source of Docker build cache.
+
+      ",scope=buildkit-$\{{ runner.arch }}" (ignore \ escape) is appended to
+      whichver value is provided for this input.
     required: false
-    default: "type=gha,scope=buildkit,timeout=10m"
+    default: "type=gha,timeout=10m"
   # See: https://github.com/moby/buildkit#github-actions-cache-experimental
   docker-build-cache-to:
-    description: "Destination of Docker build cache."
+    description: |
+      Destination of Docker build cache.
+
+      ",scope=buildkit-$\{{ runner.arch }}" (ignore \ escape) is appended to
+      whichver value is provided for this input.
     required: false
-    default: "type=gha,scope=buildkit,timeout=10m,mode=max,ignore-error=false"
+    default: "type=gha,timeout=10m,mode=max,ignore-error=false"
   docker-registry-url:
     required: true
     description: |
@@ -181,8 +189,14 @@ runs:
         tags: ${{ steps.docker-meta.outputs.tags }}
         labels: ${{ steps.docker-meta.outputs.labels }}
         platforms: ${{ inputs.platform }}
-        cache-from: ${{ inputs.docker-build-cache-from }}
-        cache-to: ${{ inputs.docker-build-cache-to }}
+        cache-from: >-
+          ${{
+            format('{0},scope={1}', inputs.docker-build-cache-from, runner.arch)
+          }}
+        cache-to: >-
+          ${{
+            format('{0},scope={1}', inputs.docker-build-cache-to, runner.arch)
+          }}
 
     - name: Set outputs
       id: set-outputs


### PR DESCRIPTION
Otherwise each build will stomp on the other's cache.