### PR TITLE
fix: setup-go use new branch-names

### DIFF
--- a/.changeset/chilly-pianos-juggle.md
+++ b/.changeset/chilly-pianos-juggle.md
@@ -1,0 +1,5 @@
+---
+"setup-golang": patch
+---
+
+fix: swap out tj-actions/branch-names for internal fork

--- a/actions/setup-golang/action.yml
+++ b/actions/setup-golang/action.yml
@@ -53,7 +53,7 @@ runs:
     - name: Get branch name
       if: ${{ inputs.only-modules == 'false' }}
       id: branch-name
-      uses: tj-actions/branch-names@6871f53176ad61624f978536bbf089c574dc19a2 # v8.0.1
+      uses: smartcontractkit/.github/actions/branch-names@branch-names/1.0.0
 
     - name: Set go cache keys
       shell: bash


### PR DESCRIPTION
### 

Use the new forked `branch-names` action in `.github`.