### PR TITLE
chore: update usages of setup-golang

### DIFF
--- a/.changeset/curly-spoons-fix.md
+++ b/.changeset/curly-spoons-fix.md
@@ -1,0 +1,5 @@
+---
+"ci-test-go": patch
+---
+
+choref; update setup-golang to 0.3.2 (tj-actions/branch-names fix)

--- a/actions/ci-test-go/action.yml
+++ b/actions/ci-test-go/action.yml
@@ -139,7 +139,7 @@ runs:
       working-directory: ${{ inputs.docker-compose-workdir }}
 
     - name: Setup go
-      uses: smartcontractkit/.github/actions/setup-golang@01d931b0455a754d12e7143cc54a5a3521a8f6f6 # setup-golang@0.3.1
+      uses: smartcontractkit/.github/actions/setup-golang@setup-golang/0.3.2
       with:
         go-version-file: ${{ inputs.go-version-file }}
         use-go-cache: ${{ inputs.use-go-cache }}


### PR DESCRIPTION
### Changes

- Update setup-golang to  `0.3.2`.