### PR TITLE
DX-198 Bump Flakeguard to send codeowners, test path and failed test log url to splunk in e2e tests workflow

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -388,7 +388,6 @@ jobs:
         uses: actions/checkout@v4.2.1
         with:
           persist-credentials: false
-          ref: ${{ inputs.chainlink_version }}
       - name: Install citool
         shell: bash
         run: go install
@@ -438,7 +437,6 @@ jobs:
         uses: actions/checkout@v4.2.1
         with:
           persist-credentials: false
-          ref: ${{ inputs.chainlink_version }}
       - name: Setup Go
         uses: actions/setup-go@v5.0.2
         with:

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -806,7 +806,7 @@ jobs:
       - name: Run tests
         id: run_tests
         timeout-minutes: ${{ fromJson(env.DOCKER_TESTS_TIMEOUT_MINUTES) }}
-        uses: smartcontractkit/.github/actions/ctf-run-tests@a778ea5c4ca7bb307169acae03ef596d78911759 # ctf-run-tests@v0.6.2
+        uses: smartcontractkit/.github/actions/ctf-run-tests@987f6401bbef0f86f6916f9b958b617a202b0037 # ctf-run-tests@v0.6.2
         env:
           DETACH_RUNNER: true
           E2E_TEST_CHAINLINK_VERSION:
@@ -1109,7 +1109,7 @@ jobs:
 
       - name: Run tests
         id: run_tests
-        uses: smartcontractkit/.github/actions/ctf-run-tests@a778ea5c4ca7bb307169acae03ef596d78911759 # ctf-run-tests@v0.6.2
+        uses: smartcontractkit/.github/actions/ctf-run-tests@987f6401bbef0f86f6916f9b958b617a202b0037 # ctf-run-tests@v0.6.2
         env:
           DETACH_RUNNER: true
           RR_MEM: ${{ matrix.tests.remote_runner_memory }}

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -1268,6 +1268,13 @@ jobs:
           summary=$(jq -c '.summary_data' ./flakeguard-report/all-test-report.json)
           echo "summary=$summary" >> $GITHUB_OUTPUT
 
+      - name: Upload Test Report as Artifact
+        if: ${{ fromJSON(steps.results.outputs.summary).total_runs > 0 }}
+        uses: actions/upload-artifact@v4
+        with:
+          path: ./flakeguard-report
+          retention-days: 14
+
       - name: Upload Failed Test Report as Artifact
         if:
           ${{ env.FLAKEGUARD_ENABLE == 'true' && (success() || failure()) &&
@@ -1311,7 +1318,7 @@ jobs:
           # Send the aggregated test report to Splunk
           flakeguard send-to-splunk \
             --report-path ./flakeguard-report/all-test-report.json \
-            --failed-logs-url ${{ steps.upload-failed-report-with-logs.outputs.artifact-url }} \
+            --failed-logs-url "${{ steps.upload-failed-report-with-logs.outputs.artifact-url }}" \
             --splunk-url "${{ secrets.FLAKEGUARD_SPLUNK_ENDPOINT }}" \
             --splunk-token "${{ secrets.FLAKEGUARD_SPLUNK_HEC }}" \
             --splunk-event "${{ github.event_name }}"
@@ -1339,8 +1346,8 @@ jobs:
 
           flakeguard generate-github-report \
             --flakeguard-report ./flakeguard-report/all-test-report.json \
-            --failed-logs-url ${{ steps.upload-failed-report-with-logs.outputs.artifact-url }} \
             --summary-report-md-path ./flakeguard-report/all-test-summary.md \
+            --failed-logs-url "${{ steps.upload-failed-report-with-logs.outputs.artifact-url }}" \
             --github-repository "${{ github.repository }}" \
             --github-run-id "${{ github.run_id }}" \
             --current-branch "${{ github.head_ref }}" \

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -1253,9 +1253,7 @@ jobs:
             --github-workflow-run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             --branch-name "${{ github.head_ref || github.ref_name }}" \
             --head-sha "$git_head_sha" \
-            --splunk-url "${{ secrets.FLAKEGUARD_SPLUNK_ENDPOINT }}" \
-            --splunk-token "${{ secrets.FLAKEGUARD_SPLUNK_HEC }}" \
-            --splunk-event "${{ github.event_name }}"
+            --gen-report-id \
 
           EXIT_CODE=$?
           if [ "$EXIT_CODE" -eq 2 ]; then

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -1222,9 +1222,9 @@ jobs:
         if: ${{ always() && env.FLAKEGUARD_ENABLE == 'true' }}
         shell: bash
         run: go install
-          github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@de11cbadfd18397cb35c19d44aa4fde8e686f560 # flakguard@0.1.0
+          github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@1e85367aeb99e88fa266d93312a6420a1a8a2cab # flakguard@0.1.0
 
-      - name: Aggregate Flakeguard Results
+      - name: Generate Flakeguard Report
         if: ${{ always() && env.FLAKEGUARD_ENABLE == 'true' }}
         id: results
         shell: bash
@@ -1238,15 +1238,21 @@ jobs:
           PATH="$PATH:$(go env GOPATH)/bin"
           export PATH
 
+          git_head_sha=$(git rev-parse HEAD)
+          git_head_short_sha=$(git rev-parse --short HEAD)
+
           # Aggregate Flakeguard test results
-          flakeguard aggregate-results \
-            --results-path ./flakeguard_results \
+          flakeguard generate-test-report \
+            --test-results-dir ./flakeguard_results \
             --output-path ./flakeguard-report \
+            --repo-path "${{ github.workspace }}" \
             --codeowners-path "${{ github.workspace }}/.github/CODEOWNERS" \
             --max-pass-ratio "$GH_INPUTS_MAX_PASS_RATIO" \
             --repo-url "https://github.com/${{ github.repository }}" \
             --github-workflow-name "${{ github.workflow }}" \
             --github-workflow-run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --branch-name "${{ github.head_ref || github.ref_name }}" \
+            --head-sha "$git_head_sha" \
             --splunk-url "${{ secrets.FLAKEGUARD_SPLUNK_ENDPOINT }}" \
             --splunk-token "${{ secrets.FLAKEGUARD_SPLUNK_HEC }}" \
             --splunk-event "${{ github.event_name }}"
@@ -1260,43 +1266,34 @@ jobs:
 
           # Print out the summary file
           echo -e "\nFlakeguard Summary:"
-          jq .summary_data ./flakeguard-report/all-test-results.json
+          jq .summary_data ./flakeguard-report/all-test-report.json
 
           # Read the summary from the generated report
-          summary=$(jq -c '.summary_data' ./flakeguard-report/all-test-results.json)
-          echo "summary=$summary" >> "$GITHUB_OUTPUT"
+          summary=$(jq -c '.summary_data' ./flakeguard-report/all-test-report.json)
+          echo "summary=$summary" >> $GITHUB_OUTPUT
 
-      - name: Upload All Test Results as Artifact
+      - name: Upload Failed Test Report as Artifact
         if:
           ${{ env.FLAKEGUARD_ENABLE == 'true' && (success() || failure()) &&
-          fromJSON(steps.results.outputs.summary).total_tests > 0 }}
-        uses: actions/upload-artifact@v4.4.3
+          fromJSON(steps.results.outputs.summary).failed_runs > 0 }}
+        uses: actions/upload-artifact@v4
         with:
-          path: ./flakeguard-report/all-test-results.json
-          name: all-test-results.json
+          path: ./flakeguard-report/failed-test-report.json
+          name: failed-test-report.json
           retention-days: 90
 
-      - name: Upload Failed Test Results as Artifact
+      - name: Upload Failed Test Report With Logs as Artifact
+        id: upload-failed-report-with-logs
         if:
           ${{ env.FLAKEGUARD_ENABLE == 'true' && (success() || failure()) &&
           fromJSON(steps.results.outputs.summary).failed_runs > 0 }}
         uses: actions/upload-artifact@v4.4.3
         with:
-          path: ./flakeguard-report/failed-test-results.json
-          name: failed-test-results.json
+          path: ./flakeguard-report/failed-test-report-with-logs.json
+          name: failed-test-report-with-logs.json
           retention-days: 90
 
-      - name: Upload Failed Test Results With Logs as Artifact
-        if:
-          ${{ env.FLAKEGUARD_ENABLE == 'true' && (success() || failure()) &&
-          fromJSON(steps.results.outputs.summary).failed_runs > 0 }}
-        uses: actions/upload-artifact@v4.4.3
-        with:
-          path: ./flakeguard-report/failed-test-results-with-logs.json
-          name: failed-test-results-with-logs.json
-          retention-days: 90
-
-      - name: Generate Flakeguard Reports
+      - name: Send Flakeguard Results to Splunk
         shell: bash
         if: ${{ env.FLAKEGUARD_ENABLE == 'true' && (success() || failure()) }}
         id: generate-report
@@ -1310,38 +1307,70 @@ jobs:
             ${{ github.event.pull_request.head.sha }}
         run: |
           # Fix flakeguard binary path
-          PATH="$PATH:$(go env GOPATH)/bin"
+          PATH=$PATH:$(go env GOPATH)/bin
           export PATH
 
-          flakeguard generate-report \
-            --aggregated-results-path ./flakeguard-report/all-test-results.json \
-            --failed-tests-artifact-name failed-test-results-with-logs.json \
-            --output-path ./flakeguard-report \
+          echo "Artifact URL: ${{ steps.upload-failed-report-with-logs.outputs.artifact-url }}"
+
+          # Send the aggregated test report to Splunk
+          flakeguard send-to-splunk \
+            --report-path ./flakeguard-report/all-test-report.json \
+            --failed-logs-url ${{ steps.upload-failed-report-with-logs.outputs.artifact-url }} \
+            --splunk-url "${{ secrets.FLAKEGUARD_SPLUNK_ENDPOINT }}" \
+            --splunk-token "${{ secrets.FLAKEGUARD_SPLUNK_HEC }}" \
+            --splunk-event "${{ github.event_name }}"
+          EXIT_CODE=$?
+          if [ $EXIT_CODE -ne 0 ]; then
+            echo "ERROR: Flakeguard encountered an error while sending report to Splunk"
+            exit $EXIT_CODE
+          fi
+
+      - name: Generate Flakeguard Github Reports
+        shell: bash
+        if: success() || failure()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_INPUTS_MAX_PASS_RATIO: ${{ env.FLAKEGUARD_MAX_PASS_RATIO }}
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_EVENT_PULL_REQUEST_BASE_REF:
+            ${{ github.event.pull_request.base.ref }}
+          GH_EVENT_PULL_REQUEST_HEAD_SHA:
+            ${{ github.event.pull_request.head.sha }}
+        run: |
+          # Fix flakeguard binary path
+          PATH=$PATH:$(go env GOPATH)/bin
+          export PATH
+
+          flakeguard generate-github-report \
+            --flakeguard-report ./flakeguard-report/all-test-report.json \
+            --failed-logs-url ${{ steps.upload-failed-report-with-logs.outputs.artifact-url }} \
+            --summary-report-md-path ./flakeguard-report/all-test-summary.md \
             --github-repository "${{ github.repository }}" \
             --github-run-id "${{ github.run_id }}" \
+            --current-branch "${{ github.head_ref }}" \
             --repo-url "https://github.com/${{ github.repository }}" \
             --action-run-id "${{ github.run_id }}" \
             --max-pass-ratio "$GH_INPUTS_MAX_PASS_RATIO"
 
           EXIT_CODE=$?
-          if [ "$EXIT_CODE" -eq 2 ]; then
+          if [ $EXIT_CODE -eq 2 ]; then
             echo "ERROR: Flakeguard encountered an error while generating reports"
-            echo "ERROR: Flakeguard encountered an error while generating reports" >> "$GITHUB_STEP_SUMMARY"
-            exit "$EXIT_CODE"
+            echo "ERROR: Flakeguard encountered an error while generating reports" >> $GITHUB_STEP_SUMMARY
+            exit $EXIT_CODE
           fi
 
       - name: Add Github Summary
-        if: ${{ env.FLAKEGUARD_ENABLE == 'true' && (success() || failure()) }}
+        if: (success() || failure())
         run: |
           FILE_SIZE=$(wc -c < ./flakeguard-report/all-test-summary.md)
-          echo "File size: $FILE_SIZE bytes"
+                    echo "File size: $FILE_SIZE bytes"
           SIZE_LIMIT=$((1024 * 1024))
 
           if [ "$FILE_SIZE" -le "$SIZE_LIMIT" ]; then
-            cat ./flakeguard-report/all-test-summary.md >> "$GITHUB_STEP_SUMMARY"
+            cat ./flakeguard-report/all-test-summary.md >> $GITHUB_STEP_SUMMARY
           else
-            echo "**We found flaky tests, so many flaky tests that the summary is too large for GitHub Actions step summaries!**" >> "$GITHUB_STEP_SUMMARY"
-            echo "**Please see logs, or the attached \`all-test-summary.md\` artifact**" >> "$GITHUB_STEP_SUMMARY"
+            echo "**We found flaky tests, so many flaky tests that the summary is too large for github actions step summaries!**" >> $GITHUB_STEP_SUMMARY
+            echo "**Please see logs, or the attached `all-test-summary.md` artifact**" >> $GITHUB_STEP_SUMMARY
             cat ./flakeguard-report/all-test-summary.md
           fi
 

--- a/actions/ctf-run-tests/action.yml
+++ b/actions/ctf-run-tests/action.yml
@@ -341,7 +341,7 @@ runs:
           --test-cmd '${{ inputs.test_command_to_run }}' \
           --run-count=${{ inputs.flakeguard_run_count }} \
           --omit-test-outputs-on-success=true \
-          --output-json=flakeguard_results.json
+          --main-results-path=flakeguard_results.json
 
     - name: Run Tests Without Flakeguard
       if: inputs.flakeguard_enable != 'true'

--- a/actions/ctf-run-tests/action.yml
+++ b/actions/ctf-run-tests/action.yml
@@ -326,7 +326,7 @@ runs:
         GO_COVERAGE_DEST_DIR: ${{ inputs.go_coverage_dest_dir }}
       run: |
         # Install Flakeguard
-        go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@de11cbadfd18397cb35c19d44aa4fde8e686f560
+        go install github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard@1e85367aeb99e88fa266d93312a6420a1a8a2cab
         PATH=$PATH:$(go env GOPATH)/bin
         export PATH
 


### PR DESCRIPTION
PR in core: https://github.com/smartcontractkit/chainlink/pull/16866