### PR TITLE
feat: signed-commits support /v tag separator

### DIFF
--- a/.changeset/clean-buses-mix.md
+++ b/.changeset/clean-buses-mix.md
@@ -1,0 +1,5 @@
+---
+"changesets-signed-commits": patch
+---
+
+feat: support /v tag separator

--- a/actions/signed-commits/action.yml
+++ b/actions/signed-commits/action.yml
@@ -46,6 +46,7 @@ inputs:
       For example:
         - Using `@`, the resulting git tag will be <package>@<version>
         - Using `/`, the resulting git tag will be <package>/<version>
+        - Using `/v`, the resulting git tag will be <package>/v<version>
     required: false
     default: "@"
   createMajorVersionTags:

--- a/actions/signed-commits/dist/index.js
+++ b/actions/signed-commits/dist/index.js
@@ -60126,7 +60126,10 @@ async function pushTags(tagSeparator, createMajorVersionTags, cwd) {
   const createdTags = await createLightweightTags(filteredRewrittenTags, cwd);
   await execWithOutput("git", ["push", "origin", "--tags"], { cwd });
   if (createMajorVersionTags) {
-    const majorVersionTags = getMajorVersionTags(filteredRewrittenTags, tagSeparator);
+    const majorVersionTags = getMajorVersionTags(
+      filteredRewrittenTags,
+      tagSeparator
+    );
     const createdMajorTags = await createLightweightTags(majorVersionTags, cwd);
     for (const tag of createdMajorTags) {
       await execWithOutput("git", ["push", "--force", "origin", tag.name], {
@@ -60207,7 +60210,7 @@ function getMajorVersionTags(tags, separator) {
     if (!info4) {
       return acc;
     }
-    const majorTag = `${info4.pkg}${separator}v${info4.major}`;
+    const majorTag = separator.endsWith("v") ? `${info4.pkg}${separator}${info4.major}` : `${info4.pkg}${separator}v${info4.major}`;
     if (tagNamesSeen.has(majorTag)) {
       return acc;
     }
@@ -60236,8 +60239,8 @@ function parseTagName(tagName, separator) {
     pkg: name,
     version: version2,
     major: majorVersion,
-    minor: match[2],
-    patch: match[3]
+    minor: match[3],
+    patch: match[4]
   };
 }
 
@@ -60926,9 +60929,9 @@ var getOptionalInput = (name) => core4.getInput(name) || void 0;
     return;
   }
   const tagSeparator = core4.getInput("tagSeparator");
-  if (tagSeparator !== "@" && tagSeparator !== "/") {
+  if (tagSeparator !== "@" && tagSeparator !== "/" && tagSeparator !== "/v") {
     core4.setFailed(
-      `Tag separator must be either '@' or '/', ${tagSeparator} is not supported`
+      `Tag separator must be either '@', '/', or '/v', ${tagSeparator} is not supported`
     );
     return;
   }

--- a/actions/signed-commits/src/git/github-git/repo-tags.ts
+++ b/actions/signed-commits/src/git/github-git/repo-tags.ts
@@ -141,8 +141,7 @@ export async function getRemoteTagNames(cwd?: string): Promise<string[]> {
 }
 
 /**
- * Replaces the tag separator in the list of tags. Typically used to replace the @ separator
- * with the / separator.
+ * Replaces the tag separator in the list of tags.
  * @param tags The list of tags to update.
  * @param separator The separator to replace the @ separator with.
  * @returns The updated list of tags.
@@ -182,7 +181,11 @@ export function getMajorVersionTags(
       return acc;
     }
 
-    const majorTag = `${info.pkg}${separator}v${info.major}`;
+    // Don't add a v to the tag, if the separator already ends with a v
+    const majorTag = separator.endsWith("v")
+      ? `${info.pkg}${separator}${info.major}`
+      : `${info.pkg}${separator}v${info.major}`;
+
     if (tagNamesSeen.has(majorTag)) {
       return acc;
     }
@@ -205,7 +208,7 @@ export function getMajorVersionTags(
 export function parseTagName(tagName: string, separator: string) {
   // [a-z-]+ is the package name
   // (\d+) is the major/minor/patch version
-  const tagRegex = new RegExp(`([a-z0-9-]+)${separator}(\\d+)\.(\\d+)\.(\\d+)`);
+  const tagRegex = new RegExp(`([a-z0-9-]+)${separator}(\\d+).(\\d+).(\\d+)`);
   const match = tagRegex.exec(tagName);
   if (!match || match.length < 5) {
     return;
@@ -223,7 +226,7 @@ export function parseTagName(tagName: string, separator: string) {
     pkg: name,
     version: version,
     major: majorVersion,
-    minor: match[2],
-    patch: match[3],
+    minor: match[3],
+    patch: match[4],
   };
 }

--- a/actions/signed-commits/src/index.ts
+++ b/actions/signed-commits/src/index.ts
@@ -14,9 +14,9 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
   }
 
   const tagSeparator = core.getInput("tagSeparator");
-  if (tagSeparator !== "@" && tagSeparator !== "/") {
+  if (tagSeparator !== "@" && tagSeparator !== "/" && tagSeparator !== "/v") {
     core.setFailed(
-      `Tag separator must be either '@' or '/', ${tagSeparator} is not supported`,
+      `Tag separator must be either '@', '/', or '/v', ${tagSeparator} is not supported`,
     );
     return;
   }
@@ -96,7 +96,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
         script: publishScript,
         githubToken,
         createGithubReleases: core.getBooleanInput("createGithubReleases"),
-        tagSeparator: tagSeparator,
+        tagSeparator,
         createMajorVersionTags,
       });
 


### PR DESCRIPTION
### Changes

- Add support for a `/v` tag separator.
- Add tests for `/v` tags
- Fix minor bug in `parseTagName`

--

RE-3546