### PR TITLE
chore: bump signed-commits to 1.5.0

### DIFF
--- a/.changeset/tricky-walls-brake.md
+++ b/.changeset/tricky-walls-brake.md
@@ -1,0 +1,6 @@
+---
+"cicd-changesets": patch
+---
+
+chore: bump changesets-signed-commits version, pass through optional parameter
+changesets-major-version-tags

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -93,6 +93,7 @@ jobs:
           git-email: app-token-issuer-releng-renovate[bot]@users.noreply.github.com
           # changesets inputs
           changesets-tag-separator: "/"
+          changesets-major-version-tags: "true"
           # aws inputs
           aws-region: ${{ secrets.AWS_REGION }}
           aws-role-arn: ${{ secrets.AWS_OIDC_IAM_ROLE_ARN_GATI }}

--- a/actions/cicd-changesets/action.yml
+++ b/actions/cicd-changesets/action.yml
@@ -61,8 +61,15 @@ inputs:
       For example:
         - Using `@`, the resulting git tag will be <package>@<version>
         - Using `/`, the resulting git tag will be <package>/<version>
+        - Using `/v` the resulting git tag will be <package>/v<version>
     required: false
     default: "@"
+  changesets-major-version-tags:
+    description: |
+      Create and mutate major version tags for each package.
+      Uses the same separator as above.
+    required: false
+    default: "false"
   pr-title:
     description: "title of the PR"
     required: false
@@ -128,7 +135,7 @@ runs:
 
     - name: Run changesets
       id: changesets
-      uses: smartcontractkit/.github/actions/signed-commits@81d53d6ed52fdd02ce7f6cf14634f06419b3a6e6 # changesets-signed-commits@1.4.0
+      uses: smartcontractkit/.github/actions/signed-commits@changesets-signed-commits/1.5.0
       env:
         GITHUB_TOKEN: ${{ steps.get-gh-token.outputs.access-token }}
       with:
@@ -139,6 +146,7 @@ runs:
         title: ${{ inputs.pr-title }}
         prDraft: ${{ inputs.pr-draft }}
         tagSeparator: ${{ inputs.changesets-tag-separator }}
+        createMajorVersionTags: ${{ inputs.changesets-major-version-tags }}
 
     - name: Check changesets output
       shell: bash


### PR DESCRIPTION
### Changes

- `cicd-changesets`: bump signed-commits action to 1.5.0
- `push-main` workflow: Create major version tags: true

---

RE-3546