### PR TITLE
chore: major version release for many actions

### DIFF
--- a/.changeset/unlucky-chefs-talk.md
+++ b/.changeset/unlucky-chefs-talk.md
@@ -1,0 +1,20 @@
+---
+"ci-lint-charts": major
+"ci-lint-go": major
+"ci-lint-misc": major
+"ci-lint-ts": major
+"ci-prettier": major
+"ci-test-go": major
+"ci-test-sol": major
+"ci-test-ts": major
+"cicd-changesets": major
+"setup-github-token": major
+"setup-golang": major
+"setup-nodejs": major
+"slack-notify-git-ref": major
+"wait-for-workflows": major
+"release-tag-check": major
+---
+
+- Bumping major version to create 1.0.0 release. This release in itself is non-breaking major version bump.
+  - Note: previous 0.x minor version bumps may have included breaking changes. If you were already fully up-to-date before this version bump, then it's ok to upgrade.


### PR DESCRIPTION
### Changes

- Add a changeset to perform a major version release for our actions which are actually used.