### PR TITLE
add more logging, read the file within the artifact folder

### DIFF
--- a/.changeset/slimy-foxes-rule.md
+++ b/.changeset/slimy-foxes-rule.md
@@ -1,0 +1,5 @@
+---
+"flakeguard-ai-analysis": minor
+---
+
+Add new parameters and handle artifact files from github actions properly

--- a/actions/flakeguard-ai-analysis/.gitignore
+++ b/actions/flakeguard-ai-analysis/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 analysis.jsonl
 context/results.json
+output.txt

--- a/actions/flakeguard-ai-analysis/main.py
+++ b/actions/flakeguard-ai-analysis/main.py
@@ -47,7 +47,7 @@ def main():
     logger.info("Wrote analysis to file")
 
     output_file = os.getenv("GITHUB_OUTPUT", file_path / "output.txt")
-    open(output_file, "w").write(f"analysis={file_path}/context/analysis.jsonl")
+    open(output_file, "w").write(f"analysis={file_path}/analysis.jsonl")
     logger.info(f"Output file written to {output_file}")
 
 

--- a/actions/flakeguard-ai-analysis/main.py
+++ b/actions/flakeguard-ai-analysis/main.py
@@ -32,8 +32,8 @@ def main():
         return
 
     # github actions downloads into a folder with a file underneath it
-    file_name = "failed-test-report-with-logs.json"
-    df = read_results_file(file_path / failed_test_results / file_name)
+    report_file_name = os.environ.get("REPORT_FILE_NAME", "failed-test-report-with-logs.json")
+    df = read_results_file(file_path / failed_test_results / report_file_name)
     logger.info("Read results file")
 
     analysis = df.apply(lambda x: analyzer(x), axis=1)

--- a/actions/flakeguard-ai-analysis/main.py
+++ b/actions/flakeguard-ai-analysis/main.py
@@ -12,32 +12,43 @@ logger = logging.getLogger(__name__)
 
 
 def main():
-    file_path = Path("/github/workspace")
+    file_path = Path(os.environ.get("FILE_PATH", "/github/workspace"))
     init()
     logger.info("Initialized dspy")
+
     test_guide = get_repo_file(
         "tools/flakeguard/e2e-flaky-test-guide.md",
         repo="chainlink-testing-framework",
         branch="main",
     )
+    logger.info("Loaded test guide")
     analyzer = FlakyTestAnalyzer(test_guide=test_guide)
+    logger.info("Initialized analyzer")
+
     failed_test_results = os.environ.get("FAILED_TEST_RESULTS", "context/results.json")
     logger.info(f"Checking for results file at {file_path / failed_test_results}")
     if not Path(file_path / failed_test_results).exists():
         logger.info("No Flakeguard failed test results found")
         return
-    df = read_results_file(file_path / failed_test_results)
+
+    # github actions downloads into a folder with a file underneath it
+    file_name = "failed-test-report-with-logs.json"
+    df = read_results_file(file_path / failed_test_results / file_name)
     logger.info("Read results file")
+
     analysis = df.apply(lambda x: analyzer(x), axis=1)
     logger.info("Analyzed results")
+
     df_analysis = pd.json_normalize(analysis)  # type: ignore
     # write to /github/workspace to ensure the file can be used as an output
     df_analysis.to_json(
         "/github/workspace/analysis.jsonl", index=False, orient="records", lines=True
     )
     logger.info("Wrote analysis to file")
+
     output_file = os.getenv("GITHUB_OUTPUT", file_path / "output.txt")
     open(output_file, "w").write(f"analysis={file_path}/context/analysis.jsonl")
+    logger.info(f"Output file written to {output_file}")
 
 
 if __name__ == "__main__":

--- a/actions/flakeguard-ai-analysis/src/utils.py
+++ b/actions/flakeguard-ai-analysis/src/utils.py
@@ -1,9 +1,13 @@
 import json
+import logging
 from pathlib import Path
 
 import dspy
 import pandas as pd
 import requests
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 def get_repo_file(
@@ -15,6 +19,7 @@ def get_repo_file(
     raw_url = (
         f"https://raw.githubusercontent.com/{username}/{repo}/{branch}/{file_path}"
     )
+    logger.info(f"Getting file at {raw_url}")
 
     response = requests.get(raw_url)
     response.raise_for_status()
@@ -27,6 +32,7 @@ def init() -> None:
 
 
 def read_results_file(file: Path) -> pd.DataFrame:
+    logger.info(f"Reading results file at {file}")
     data = json.loads(file.read_text())
     results = data.get("results", [])
     return pd.DataFrame(results)


### PR DESCRIPTION
successful run with this update:
https://github.com/smartcontractkit/chainlink/actions/runs/14091172597/job/39469043542

added a `FILE_PATH` value that we can override in case we do end up changing the runner in the future at some point.

when an artifact is downloaded via `actions/download-artifact@v4` it actually is a folder with the file inside of it. handling this correctly in python now. add `REPORT_FILE_NAME` in case it changes in the future.

also added a bunch of logging.