### PR TITLE
Use GATI within the reusable workflow to get around secret limitations

### DIFF
--- a/.changeset/funny-students-thank.md
+++ b/.changeset/funny-students-thank.md
@@ -1,0 +1,5 @@
+---
+"build-push-docker": minor
+---
+
+Use GATI within the reusable workflow to get around secret limitations

--- a/.github/workflows/reusable-docker-build-publish.yml
+++ b/.github/workflows/reusable-docker-build-publish.yml
@@ -38,7 +38,8 @@ name: Reusable Docker Build and Publish
 #         # GITHUB_TOKEN_GATI: <GATI step token output>
 #         AWS_ACCOUNT_ID: $\{{ secrets.AWS_ACCOUNT_ID }}
 #         AWS_REGION: $\{{ secrets.AWS_REGION }} # Remove the "\" escape character.
-#         AWS_ROLE_ARN: $\{{ secrets.AWS_ROLE_ARN }} # Remove the "\" escape character.
+#         AWS_ROLE_PUBLISH_ARN: $\{{ secrets.AWS_ROLE_PUBLISH_ARN }} # Remove the "\" escape character.
+#         AWS_ROLE_GATI_ARN: $\{{ secrets.AWS_ROLE_GATI_ARN }} # Remove the "\" escape character.
 ##
 on:
   workflow_call:
@@ -49,12 +50,14 @@ on:
       AWS_REGION:
         description: "AWS region for AWS ECR."
         required: true
-      AWS_ROLE_ARN:
+      AWS_ROLE_PUBLISH_ARN:
         description: "AWS OIDC role ARN used for publishing to AWS ECR."
         required: true
-      GITHUB_TOKEN_GATI:
-        description:
-          "GitHub token for accessing private repositories from e.g. GATI."
+      AWS_ROLE_GATI_ARN:
+        description: "AWS OIDC role ARN used for getting token from GATI."
+        required: false
+      AWS_LAMBDA_GATI_URL:
+        description: "AWS Lambda URL for GATI."
         required: false
     inputs:
       aws-ecr-name:
@@ -236,6 +239,7 @@ jobs:
             pr_number=$(echo "${GITHUB_REF_NAME}" | cut -d'/' -f1)
             echo "pr-number=${pr_number}" | tee -a "${GITHUB_OUTPUT}"
           fi
+
   build-publish:
     name: build-publish-${{ matrix.arch }}
     needs: init
@@ -313,11 +317,20 @@ jobs:
           # job (without the arch suffix).
           echo "docker-manifest-tag=${tag_value}" | tee -a "${GITHUB_OUTPUT}"
 
+      - name: Setup GitHub token using GATI
+        id: token
+        uses: smartcontractkit/.github/actions/setup-github-token@9fc306ac63d8997c9ca0da283e56caaf71589f83 # setup-github-token/1.0.0
+        with:
+          aws-role-arn: ${{ secrets.AWS_ROLE_GATI_ARN }}
+          aws-lambda-url: ${{ secrets.AWS_LAMBDA_GATI_URL }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-role-duration-seconds: "1800"
+
       - name: Debug token output
         shell: bash
         if: always()
         run: |
-          echo "Token exists: ${{ secrets.GITHUB_TOKEN_GATI != '' }}"
+          echo "Token exists: ${{ steps.token.outputs.access-token != '' }}"
 
       - name: Docker image build
         id: build
@@ -339,8 +352,9 @@ jobs:
           docker-build-args: ${{ inputs.docker-build-args }}
           context: ${{ inputs.docker-build-context }}
           aws-account-number: ${{ secrets.AWS_ACCOUNT_ID }}
-          aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
+          aws-role-arn: ${{ secrets.AWS_ROLE_PUBLISH_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}
+          github-token: ${{ steps.token.outputs.access-token || '' }}
 
   docker-manifest:
     name: docker-manifest

--- a/.github/workflows/reusable-docker-build-publish.yml
+++ b/.github/workflows/reusable-docker-build-publish.yml
@@ -33,6 +33,9 @@ name: Reusable Docker Build and Publish
 #         github-event-name: $\{{ github.event_name }}
 #         github-ref-name: $\{{ github.ref_name }}
 #       secrets:
+#         # GITHUB_TOKEN_GATI is optional and only needed if we need the Dockerfile
+#         # to mount it to build the image while fetching with a private GitHub repo.
+#         # GITHUB_TOKEN_GATI: <GATI step token output>
 #         AWS_ACCOUNT_ID: $\{{ secrets.AWS_ACCOUNT_ID }}
 #         AWS_REGION: $\{{ secrets.AWS_REGION }} # Remove the "\" escape character.
 #         AWS_ROLE_ARN: $\{{ secrets.AWS_ROLE_ARN }} # Remove the "\" escape character.
@@ -49,6 +52,10 @@ on:
       AWS_ROLE_ARN:
         description: "AWS OIDC role ARN used for publishing to AWS ECR."
         required: true
+      GITHUB_TOKEN_GATI:
+        description:
+          "GitHub token for accessing private repositories from e.g. GATI."
+        required: false
     inputs:
       aws-ecr-name:
         description: |
@@ -154,11 +161,6 @@ on:
         # NOTE: This runner is not yet available on non-public repos.
         # Will require an override for private/internal repos.
         default: "ubuntu-24.04-arm"
-      github-token:
-        description: "GitHub token for accessing private repositories"
-        required: false
-        type: string
-        default: ""
       github-workflow-repository:
         description: |
           The repository name of the workflow that triggered the workflow run.
@@ -330,7 +332,7 @@ jobs:
           dockerfile: ${{ inputs.dockerfile }}
           docker-build-args: ${{ inputs.docker-build-args }}
           context: ${{ inputs.docker-build-context }}
-          github-token: ${{ inputs.github-token }}
+          github-token: ${{ secrets.GITHUB_TOKEN_GATI }}
           aws-account-number: ${{ secrets.AWS_ACCOUNT_ID }}
           aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/reusable-docker-build-publish.yml
+++ b/.github/workflows/reusable-docker-build-publish.yml
@@ -335,7 +335,7 @@ jobs:
       - name: Setup GitHub token using GATI
         if: steps.check-gati.outputs.use-gati == 'true'
         id: token
-        uses: smartcontractkit/.github/actions/setup-github-token@9fc306ac63d8997c9ca0da283e56caaf71589f83 # setup-github-token/1.0.0
+        uses: smartcontractkit/.github/actions/setup-github-token@setup-github-token/1.0.0
         with:
           aws-role-arn: ${{ secrets.AWS_ROLE_GATI_ARN }}
           aws-lambda-url: ${{ secrets.AWS_LAMBDA_GATI_URL }}
@@ -350,7 +350,7 @@ jobs:
 
       - name: Docker image build
         id: build
-        uses: smartcontractkit/.github/actions/build-push-docker@re-3577/docker-reusable-workflow-github-token-secret # TODO
+        uses: smartcontractkit/.github/actions/build-push-docker@build-push-docker/0.5.0
         with:
           platform: ${{ format('linux/{0}', matrix.arch) }}
           docker-registry-url: >-
@@ -382,7 +382,7 @@ jobs:
       name: ${{ steps.docker-manifest.outputs.manifest-name }}
       tag: ${{ steps.docker-manifest.outputs.manifest-tag }}
     steps:
-      - uses: smartcontractkit/.github/actions/build-push-docker-manifest@c147b5676b87e06c34f175c5537bc06901df085c # build-push-docker-manifest@0.2.0
+      - uses: smartcontractkit/.github/actions/build-push-docker-manifest@build-push-docker-manifest/0.2.0
         id: docker-manifest
         with:
           # Avoid using `github.workflow_ref` here because the `cosign sign`

--- a/.github/workflows/reusable-docker-build-publish.yml
+++ b/.github/workflows/reusable-docker-build-publish.yml
@@ -33,13 +33,11 @@ name: Reusable Docker Build and Publish
 #         github-event-name: $\{{ github.event_name }}
 #         github-ref-name: $\{{ github.ref_name }}
 #       secrets:
-#         # GITHUB_TOKEN_GATI is optional and only needed if we need the Dockerfile
-#         # to mount it to build the image while fetching with a private GitHub repo.
-#         # GITHUB_TOKEN_GATI: <GATI step token output>
 #         AWS_ACCOUNT_ID: $\{{ secrets.AWS_ACCOUNT_ID }}
 #         AWS_REGION: $\{{ secrets.AWS_REGION }} # Remove the "\" escape character.
 #         AWS_ROLE_PUBLISH_ARN: $\{{ secrets.AWS_ROLE_PUBLISH_ARN }} # Remove the "\" escape character.
 #         AWS_ROLE_GATI_ARN: $\{{ secrets.AWS_ROLE_GATI_ARN }} # Remove the "\" escape character.
+#         AWS_LAMBDA_GATI_URL: $\{{ secrets.AWS_LAMBDA_GATI_URL }} # Remove the "\" escape character.
 ##
 on:
   workflow_call:
@@ -54,7 +52,12 @@ on:
         description: "AWS OIDC role ARN used for publishing to AWS ECR."
         required: true
       AWS_ROLE_GATI_ARN:
-        description: "AWS OIDC role ARN used for getting token from GATI."
+        description: |
+          AWS OIDC role ARN used for getting token from GATI.
+
+          Use this and AWS_LAMBDA_GATI_URL if building a Docker image with private GitHub repo dependencies.
+
+          The token will be mounted as a secret within the Docker build context.
         required: false
       AWS_LAMBDA_GATI_URL:
         description: "AWS Lambda URL for GATI."
@@ -317,7 +320,20 @@ jobs:
           # job (without the arch suffix).
           echo "docker-manifest-tag=${tag_value}" | tee -a "${GITHUB_OUTPUT}"
 
+      - name: Check for GATI
+        id: check-gati
+        env:
+          AWS_ROLE_GATI_ARN: ${{ secrets.AWS_ROLE_GATI_ARN }}
+          AWS_LAMBDA_GATI_URL: ${{ secrets.AWS_LAMBDA_GATI_URL }}
+        run: |
+          if [[ -n "${AWS_ROLE_GATI_ARN}" && -n "${AWS_LAMBDA_GATI_URL}" ]]; then
+            echo "use-gati=true" | tee -a "${GITHUB_OUTPUT}"
+          else
+            echo "Skipping GATI because secrets.AWS_ROLE_GATI_ARN and/or secrets.AWS_LAMBDA_GATI_URL is not set."
+          fi
+
       - name: Setup GitHub token using GATI
+        if: steps.check-gati.outputs.use-gati == 'true'
         id: token
         uses: smartcontractkit/.github/actions/setup-github-token@9fc306ac63d8997c9ca0da283e56caaf71589f83 # setup-github-token/1.0.0
         with:
@@ -395,5 +411,5 @@ jobs:
             }}
           github-workflow-repository: ${{ inputs.github-workflow-repository }}
           aws-account-number: ${{ secrets.AWS_ACCOUNT_ID }}
-          aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
+          aws-role-arn: ${{ secrets.AWS_ROLE_PUBLISH_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/reusable-docker-build-publish.yml
+++ b/.github/workflows/reusable-docker-build-publish.yml
@@ -315,7 +315,7 @@ jobs:
 
       - name: Docker image build
         id: build
-        uses: smartcontractkit/.github/actions/build-push-docker@792d6d9548a39c57b434fff34910e4c526387da3 # build-push-docker/0.4.0
+        uses: smartcontractkit/.github/actions/build-push-docker@re-3577/docker-reusable-workflow-github-token-secret # TODO
         with:
           platform: ${{ format('linux/{0}', matrix.arch) }}
           docker-registry-url: >-

--- a/.github/workflows/reusable-docker-build-publish.yml
+++ b/.github/workflows/reusable-docker-build-publish.yml
@@ -313,6 +313,12 @@ jobs:
           # job (without the arch suffix).
           echo "docker-manifest-tag=${tag_value}" | tee -a "${GITHUB_OUTPUT}"
 
+      - name: Debug token output
+        shell: bash
+        if: always()
+        run: |
+          echo "Token exists: ${{ secrets.GITHUB_TOKEN_GATI != '' }}"
+
       - name: Docker image build
         id: build
         uses: smartcontractkit/.github/actions/build-push-docker@re-3577/docker-reusable-workflow-github-token-secret # TODO

--- a/.github/workflows/reusable-docker-build-publish.yml
+++ b/.github/workflows/reusable-docker-build-publish.yml
@@ -338,7 +338,6 @@ jobs:
           dockerfile: ${{ inputs.dockerfile }}
           docker-build-args: ${{ inputs.docker-build-args }}
           context: ${{ inputs.docker-build-context }}
-          github-token: ${{ secrets.GITHUB_TOKEN_GATI }}
           aws-account-number: ${{ secrets.AWS_ACCOUNT_ID }}
           aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}

--- a/actions/build-push-docker/action.yml
+++ b/actions/build-push-docker/action.yml
@@ -48,6 +48,11 @@ inputs:
     description: "Push the docker image. Build only (no push) if: false."
     required: false
     default: "true"
+  github-token:
+    description: |
+      GitHub token mounted as a Docker secret for builds which require GitHub
+      auth (private repo deps).
+    required: false
   tags:
     required: false
     description: "Tags input for the docker metadata action"
@@ -198,7 +203,7 @@ runs:
             format('{0},scope={1}', inputs.docker-build-cache-to, runner.arch)
           }}
         secrets: |
-          GIT_AUTH_TOKEN=${{ secrets.GITHUB_TOKEN_GATI || '' }}
+          GIT_AUTH_TOKEN=${{ inputs.github-token || ''}}
 
     - name: Set outputs
       id: set-outputs

--- a/actions/build-push-docker/action.yml
+++ b/actions/build-push-docker/action.yml
@@ -79,10 +79,6 @@ inputs:
   aws-role-arn:
     description: "AWS role ARN with permissions to push ECR images."
     required: true
-  github-token:
-    description: "GitHub token for accessing private repositories"
-    required: false
-    default: ""
 
 outputs:
   docker-repository-name:
@@ -173,12 +169,6 @@ runs:
         fi
         echo "upload=${build_record_artifact_upload}" | tee -a "${GITHUB_OUTPUT}"
 
-    - name: Debug token output
-      shell: bash
-      if: always()
-      run: |
-        echo "Token exists: ${{ inputs.github-token != '' }}"
-
     - name: Build & push image
       id: build-image
       uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
@@ -208,7 +198,7 @@ runs:
             format('{0},scope={1}', inputs.docker-build-cache-to, runner.arch)
           }}
         secrets: |
-          GIT_AUTH_TOKEN=${{ inputs.github-token }}
+          GIT_AUTH_TOKEN=${{ secrets.GITHUB_TOKEN_GATI || '' }}
 
     - name: Set outputs
       id: set-outputs

--- a/actions/build-push-docker/action.yml
+++ b/actions/build-push-docker/action.yml
@@ -173,6 +173,12 @@ runs:
         fi
         echo "upload=${build_record_artifact_upload}" | tee -a "${GITHUB_OUTPUT}"
 
+    - name: Debug token output
+      shell: bash
+      if: always()
+      run: |
+        echo "Token exists: ${{ inputs.github-token != '' }}"
+
     - name: Build & push image
       id: build-image
       uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0


### PR DESCRIPTION
- **Move github-token from input to secret**
- **Add debugging for token**
- **Add more debugging for token**
- **Read secret directly instead of via input**
- **Use GATI in the reusable workflow to get token**
- **Make using GATI optional**
- **Bump tags**
- **Add changeset**
