### PR TITLE
fix: envoy proxy health check

### DIFF
--- a/.changeset/warm-bikes-shave.md
+++ b/.changeset/warm-bikes-shave.md
@@ -1,0 +1,5 @@
+---
+"setup-gap": patch
+---
+
+fix: health check for K8s API when enabled

--- a/actions/setup-gap/action.yml
+++ b/actions/setup-gap/action.yml
@@ -360,29 +360,18 @@ runs:
 
           echo "Checking if the ${name} proxy is up and running on [https://localhost:${port}]"
           for attempt in {1..10}; do
-            # Get the status code using curl
-            status_code=$(curl --silent --cacert "${PATH_CERTS_DIR}/ca.crt" \
-                          -o /dev/null -w "%{http_code}" https://localhost:${port})
-
-            echo "Attempt ${attempt}/10: Status code: ${status_code}"
-
-            if [[ $status_code -eq 200 ]]; then
-              echo "${name} proxy is up, and the HTTPS connection is successful with status code 200."
+            # Check if we can establish a connection to the proxy
+            if curl --silent --max-time 5 --cacert "${PATH_CERTS_DIR}/ca.crt" \
+                -o /dev/null https://localhost:${port}/ 2>/dev/null; then
+              echo "${name} proxy is up, TLS connection established with valid certificate!"
               return 0
-            elif [[ $status_code -ne 000 ]]; then
-              echo "WARNING: ${name} proxy returned non-200 status code: ${status_code}"
-              if [[ $attempt -eq 10 ]]; then
-                echo "::error:: ${name} proxy is responding but with unexpected status code: ${status_code}"
-                return 1
-              fi
-              sleep 3
             else
               echo "Waiting for the ${name} proxy to start... Attempt ${attempt}/10"
               sleep 3
             fi
           done
 
-          echo "Timed out waiting for the ${name} proxy to start."
+          echo "::error::Timed out waiting for the ${name} proxy to start. Connection could not be established."
           return 1
         }
 

--- a/actions/setup-gap/envoy.yaml.gotmpl
+++ b/actions/setup-gap/envoy.yaml.gotmpl
@@ -149,7 +149,7 @@ static_resources:
                       domains: ["localhost", "127.0.0.1", "localhost:{{ getenv "DYNAMIC_PROXY_PORT" }}", "127.0.0.1:{{ getenv "DYNAMIC_PROXY_PORT" }}"]
                       routes:
                         - match:
-                            prefix: /
+                            prefix: '/'
                           direct_response:
                             status: 200
                             body:
@@ -272,7 +272,7 @@ static_resources:
                       domains: [ "localhost", "127.0.0.1", "localhost:{{ getenv "WEBSOCKETS_PROXY_PORT" }}", "127.0.0.1:{{ getenv "WEBSOCKETS_PROXY_PORT" }}"]
                       routes:
                         - match:
-                            prefix: /
+                            prefix: '/'
                           direct_response:
                             status: 200
                             body:


### PR DESCRIPTION
#997 broke the setup-gap preliminary health check for the K8s listener.

Switching back to something that only cares if a connection was successful rather than relying on status codes.

### Testing

https://github.com/smartcontractkit/releng-test/actions/runs/14503557560/job/40689038832?pr=84

### Notes

I tried adding another virtual host in for the K8s listener, but it didn't work. So going back to connection successful. The existing virtual hosts for local host requests on the dynamic and websocket proxy will remain so they don't route to envoy itself.

---

DX-541