### PR TITLE
feat: setup-postgres image-tag input

### DIFF
--- a/.changeset/smooth-plants-train.md
+++ b/.changeset/smooth-plants-train.md
@@ -1,0 +1,5 @@
+---
+"setup-postgres": major
+---
+
+feat: add configurable image-tag input (note: this is a non-breaking change but wanted to bump it to 1.0.0)

--- a/actions/setup-postgres/action.yml
+++ b/actions/setup-postgres/action.yml
@@ -3,6 +3,12 @@ description:
   Setup postgres docker container via docker-compose, allowing usage of a custom
   command, see https://github.com/orgs/community/discussions/26688
 inputs:
+  image-tag:
+    description: |
+      The image tag from the dockerhub (https://hub.docker.com/_/postgres) to use as the
+      postgres image. Defaults to "14-alpine".
+    default: "14-alpine"
+
   print-logs:
     description: |
       Whether to print the logs of the postgres service to the console and a file.
@@ -39,6 +45,7 @@ runs:
       shell: bash
       working-directory: ${{ github.action_path }}
       env:
+        IMAGE_TAG: ${{ inputs.image-tag }}
         USE_TMPFS: ${{ inputs.tmpfs }}
       run: |
         if [ "${USE_TMPFS}" == "true" ]; then

--- a/actions/setup-postgres/docker-compose.yml
+++ b/actions/setup-postgres/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     ports:
       - "5432:5432"
     container_name: cl_pg
-    image: postgres:14-alpine
+    image: postgres:${IMAGE_TAG}
     command: postgres ${POSTGRES_OPTIONS}
     env_file:
       - .env


### PR DESCRIPTION
### Changes

- add `image-tag` input to `setup-postgres` action, allowing to override the previously hardcoded image.

---

RE-3523