### PR TITLE
fix: allow multiple instances of GAP

### DIFF
--- a/.changeset/shaggy-wolves-unite.md
+++ b/.changeset/shaggy-wolves-unite.md
@@ -1,0 +1,9 @@
+---
+"setup-gap": minor
+---
+
+- fix: (action) add --project parameter for docker compose commands
+- fix: (envoy config) websocket service routing with explicit port
+- fix: (authz + envoy config) host header port rewrites
+- fix: (authz) logging level environment variable name
+- feat: (authz) better header debug logging

--- a/actions/setup-gap/action.yml
+++ b/actions/setup-gap/action.yml
@@ -321,14 +321,15 @@ runs:
         PROXY_PORT: ${{ inputs.proxy-port }}
         WEBSOCKETS_PROXY_PORT: ${{ inputs.websockets-proxy-port }}
         WEBSOCKETS_SERVICES: ${{ inputs.websockets-services }}
+        ENVOY_SERVICE_NAME: ${{ inputs.gap-name }}-envoy
         AUTH_SERVICE_NAME: ${{ inputs.gap-name }}-authz
         AUTH_SERVICE_PORT: ${{ inputs.auth-service-port }}
         PATH_CERTS_DIR: ${{ env.PATH_CERTS_DIR }}
         DEBUG_MODE: ${{ steps.enable-debug.outputs.debug-mode }}
         REQUIRED_ENV_VARS: >-
-          WEBSOCKETS_PROXY_PORT DYNAMIC_PROXY_PORT PROXY_PORT
+          GAP_NAME WEBSOCKETS_PROXY_PORT DYNAMIC_PROXY_PORT PROXY_PORT
           K8S_API_ENDPOINT_PORT MAIN_DNS_ZONE ENVOY_PROXY_IMAGE PROXY_LOG_LEVEL
-          AUTH_LOG_LEVEL AUTH_SERVICE_NAME AUTH_SERVICE_PORT
+          AUTH_LOG_LEVEL ENVOY_SERVICE_NAME AUTH_SERVICE_NAME AUTH_SERVICE_PORT
           ACTIONS_ID_TOKEN_REQUEST_TOKEN ACTIONS_ID_TOKEN_REQUEST_URL
           GITHUB_REPOSITORY GITHUB_OIDC_TOKEN_HEADER_NAME GITHUB_OIDC_HOSTNAME
       run: |
@@ -374,11 +375,11 @@ runs:
 
         if [[ "$DEBUG_MODE" == "true" ]]; then
           echo "Docker compose configuration:"
-          docker compose -f "${GITHUB_ACTION_PATH}/docker-compose.yml" config
+          docker compose -p ${GAP_NAME} -f "${GITHUB_ACTION_PATH}/docker-compose.yml" config
         fi
 
         echo "Starting the auth service and Envoy proxy..."
-        docker compose -f "${GITHUB_ACTION_PATH}/docker-compose.yml" up -d
+        docker compose -p ${GAP_NAME} -f "${GITHUB_ACTION_PATH}/docker-compose.yml" up -d
 
     - name: Verify Envoy Proxy
       shell: bash

--- a/actions/setup-gap/docker-compose.yml
+++ b/actions/setup-gap/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ACTIONS_ID_TOKEN_REQUEST_URL=${ACTIONS_ID_TOKEN_REQUEST_URL}
       - ACTIONS_ID_TOKEN_REQUEST_TOKEN=${ACTIONS_ID_TOKEN_REQUEST_TOKEN}
       - GITHUB_REPOSITORY=${GITHUB_REPOSITORY}
-      - AUTH_LOG_LEVEL=${AUTH_LOG_LEVEL}
+      - LOG_LEVEL=${AUTH_LOG_LEVEL}
     healthcheck:
       test:
         [
@@ -31,7 +31,7 @@ services:
 
   envoy:
     image: ${ENVOY_PROXY_IMAGE}
-    container_name: ${GAP_NAME}
+    container_name: ${ENVOY_SERVICE_NAME}
     dns:
       - 8.8.8.8
       - 8.8.4.4

--- a/actions/setup-gap/envoy.yaml.gotmpl
+++ b/actions/setup-gap/envoy.yaml.gotmpl
@@ -129,7 +129,7 @@ static_resources:
                 route_config:
                   virtual_hosts:
                     - name: dynamic_forward_host
-                      domains: ["*.{{ getenv "MAIN_DNS_ZONE" }}"]
+                      domains: ["*.{{ getenv "MAIN_DNS_ZONE" }}", "*.{{ getenv "MAIN_DNS_ZONE" }}:{{ getenv "DYNAMIC_PROXY_PORT" }}"]
                       routes:
                         - match:
                             prefix: /
@@ -170,9 +170,7 @@ static_resources:
                               - exact: "x-repository"
                               - exact: "{{ getenv "GITHUB_OIDC_TOKEN_HEADER_NAME" }}"
                               - exact: ":authority"
-                      allowed_headers:
-                        patterns:
-                          - exact: ":authority"
+                              - exact: "host"
                       failure_mode_allow: false
                   - name: envoy.filters.http.dynamic_forward_proxy
                     typed_config:
@@ -255,7 +253,7 @@ static_resources:
                   name: local_route
                   virtual_hosts:
                     - name: gap_ws_echo
-                      domains: ["gap-ws-echo.{{ getenv "MAIN_DNS_ZONE" }}*"]
+                      domains: ["gap-ws-echo.{{ getenv "MAIN_DNS_ZONE" }}", "gap-ws-echo.{{ getenv "MAIN_DNS_ZONE" }}:{{ getenv "WEBSOCKETS_PROXY_PORT" }}"]
                       routes:
                         - match:
                             prefix: "/"
@@ -281,7 +279,7 @@ static_resources:
                     {{- $services := getenv "WEBSOCKETS_SERVICES" | strings.Split "," }}
                     {{- range $services }}
                     - name: {{ replaceAll "-" "_" . }}
-                      domains: ["{{ . }}.{{ getenv "MAIN_DNS_ZONE" }}*"]
+                      domains: ["{{ . }}.{{ getenv "MAIN_DNS_ZONE" }}", "{{ . }}.{{ getenv "MAIN_DNS_ZONE" }}:{{ getenv "WEBSOCKETS_PROXY_PORT" }}"]
                       routes:
                         - match:
                             prefix: "/"

--- a/actions/setup-gap/scripts/debug-docker-compose.sh
+++ b/actions/setup-gap/scripts/debug-docker-compose.sh
@@ -1,0 +1,27 @@
+#! /bin/bash
+export GAP_NAME="gap-name"
+export GITHUB_ACTION_PATH="."
+
+export AUTH_SERVICE_NAME="auth-service-name"
+export AUTH_SERVICE_PORT="9001"
+export AUTH_LOG_LEVEL="debug"
+
+export MAIN_DNS_ZONE="main.dns.zone"
+
+export GITHUB_OIDC_TOKEN_HEADER_NAME="github-oidc-token-header-name"
+export GITHUB_OIDC_HOSTNAME="github-oidc-hostname"
+export ACTIONS_ID_TOKEN_REQUEST_URL="actions-id-token-request-url"
+export ACTIONS_ID_TOKEN_REQUEST_TOKEN="actions-id-token-request-token"
+export GITHUB_REPOSITORY="github-repository"
+
+export ENVOY_PROXY_IMAGE="envoy-proxy-image:version"
+export ENVOY_SERVICE_NAME="envoy-service-name"
+export ENVOY_EXTRA_ARGS="--extra-args"
+export PROXY_LOG_LEVEL="debug"
+
+export DYNAMIC_PROXY_PORT="443"
+export PROXY_PORT="8080"
+export WEBSOCKETS_PROXY_PORT="9443"
+export PATH_CERTS_DIR="/path/to/certs"
+
+docker compose config

--- a/actions/setup-gap/scripts/debug-render-template.sh
+++ b/actions/setup-gap/scripts/debug-render-template.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+export MAIN_DNS_ZONE="main.dns.zone"
+export GITHUB_OIDC_TOKEN_HEADER_NAME="github-oidc-token-header-name"
+export PROXY_PORT="8080"
+export K8S_API_ENDPOINT_PORT="6443"
+export DYNAMIC_PROXY_PORT="443"
+export AUTH_SERVICE_NAME="auth-service-name"
+export AUTH_SERVICE_PORT="9001"
+export WEBSOCKETS_SERVICES="websocket-service-1,websocket-service-2"
+export WEBSOCKETS_PROXY_PORT="9443"
+
+gomplate -V -f envoy.yaml.gotmpl -o envoy-debug.yaml


### PR DESCRIPTION
### Changes

- fix: (action) add --project parameter for docker compose commands
	- 	this should allow for multiple GAPs to be `up`'d
- fix: (envoy config) websocket service routing with explicit port
	- this constrains the domain from any suffix, to a specific port suffix only
- fix: (authz + envoy config) host header port rewrites
	- Now properly rewrites the host header to ensure a 443 port, which is what the upstream LBs are listening on. This only affected GAPs with non-standard ports
- fix: (authz) logging level environment variable name
	- Fixes enabling debug logs for the authz service 
- feat: (authz) better header debug logging
	- more and better logging for  	


### Testing

- Test for `setup-gap/4.2.1`: https://github.com/smartcontractkit/releng-test/actions/runs/14542299406/job/40802438956
- Test for this change: https://github.com/smartcontractkit/releng-test/actions/runs/14599941907

---

DX-541
