### PR TITLE
Disabling connection timeouts on the local proxy side

### DIFF
--- a/.changeset/fast-plums-notice.md
+++ b/.changeset/fast-plums-notice.md
@@ -1,0 +1,5 @@
+---
+"setup-gap": patch
+---
+
+Disabling connection timeouts on the local proxy side

--- a/actions/setup-gap/envoy.yaml.gotmpl
+++ b/actions/setup-gap/envoy.yaml.gotmpl
@@ -271,6 +271,7 @@ static_resources:
                             prefix: "/"
                           route:
                             cluster: gap_ws_echo
+                            timeout: 0s
                             retry_policy:
                               retry_on: connect-failure,refused-stream,gateway-error,deadline-exceeded,unavailable,internal,reset
                               num_retries: 5
@@ -303,6 +304,7 @@ static_resources:
                             prefix: "/"
                           route:
                             cluster: {{ replaceAll "-" "_" . }}
+                            timeout: 0s
                             retry_policy:
                               retry_on: connect-failure,refused-stream,gateway-error,deadline-exceeded,unavailable,internal,reset
                               num_retries: 5

--- a/actions/setup-gap/envoy.yaml.gotmpl
+++ b/actions/setup-gap/envoy.yaml.gotmpl
@@ -442,7 +442,16 @@ static_resources:
       {{- range $services }}
       # Cluster for WebSocket {{ . }} service
     - name: {{ replaceAll "-" "_" . }}
-      connect_timeout: 5s
+      connect_timeout: 10s
+      common_http_protocol_options:
+        idle_timeout: 0
+        max_connection_duration: 0
+      circuit_breakers:
+        thresholds:
+          - max_connections: 1000
+            max_pending_requests: 1000
+            max_requests: 1000
+            max_retries: 1000
       type: LOGICAL_DNS
       dns_lookup_family: V4_ONLY
       lb_policy: ROUND_ROBIN

--- a/actions/setup-gap/envoy.yaml.gotmpl
+++ b/actions/setup-gap/envoy.yaml.gotmpl
@@ -491,10 +491,10 @@ static_resources:
         max_connection_duration: 0
       circuit_breakers:
         thresholds:
-          - max_connections: 1000
-            max_pending_requests: 1000
-            max_requests: 1000
-            max_retries: 1000
+          max_connections: 1000
+          max_pending_requests: 1000
+          max_requests: 1000
+          max_retries: 1000
       type: LOGICAL_DNS
       dns_lookup_family: V4_ONLY
       lb_policy: ROUND_ROBIN


### PR DESCRIPTION

I'd like to ensure that we don't have any timeout issues related to terminating connections.