### PR TITLE
Add aptos support e2e to ctf run test action

### DIFF
--- a/actions/ctf-run-tests/action.yml
+++ b/actions/ctf-run-tests/action.yml
@@ -222,6 +222,14 @@ inputs:
   gauntlet_plus_plus_image:
     required: false
     description: Gauntlet-plus-plus image link
+  install_plugins_public:
+    required: false
+    default: "false"
+    description: "Set to true to install the public LOOP plugins"
+  aptos_cli_version:
+    required: false
+    default: ""
+    description: "Set to an Aptos CLI version to install (e.g. 7.2.0, latest)"
 
 runs:
   using: composite
@@ -229,7 +237,7 @@ runs:
     # Setup Tools and libraries
     - name: Setup environment
       if: inputs.run_setup == 'true'
-      uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@ctf-setup-run-tests-environment/0.6.0 # ctf-setup-run-tests-environment@v0.6.0
+      uses: smartcontractkit/.github/actions/ctf-setup-run-tests-environment@ctf-setup-run-tests-environment@0e45310c4e5f3f270599b82e9c608ebc4a7dd330 # ctf-setup-run-tests-environment@v0.6.0
       with:
         test_download_vendor_packages_command:
           ${{ inputs.test_download_vendor_packages_command }}
@@ -254,6 +262,8 @@ runs:
         k8s-cluster-name: ${{ inputs.k8s-cluster-name }}
         enable-gap: ${{ inputs.enable-gap }}
         enable-proxy-debug: ${{ inputs.enable-proxy-debug }}
+        install_plugins_public: ${{ inputs.install_plugins_public }}
+        aptos_cli_version: ${{ inputs.aptos_cli_version }}
 
     - name: Replace chainlink/integration-tests deps
       if: ${{ inputs.dep_chainlink_integration_tests }}


### PR DESCRIPTION
This pull request updates the `action.yml` file for the `ctf-run-tests` GitHub Action by introducing new input parameters and updating a referenced action version. These changes enhance configurability and ensure compatibility with the latest dependencies.

### Additions to input parameters:
* Added `install_plugins_public` input to optionally install public LOOP plugins. It defaults to `"false"`.
* Added `aptos_cli_version` input to specify an Aptos CLI version for installation (e.g., `7.2.0` or `latest`). It defaults to an empty string.

### Updates to action configuration:
* Updated the `ctf-setup-run-tests-environment` action version to a specific commit hash (`0e45310c4e5f3f270599b82e9c608ebc4a7dd330`) for improved stability.
* Incorporated the new inputs `install_plugins_public` and `aptos_cli_version` into the `runs` section to pass them to the setup environment step.