### PR TITLE
fix: get-pr-labels incompatible events

### DIFF
--- a/.changeset/empty-needles-tap.md
+++ b/.changeset/empty-needles-tap.md
@@ -1,0 +1,5 @@
+---
+"get-pr-labels": minor
+---
+
+fix: don't error on non pull_request or merge_group events

--- a/actions/get-pr-labels/README.md
+++ b/actions/get-pr-labels/README.md
@@ -1,7 +1,7 @@
 # Get PR Labels
 
 Will get the labels on a PR, for a `pull_request` event or a `merge_group`
-event.
+event. All other events will return nothing.
 
 ## Inputs
 

--- a/actions/get-pr-labels/action.yml
+++ b/actions/get-pr-labels/action.yml
@@ -65,16 +65,25 @@ runs:
   using: composite
   steps:
     - name: Validate Inputs
+      id: inputs
       shell: bash
       env:
         GITHUB_EVENT_NAME: ${{ github.event_name }}
         CHECK_TYPE: ${{ inputs.check-type }}
+        SKIP_MERGE_GROUP: ${{ inputs.skip-merge-group }}
       run: |
         echo "::group::Validate event type"
         if [[ "${GITHUB_EVENT_NAME}" != 'merge_group' ]] && [[ "${GITHUB_EVENT_NAME}" != 'pull_request' ]]; then
-          echo ":error::This action only works with merge_group and pull_request events. Not ${GITHUB_EVENT_NAME}."
-          exit 1
+          echo "Not running for event type: ${GITHUB_EVENT_NAME}"
+          echo "should-run=false" | tee -a $GITHUB_OUTPUT
+        elif [[ "${GITHUB_EVENT_NAME}" == 'merge_group' ]] && [[ "${SKIP_MERGE_GROUP}" == 'true' ]]; then
+          echo "Skipping merge group event"
+          echo "should-run=false" | tee -a $GITHUB_OUTPUT
+        else
+          echo "Running for event type: ${GITHUB_EVENT_NAME}"
+          echo "should-run=true" | tee -a $GITHUB_OUTPUT
         fi
+
         echo "::endgroup::"
 
         echo "::group::Validate Check Type"
@@ -85,9 +94,7 @@ runs:
         echo "::endgroup::"
 
     - name: Get PR number
-      if:
-        ${{ github.event_name != 'merge_group' || inputs.skip-merge-group ==
-        'false' }}
+      if: ${{ steps.inputs.outputs.should-run == 'true' }}
       id: get-pr-number
       shell: bash
       env:
@@ -121,9 +128,7 @@ runs:
         exit 1
 
     - name: Get PR Labels
-      if:
-        ${{ github.event_name != 'merge_group' || inputs.skip-merge-group ==
-        'false' }}
+      if: ${{ steps.inputs.outputs.should-run == 'true' }}
       id: get-pr-labels
       shell: bash
       env:
@@ -155,8 +160,8 @@ runs:
     - name: Check for label
       id: check-label
       if:
-        ${{ inputs.check-label != '' && (github.event_name != 'merge_group' ||
-        inputs.skip-merge-group == 'false') }}
+        ${{ inputs.check-label != '' && steps.inputs.outputs.should-run ==
+        'true' }}
       shell: bash
       env:
         EXISTS_API_LABELS: >-


### PR DESCRIPTION
### Changes

Dont error for non PR or MQ events.

### Motivation

https://github.com/smartcontractkit/chainlink/actions/runs/15286494615/job/42997746992

### Testing

https://github.com/smartcontractkit/releng-test/actions/runs/15286692666?pr=96
