### PR TITLE
feat: optionally setup db for ctf env

### DIFF
--- a/.changeset/clever-mails-hear.md
+++ b/.changeset/clever-mails-hear.md
@@ -1,0 +1,5 @@
+---
+"ctf-setup-run-tests-environment": minor
+---
+
+feat: add setup_db parameter, to setup the pg database

--- a/actions/ctf-setup-run-tests-environment/action.yml
+++ b/actions/ctf-setup-run-tests-environment/action.yml
@@ -104,6 +104,15 @@ inputs:
     required: false
     default: ""
     description: "Set to an Aptos CLI version to install (e.g. 7.2.0, latest)"
+  setup_db:
+    required: false
+    default: "false"
+    description: "Set to true to setup the database for the tests"
+
+outputs:
+  database_url:
+    description: The database URL for the tests
+    value: ${{ steps.setup-pg.outputs.database_url }}
 
 runs:
   using: composite
@@ -120,6 +129,7 @@ runs:
           echo "Error: k8s-cluster-name is required when enable-gap is true."
           exit 1
         fi
+
     # Go setup and caching
     - name: Setup Go
       if: inputs.go_necessary == 'true'
@@ -134,6 +144,21 @@ runs:
         test_download_vendor_packages_command:
           ${{ inputs.test_download_vendor_packages_command }}
         gati_token: ${{ inputs.gati_token }}
+
+    - name: Setup postgres container
+      id: setup-pg
+      if: inputs.setup_db == 'true'
+      uses: smartcontractkit/.github/actions/setup-postgres@setup-postgres/v1
+      with:
+        tmpfs: true
+
+    - name: Setup database
+      if: inputs.setup_db == 'true'
+      shell: bash
+      env:
+        CL_DATABASE_URL: ${{ steps.pg-setup.outputs.database_url }}
+      run: |
+        go run . local db preparetest
 
     - name: Setup gauntlet plus plus
       if: inputs.gauntlet_plus_plus_image

--- a/actions/ctf-setup-run-tests-environment/action.yml
+++ b/actions/ctf-setup-run-tests-environment/action.yml
@@ -158,7 +158,7 @@ runs:
       env:
         CL_DATABASE_URL: ${{ steps.setup-pg.outputs.database-url }}
       run: |
-        go run . local db preparetest
+        go run ./core/store/cmd/preparetest
 
     - name: Setup gauntlet plus plus
       if: inputs.gauntlet_plus_plus_image

--- a/actions/ctf-setup-run-tests-environment/action.yml
+++ b/actions/ctf-setup-run-tests-environment/action.yml
@@ -112,7 +112,7 @@ inputs:
 outputs:
   database_url:
     description: The database URL for the tests
-    value: ${{ steps.setup-pg.outputs.database_url }}
+    value: ${{ steps.setup-pg.outputs.database-url }}
 
 runs:
   using: composite
@@ -156,7 +156,7 @@ runs:
       if: inputs.setup_db == 'true'
       shell: bash
       env:
-        CL_DATABASE_URL: ${{ steps.pg-setup.outputs.database_url }}
+        CL_DATABASE_URL: ${{ steps.setup-pg.outputs.database-url }}
       run: |
         go run . local db preparetest
 


### PR DESCRIPTION
### Changes

- Add the `setup_db` parameter to the `ctf-setup-run-tests-environment` action, add steps to setup the DB when enabled.
- Use newer command to setup db that doesnt have to build the whole cl binary

### Motivation

`run-in-memory-tests` job (from `run-e2e-test` reusable workflow) is setting up the DB at the job level - https://github.com/smartcontractkit/.github/blob/4962346cc5ffc9f3840f48639e7b5fa179bcc2cc/.github/workflows/run-e2e-tests.yml#L1255-L1294

This creates issues because in `ctf-setup-run-tests-environment` action we are setting up go and properly restoring from the mod/build cache. This should significantly improve the time it takes to build the binary and set up the db

This also uses the `setup-postgres` reusable action now, which has `tmpfs` option which should improve database speeds.

### Testing

See: https://github.com/smartcontractkit/chainlink/pull/17943

### Notes

This is the first of 3 PRs.

1. This action
2. Update `ctf-run-tests` action (#1061)
3. Update `run-e2e-tests` reusable workflow (#1062)

---

DX-931