### PR TITLE
feat: run-e2e-tests optionally setup db

### DIFF
--- a/.changeset/clever-mails-hear.md
+++ b/.changeset/clever-mails-hear.md
@@ -1,0 +1,5 @@
+---
+"ctf-setup-run-tests-environment": minor
+---
+
+feat: add setup_db parameter, to setup the pg database

--- a/.changeset/clever-mails-hear.md
+++ b/.changeset/clever-mails-hear.md
@@ -1,5 +1,0 @@
----
-"ctf-setup-run-tests-environment": minor
----
-
-feat: add setup_db parameter, to setup the pg database

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -838,7 +838,7 @@ jobs:
       - name: Run tests
         id: run_tests
         timeout-minutes: ${{ fromJson(env.DOCKER_TESTS_TIMEOUT_MINUTES) }}
-        uses: smartcontractkit/.github/actions/ctf-run-tests@feat/speed-up-in-memory-tests-run-tests
+        uses: smartcontractkit/.github/actions/ctf-run-tests@ctf-run-tests/0.8.0
         env:
           DETACH_RUNNER: true
           E2E_TEST_CHAINLINK_VERSION:
@@ -1156,7 +1156,7 @@ jobs:
 
       - name: Run tests
         id: run_tests
-        uses: smartcontractkit/.github/actions/ctf-run-tests@feat/speed-up-in-memory-tests-run-tests
+        uses: smartcontractkit/.github/actions/ctf-run-tests@ctf-run-tests/0.8.0
         env:
           DETACH_RUNNER: true
           RR_MEM: ${{ matrix.tests.remote_runner_memory }}
@@ -1283,7 +1283,7 @@ jobs:
 
       - name: Run tests
         id: run_tests
-        uses: smartcontractkit/.github/actions/ctf-run-tests@feat/speed-up-in-memory-tests-run-tests
+        uses: smartcontractkit/.github/actions/ctf-run-tests@ctf-run-tests/0.8.0
         with:
           flakeguard_enable: ${{ env.FLAKEGUARD_ENABLE }}
           flakeguard_run_count: ${{ env.FLAKEGUARD_RUN_COUNT }}

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -838,7 +838,7 @@ jobs:
       - name: Run tests
         id: run_tests
         timeout-minutes: ${{ fromJson(env.DOCKER_TESTS_TIMEOUT_MINUTES) }}
-        uses: smartcontractkit/.github/actions/ctf-run-tests@30b46ee5e5a5be9ae091fda296bbef605df01afd # ctf-run-tests@v0.6.2
+        uses: smartcontractkit/.github/actions/ctf-run-tests@feat/speed-up-in-memory-tests-run-tests
         env:
           DETACH_RUNNER: true
           E2E_TEST_CHAINLINK_VERSION:
@@ -1156,7 +1156,7 @@ jobs:
 
       - name: Run tests
         id: run_tests
-        uses: smartcontractkit/.github/actions/ctf-run-tests@30b46ee5e5a5be9ae091fda296bbef605df01afd # ctf-run-tests@v0.6.2
+        uses: smartcontractkit/.github/actions/ctf-run-tests@feat/speed-up-in-memory-tests-run-tests
         env:
           DETACH_RUNNER: true
           RR_MEM: ${{ matrix.tests.remote_runner_memory }}

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -447,7 +447,7 @@ jobs:
         with:
           go-version: "1.24.0"
           check-latest: true
-          cache: false # disable caching as this job benefit from it
+          cache: false # disable caching as this job doesn't benefit from it
 
       - name: Install citool
         shell: bash

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -277,7 +277,6 @@ env:
   TEST_LOG_LEVEL: ${{ inputs.test_log_level }}
   METRICS_COLLECTION_ID: chainlink-e2e-tests
   SLACK_API_KEY: ${{ secrets.SLACK_API_KEY }}
-  DB_URL: postgresql://postgres:postgres@localhost:5432/chainlink_test?sslmode=disable
   CHAINLINK_USER_TEAM: ${{ inputs.team }}
   E2E_JD_IMAGE:
     ${{ secrets.PROD_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{
@@ -1252,17 +1251,6 @@ jobs:
       ${{ needs.load-test-configurations.outputs.run-in-memory-tests == 'true'
       && always() && !failure() && !cancelled() }}
     needs: load-test-configurations
-    services:
-      postgres:
-        image: postgres:14-alpine
-        ports:
-          - 5432:5432
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-        options: >-
-          --health-cmd pg_isready  --health-interval 2s  --health-timeout 5s
-          --health-retries 5
     # Run when none of the needed jobs fail or are cancelled (skipped or successful jobs are ok)
     runs-on: ${{ matrix.tests.runs_on }}
     strategy:
@@ -1282,16 +1270,7 @@ jobs:
         uses: actions/checkout@v4.2.1
         with:
           persist-credentials: false
-      - name: Wait for postgres to be ready
-        run: |
-          until pg_isready -h localhost -p 5432 -U postgres; do
-            echo "Waiting for postgres to be ready..."
-            sleep 1
-          done
-      - name: Setup DB
-        run: go run . local db preparetest
-        env:
-          CL_DATABASE_URL: ${{  env.DB_URL }}
+
       - name: Set dynamic env vars for tests
         shell: bash
         run: |
@@ -1307,11 +1286,10 @@ jobs:
               echo "$key=$value" >> "$GITHUB_ENV"
             done
           fi
+
       - name: Run tests
         id: run_tests
-        uses: smartcontractkit/.github/actions/ctf-run-tests@e01e0004fd0c96c55adc8c421c4e867c781487bc # ctf-run-tests@v0.6.2
-        env:
-          CL_DATABASE_URL: ${{ env.DB_URL }}
+        uses: smartcontractkit/.github/actions/ctf-run-tests@feat/speed-up-in-memory-tests-run-tests
         with:
           flakeguard_enable: ${{ env.FLAKEGUARD_ENABLE }}
           flakeguard_run_count: ${{ env.FLAKEGUARD_RUN_COUNT }}
@@ -1343,6 +1321,7 @@ jobs:
           enable-gap: false
           install_plugins_public: ${{ matrix.tests.install_plugins_public }}
           aptos_cli_version: ${{ matrix.tests.aptos_cli_version }}
+          setup_db: "true"
 
   after_tests:
     needs:

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -444,15 +444,19 @@ jobs:
         uses: actions/checkout@v4.2.1
         with:
           persist-credentials: false
+
       - name: Setup Go
         uses: actions/setup-go@v5.0.2
         with:
           go-version: "1.24.0"
           check-latest: true
+          cache: false
+
       - name: Install citool
         shell: bash
         run: go install
           github.com/smartcontractkit/chainlink-testing-framework/tools/citool@1f6d929b4a5ffb56a89268339851fe993957d43f # v1.34.4
+
       - name: Install jq
         run: sudo apt-get install jq
 

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -345,9 +345,6 @@ jobs:
             echo "Will run tests with custom test secrets from AWS Secrets Manager. AWS Secret ID: $SECRET_ID"
           fi
 
-      - name: Install jq
-        run: sudo apt-get install jq
-
       - name: Create matrix for required Chainlink image versions
         id: set-required-chainlink-image-versions-matrix
         shell: bash
@@ -450,15 +447,12 @@ jobs:
         with:
           go-version: "1.24.0"
           check-latest: true
-          cache: false
+          cache: false # disable caching as this job benefit from it
 
       - name: Install citool
         shell: bash
         run: go install
           github.com/smartcontractkit/chainlink-testing-framework/tools/citool@1f6d929b4a5ffb56a89268339851fe993957d43f # v1.34.4
-
-      - name: Install jq
-        run: sudo apt-get install jq
 
       - name: Generate Docker Tests Matrix
         id: set-docker-matrix
@@ -742,8 +736,6 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ inputs.chainlink_version }}
-      - name: Install jq
-        run: sudo apt-get install -y jq
 
       - name: Show test config override path in summary
         if: ${{ env.TEST_CONFIG_OVERRIDE_PATH }}
@@ -1113,8 +1105,6 @@ jobs:
         uses: actions/checkout@v4.2.1
         with:
           persist-credentials: false
-      - name: Install jq
-        run: sudo apt-get install -y jq
 
       - name: Show test config override path in summary
         if: ${{ env.TEST_CONFIG_OVERRIDE_PATH }}


### PR DESCRIPTION
### Changes

- Don't setup the DB at the job level for `in-memory-tests` job
  -  See related PRs: #1060, #1061 
- Don't cache `go` for `load-test-configurations` job
  - This routinely takes a very long time, not sure if it's necessary for such a simple tool like ci-tool.
  - Example: 5min setup-go step, and 5min post setup-go step - https://github.com/smartcontractkit/chainlink/actions/runs/15334488256/job/43148823751?pr=17943#step:3:31 
- Don't install jq as it comes automatically installed on runners

### Testing

See https://github.com/smartcontractkit/chainlink/pull/17943

---

DX-931 + DX-934

