### PR TITLE
Fix to work with scoped name packages

### DIFF
--- a/.changeset/yellow-files-buy.md
+++ b/.changeset/yellow-files-buy.md
@@ -1,0 +1,5 @@
+---
+"changesets-signed-commits": minor
+---
+
+Support scoped name package git tags

--- a/actions/signed-commits/dist/index.js
+++ b/actions/signed-commits/dist/index.js
@@ -60825,7 +60825,11 @@ function replaceTagSeparator(tags, separator) {
     return tags;
   }
   return tags.map((tag) => {
-    const newTagName = tag.name.replace("@", separator);
+    const lastAtIndex = tag.name.lastIndexOf("@");
+    let newTagName = tag.name;
+    if (lastAtIndex !== -1) {
+      newTagName = tag.name.substring(0, lastAtIndex) + separator + tag.name.substring(lastAtIndex + 1);
+    }
     return {
       ...tag,
       name: newTagName,
@@ -60882,9 +60886,9 @@ function getMajorVersionTags(tags, separator, rootPackageInfo) {
   }, []);
 }
 function parseTagName(tagName, separator) {
-  const escapedSeparator = separator.replace(/[.*+?^${}()|[\]\\]/g, "\\\\$&");
+  const escapedSeparator = separator.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const tagRegex = new RegExp(
-    `^([a-z0-9-]+)${escapedSeparator}(\\d+)\\.(\\d+)\\.(\\d+)`
+    `^((?:@[a-zA-Z0-9-]+/)?[a-zA-Z0-9-]+)${escapedSeparator}(\\d+)\\.(\\d+)\\.(\\d+)$`
   );
   const match = tagRegex.exec(tagName);
   if (!match || match.length < 5) {

--- a/actions/signed-commits/src/git/github-git/repo-tags.ts
+++ b/actions/signed-commits/src/git/github-git/repo-tags.ts
@@ -174,7 +174,10 @@ export function replaceTagSeparator(
     const lastAtIndex = tag.name.lastIndexOf("@");
     let newTagName = tag.name;
     if (lastAtIndex !== -1) {
-      newTagName = tag.name.substring(0, lastAtIndex) + separator + tag.name.substring(lastAtIndex + 1);
+      newTagName =
+        tag.name.substring(0, lastAtIndex) +
+        separator +
+        tag.name.substring(lastAtIndex + 1);
     }
     return {
       ...tag,


### PR DESCRIPTION
- Fixes tag rewrites when packages use namespaced prefixes like `@chainlink` (like `@chainlink/contracts@0.0.1`)
  - Old behaviour would rewrite this to `/vchainlink/contracts/v0.0.1` but it should only replace the last `@`