### PR TITLE
Fix filtering for branches from tag commit

### DIFF
--- a/.changeset/popular-crews-beam.md
+++ b/.changeset/popular-crews-beam.md
@@ -1,0 +1,5 @@
+---
+"guard-tag-from-branch": patch
+---
+
+Fix filtering for branches from tag commit

--- a/actions/guard-tag-from-branch/scripts/tag-branch-check.sh
+++ b/actions/guard-tag-from-branch/scripts/tag-branch-check.sh
@@ -17,17 +17,46 @@ fi
 # Get the sha of the tag's ancestor commit
 TAG_SHA=$(git rev-parse "${TAG}^{commit}")
 echo "::debug::TAG_SHA: ${TAG_SHA}"
-SOURCE_BRANCHES=$(git branch -a --contains "${TAG_SHA}" | grep -v '(detached from' | sed 's/^\* //' | awk '{print $1}')
+
+# Get branches containing the tag, with filtering for CI environments
+# Filter out: detached HEAD states, current HEAD pointer, empty lines, and whitespace-only lines
+SOURCE_BRANCHES=$(git branch -a --contains "${TAG_SHA}" | \
+    grep -v '(detached from' | \
+    grep -v '(HEAD' | \
+    grep -v '^[[:space:]]*$' | \
+    sed 's/^\* //' | \
+    sed 's/^[[:space:]]*//' | \
+    awk 'NF {print $1}')
+
 echo "::debug::SOURCE_BRANCHES: ${SOURCE_BRANCHES}"
+
+# Ensure we found at least one branch
+if [[ -z "${SOURCE_BRANCHES}" ]]; then
+    echo "::error::No valid branches found containing tag '${TAG}'. This may indicate a git repository issue."
+    exit 1
+fi
 
 MATCH_FOUND=0
 for branch in $SOURCE_BRANCHES; do
-  echo "::debug::Stripping 'remotes/origin/' from branch name '${branch}'..."
-  branch="${branch#remotes/origin/}"
-  echo "::debug::Checking if branch '${branch}' matches the pattern '${BRANCH_REGEX}'..."
-  if [[ "$branch" =~ ${BRANCH_REGEX} ]]; then
+  # Skip empty or invalid branch names
+  if [[ -z "${branch}" || "${branch}" == "(HEAD" || "${branch}" =~ ^\(.*\)$ ]]; then
+    echo "::debug::Skipping invalid branch name: '${branch}'"
+    continue
+  fi
+
+  echo "::debug::Processing branch: '${branch}'"
+
+  # Strip 'remotes/origin/' prefix if present
+  clean_branch="${branch#remotes/origin/}"
+  echo "::debug::Clean branch name: '${clean_branch}'"
+
+  echo "::debug::Checking if branch '${clean_branch}' matches the pattern '${BRANCH_REGEX}'..."
+  if [[ "${clean_branch}" =~ ${BRANCH_REGEX} ]]; then
+    echo "::debug::✓ Branch '${clean_branch}' matches pattern '${BRANCH_REGEX}'"
     MATCH_FOUND=1
     break
+  else
+    echo "::debug::✗ Branch '${clean_branch}' does not match pattern '${BRANCH_REGEX}'"
   fi
 done
 


### PR DESCRIPTION
This was failing from CI here: https://github.com/smartcontractkit/chainlink/actions/runs/15477407422/job/43576605910#step:7:94 but working locally.

CI returns `(HEAD` for the $SOURCE_BRANCHES.