### PR TITLE
[DX-1075] update action versions in solidity artifact generating pipeline

### DIFF
--- a/.github/workflows/solidity-review-artifacts.yml
+++ b/.github/workflows/solidity-review-artifacts.yml
@@ -178,7 +178,7 @@ jobs:
           done
 
       - name: Upload basic info and modified contracts list
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@v4.6.2
         timeout-minutes: 2
         continue-on-error: true
         with:
@@ -202,13 +202,13 @@ jobs:
     needs: [gather-basic-info]
     steps:
       - name: Checkout the caller repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4.2.2
         with:
           ref: ${{ env.head_ref }}
           persist-credentials: false
 
       - name: Setup NodeJS
-        uses: smartcontractkit/.github/actions/setup-nodejs@bff23e98280a3f60233e7ab2d5675a006843732c # v0.0.0
+        uses: smartcontractkit/.github/actions/setup-nodejs@0b8d877a32bfa479b62ce70c1f6d2493a7c93fed # v0.0.0
         with:
           package-json-directory: ${{ inputs.contracts_directory }}
           pnpm-version: ^10.0.0
@@ -277,7 +277,7 @@ jobs:
           FOUNDRY_PROFILE: ${{ inputs.product }}
 
       - name: Upload Artifacts for product contracts
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@v4.6.2
         timeout-minutes: 2
         continue-on-error: true
         with:
@@ -302,14 +302,14 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout caller repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
           ref: ${{ env.head_ref }}
           persist-credentials: false
 
       - name: Checkout .github repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4.2.2
         with:
           repository: smartcontractkit/.github
           ref: 65249c7eae628aad6e70a0c0850d981cd0074bf9
@@ -317,7 +317,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup NodeJS
-        uses: smartcontractkit/.github/actions/setup-nodejs@bff23e98280a3f60233e7ab2d5675a006843732c # v0.0.0
+        uses: smartcontractkit/.github/actions/setup-nodejs@0b8d877a32bfa479b62ce70c1f6d2493a7c93fed # v0.0.0
         with:
           package-json-directory: ${{ inputs.contracts_directory }}
           pnpm-version: ^10.0.0
@@ -334,7 +334,7 @@ jobs:
 
       - name: Set up Python
         if: ${{ inputs.generate_slither_reports == true }}
-        uses: actions/setup-python@v5.2.0
+        uses: actions/setup-python@v5.6.0
         with:
           python-version: "3.8"
 
@@ -396,7 +396,7 @@ jobs:
           ./dot_github/tools/scripts/solidity/generate_slither_report.sh "${{ github.server_url }}/${{ github.repository }}/blob/${{ env.head_ref }}/" "$SLITHER_CONFIG_FILE_PATH" "$CONTRACTS_DIRECTORY" "$contract_list" "${{ env.artifacts_dir }}/slither-reports" "--solc-remaps @=$CONTRACTS_DIRECTORY/node_modules/@"
 
       - name: Upload UMLs and Slither reports
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@v4.6.2
         timeout-minutes: 10
         continue-on-error: true
         with:
@@ -427,13 +427,13 @@ jobs:
     needs: [coverage-and-book, uml-static-analysis, gather-basic-info]
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4.1.8
+        uses: actions/download-artifact@v4.3.0
         with:
           path: review_artifacts
           merge-multiple: true
 
       - name: Upload all artifacts as single package
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@v4.6.2
         with:
           name:
             review-artifacts-${{ inputs.product }}-${{ inputs.base_ref }}-${{
@@ -441,7 +441,7 @@ jobs:
           path: review_artifacts
 
       - name: Remove temporary artifacts
-        uses: geekyeggo/delete-artifact@24928e75e6e6590170563b8ddae9fac674508aa1 # v5.0
+        uses: geekyeggo/delete-artifact@f275313e70c08f6120db482d7a6b98377786765b # v5.1.0
         with:
           name: tmp-*
 
@@ -469,7 +469,7 @@ jobs:
 
       - name: Checkout caller repository
         if: ${{ inputs.link_with_jira == true }}
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4.2.2
         with:
           ref: ${{ env.head_ref }}
           persist-credentials: false
@@ -485,7 +485,7 @@ jobs:
 
       - name: Setup NodeJS
         if: ${{ inputs.link_with_jira == true }}
-        uses: smartcontractkit/.github/actions/setup-nodejs@bff23e98280a3f60233e7ab2d5675a006843732c # v0.0.0
+        uses: smartcontractkit/.github/actions/setup-nodejs@0b8d877a32bfa479b62ce70c1f6d2493a7c93fed # v0.0.0
         with:
           package-json-directory: ${{ inputs.contracts_directory }}
           pnpm-version: ^10.0.0


### PR DESCRIPTION
We wanna fix this deprecated `actions/cache`  issue: https://github.com/smartcontractkit/payments/actions/runs/15608791404/job/43964518232#step:1:51
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: 0c45773b623bea8c8e75f6c82b208c3cf94ea4f9`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down
```