### PR TITLE
fix: ctf codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,7 @@
 * @smartcontractkit/devex-cicd
 
-# Chainlink Testing Framework (CTF)
-/actions/ctf-*/** @smartcontractkit/devex-tooling @smartcontractkit/devex-cicd
-.github/workflows/run-e2e-tests.yml @smartcontractkit/devex-tooling @smartcontractkit/devex-cicd
+/actions/ctf-*/** @smartcontractkit/devex-cicd
+.github/workflows/run-e2e-tests.yml @smartcontractkit/devex-cicd
 
 # CRIB
 /actions/crib-*/** @smartcontractkit/cl-orchestration


### PR DESCRIPTION
The joint ownership added in #1104 did not help. Removing tooling completely for the time being until `devex` team is added to repo.