### PR TITLE
fix: run-e2e-tests use refactored ctf-build-image

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -626,15 +626,18 @@ jobs:
           persist-credentials: false
           ref: ${{ inputs.chainlink_version }}
 
-      - name: Get Chainlink image
-        uses: ./.github/actions/build-chainlink-image
+      - name: Build Chainlink Image
+        uses: smartcontractkit/.github/actions/ctf-build-image@ctf-build-image/v1
         with:
+          image-tag: ${{ matrix.version }}
           dockerfile: core/chainlink.Dockerfile
-          git_commit_sha: ${{ matrix.version }}
-          tag_suffix: ""
-          check_image_exists: "true"
-          AWS_REGION: ${{ secrets.QA_AWS_REGION }}
-          AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
+          docker-registry-url: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com
+          docker-repository-name: "chainlink"
+          aws-account-number: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
+          aws-region: ${{ secrets.QA_AWS_REGION }}
+          aws-role-arn: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
+          gati-role-arn: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
+          gati-lambda-url: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
 
   # Check if Chainlink plugins required for the tests exist. If not, build and push the images to QA ECR
   require-chainlink-plugin-versions-in-qa-ecr:


### PR DESCRIPTION
Switch to using `ctf-build-image/v1` directly.

---

DX-1141