### PR TITLE
Support setup-nodejs inputs for alt package manager

### DIFF
--- a/.changeset/slow-ligers-sit.md
+++ b/.changeset/slow-ligers-sit.md
@@ -1,0 +1,5 @@
+---
+"cicd-changesets": minor
+---
+
+Support setup-nodejs inputs for alt package manager

--- a/actions/cicd-changesets/action.yml
+++ b/actions/cicd-changesets/action.yml
@@ -84,6 +84,15 @@ inputs:
     description: "whether to put the PR in draft mode or not"
     required: false
     default: "false"
+  package-manager:
+    description: Which package manager to use (pnpm, npm, yarn)
+    required: false
+    default: pnpm
+  install-command:
+    description:
+      The install command to run (e.g. pnpm install, npm install, yarn install)
+    required: false
+    default: pnpm install
 outputs:
   published:
     description:
@@ -139,6 +148,8 @@ runs:
         pnpm-version: ${{ inputs.pnpm-version }}
         use-cache: ${{ inputs.pnpm-use-cache }}
         run-install: "true"
+        package-manager: ${{ inputs.package-manager }}
+        install-command: ${{ inputs.install-command }}
 
     - name: Run changesets
       id: changesets


### PR DESCRIPTION
Depends on https://github.com/smartcontractkit/.github/pull/1115.