### PR TITLE
Create do-not-merge composite action

### DIFF
--- a/.changeset/cyan-clocks-care.md
+++ b/.changeset/cyan-clocks-care.md
@@ -1,0 +1,5 @@
+---
+"do-not-merge": major
+---
+
+Create do-not-merge composite action

--- a/actions/do-not-merge/README.md
+++ b/actions/do-not-merge/README.md
@@ -1,0 +1,3 @@
+# do-not-merge
+
+> Creates failing check if PR contains certain labels to prevent merging

--- a/actions/do-not-merge/action.yml
+++ b/actions/do-not-merge/action.yml
@@ -1,0 +1,22 @@
+name: do-not-merge
+description:
+  "Creates failing check if PR contains certain labels to prevent merging"
+
+inputs:
+  fail-labels:
+    description: |
+      Comma separated list of labels that will cause the action to fail.
+    required: false
+    default: "do-not-merge"
+
+runs:
+  using: composite
+  steps:
+    - name: Fail if label present
+      uses: actions/github-script@v7
+      env:
+        FAIL_LABELS: ${{ inputs.fail-labels }}
+      with:
+        script: |
+          const script = require(`${process.env.GITHUB_ACTION_PATH}/scripts/do-not-merge-block.js`);
+          await script({ context, core });

--- a/actions/do-not-merge/package.json
+++ b/actions/do-not-merge/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "do-not-merge",
+  "version": "0.0.0",
+  "description": "",
+  "private": true,
+  "scripts": {},
+  "author": "@smartcontractkit",
+  "license": "MIT",
+  "dependencies": {},
+  "repository": "https://github.com/smartcontractkit/.github"
+}

--- a/actions/do-not-merge/project.json
+++ b/actions/do-not-merge/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "do-not-merge",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "actions/do-not-merge",
+  "targets": {}
+}

--- a/actions/do-not-merge/scripts/do-not-merge-block.js
+++ b/actions/do-not-merge/scripts/do-not-merge-block.js
@@ -1,0 +1,33 @@
+/**
+ * Fails the workflow if any of the specified labels are present on the PR.
+ *
+ * Inputs (via environment):
+ *   FAIL_LABELS: comma-separated list of labels to check (default: "do-not-merge")
+ */
+
+module.exports = async ({ context, core }) => {
+  const failLabels = (process.env.FAIL_LABELS || "do-not-merge")
+    .split(",")
+    .map((l) => l.trim().toLowerCase())
+    .filter(Boolean);
+
+  const pr = context.payload.pull_request;
+  if (!pr) {
+    core.info("This action is only applicable to pull requests.");
+    return;
+  }
+
+  const prLabels = (pr.labels || []).map((l) => l.name.toLowerCase());
+  const found = failLabels.find((label) => prLabels.includes(label));
+
+  if (found) {
+    const msg = `❌ This PR has a label that blocks merging: \`${found}\`.\nPlease remove the label to proceed.`;
+    core.summary.addRaw(msg);
+    core.setFailed(msg);
+    return;
+  }
+
+  core.info(
+    `No blocking labels found. Blocking labels checked: [${failLabels.join(", ")}]`,
+  );
+};


### PR DESCRIPTION
To prevent merging with certain labels. Will creating a failing check if a PR is opened with a specified label or if a specified label is later added.