### PR TITLE
fix: ctf-build-image go dep overrides

### DIFF
--- a/.changeset/fuzzy-mugs-peel.md
+++ b/.changeset/fuzzy-mugs-peel.md
@@ -1,0 +1,5 @@
+---
+"ctf-build-image": minor
+---
+
+fix: go-get-overrides input, and script

--- a/actions/ctf-build-image/scripts/go-get-overrides.sh
+++ b/actions/ctf-build-image/scripts/go-get-overrides.sh
@@ -11,7 +11,7 @@ if ! command -v go &> /dev/null; then
 fi
 
 # Validate environment variables
-if [[ -z "${OVERRIDES}" ]]; then
+if [[ -z "${GO_OVERRIDES}" ]]; then
     echo "::info:: No go get overrides specified, skipping."
     exit 0
 fi
@@ -21,6 +21,12 @@ echo "::info:: Processing go get overrides..."
 while IFS= read -r line || [[ -n "$line" ]]; do
     # Skip empty lines
     [[ -z "$line" ]] && continue
+
+    # Check if line contains '=' character
+    if [[ "$line" != *"="* ]]; then
+        echo "::warning::Invalid format for line '$line', expected 'dependency=sha', skipping."
+        continue
+    fi
 
     # Extract dependency name and SHA
     dependency="${line%%=*}"
@@ -48,6 +54,6 @@ while IFS= read -r line || [[ -n "$line" ]]; do
         }
         echo "::info::Successfully updated ${dependency} to ${sha}"
     fi
-done <<< "$OVERRIDES"
+done <<< "$GO_OVERRIDES"
 
 echo "Go get overrides processing completed."

--- a/actions/ctf-build-image/scripts/test-go-get-overrides.sh
+++ b/actions/ctf-build-image/scripts/test-go-get-overrides.sh
@@ -8,7 +8,7 @@ export DRY_RUN=true
 
 # Test 1: Dry run with valid input
 echo "Test 1: Dry run with valid input"
-export OVERRIDES="chainlink-solana=abc123
+export GO_OVERRIDES="chainlink-solana=abc123
 atlas=def456
 chainlink-common=ghi789"
 ./go-get-overrides.sh
@@ -17,14 +17,14 @@ echo
 
 # Test 2: Empty overrides
 echo "Test 2: Empty overrides"
-export OVERRIDES=""
+export GO_OVERRIDES=""
 ./go-get-overrides.sh
 echo "Test 2 completed."
 echo
 
 # Test 3: Malformed input
 echo "Test 3: Malformed input"
-export OVERRIDES="chainlink-solana=abc123
+export GO_OVERRIDES="chainlink-solana=abc123
 atlas=
 invalid-line
 chainlink-common=ghi789"


### PR DESCRIPTION
### Changes

- Fixed mismatch between `OVERRIDES` env var and `GO_OVERRIDES` env var.
- Fixed lined validation

Related to https://github.com/smartcontractkit/chainlink-solana/pull/1283

