### PR TITLE
fix: remove test- prefix, allow for configurable ECR name

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -639,7 +639,7 @@ jobs:
         id: check-image-exists
         uses: smartcontractkit/.github/actions/ecr-image-exists@ecr-image-exists/0.0.1
         with:
-          repository: "chainlink"
+          repository: ${{ inputs.ecr_name }}
           tag: ${{ matrix.version }}
           aws-role-arn: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
 
@@ -657,7 +657,7 @@ jobs:
           image-tag: ${{ matrix.version }}
           dockerfile: core/chainlink.Dockerfile
           docker-registry-url: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com
-          docker-repository-name: "chainlink"
+          docker-repository-name: ${{ inputs.ecr_name }}
           aws-account-number: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
           aws-region: ${{ secrets.QA_AWS_REGION }}
           aws-role-arn: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -180,6 +180,14 @@ on:
         required: false
         type: string
         default: "false"
+      ecr_name:
+        description: |
+          ECR name to use for the tests. Default is 'chainlink'.
+          This will set the ECR to <aws_account_number>.dkr.ecr.<aws_region>.amazonaws.com/<ecr_name>
+          where aws_account_number and aws_region are taken from the secrets.
+        required: false
+        type: string
+        default: "chainlink"
       extraArgs:
         required: false
         type: string
@@ -256,13 +264,12 @@ on:
         required: false
 
 env:
-  CHAINLINK_IMAGE: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION
-    }}.amazonaws.com/chainlink
-  QA_CHAINLINK_IMAGE: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION
-    }}.amazonaws.com/chainlink
-  DEFAULT_CHAINLINK_VERSION: test-${{ inputs.chainlink_version }}
-  DEFAULT_CHAINLINK_PLUGINS_VERSION:
-    test-${{ inputs.chainlink_version != '' && format('{0}-plugins',
+  CHAINLINK_IMAGE: >-
+    ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/${{ inputs.ecr_name}}
+  QA_CHAINLINK_IMAGE: >-
+    ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/${{ inputs.ecr_name }}
+  DEFAULT_CHAINLINK_VERSION: ${{ inputs.chainlink_version }}
+  DEFAULT_CHAINLINK_PLUGINS_VERSION: ${{ inputs.chainlink_version != '' && format('{0}-plugins',
     inputs.chainlink_version) }}
   DEFAULT_CHAINLINK_UPGRADE_VERSION: ${{ inputs.chainlink_version }}
   CHAINLINK_ENV_USER: ${{ github.actor }}
@@ -621,7 +628,7 @@ jobs:
       contents: read
     env:
       CHAINLINK_IMAGE: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION
-        }}.amazonaws.com/chainlink
+        }}.amazonaws.com/${{ inputs.ecr_name }}
     strategy:
       matrix:
         version: ${{
@@ -671,7 +678,7 @@ jobs:
       contents: read
     env:
       CHAINLINK_IMAGE: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION
-        }}.amazonaws.com/chainlink
+        }}.amazonaws.com/${{ inputs.ecr_name }}
     strategy:
       matrix:
         version: ${{


### PR DESCRIPTION
### Changes

- Remove `test-` prefix from expected image name
- Allow for configurable ECR name

### Testing

https://github.com/smartcontractkit/chainlink/pull/18536
- https://github.com/smartcontractkit/chainlink/actions/runs/16149840932?pr=18536

### Motivation

To reduce the number of images published to SDLC /chainlink ECR, we need to add support for integration tests to use a different ECR.

---

DX-1339