### PR TITLE
feat: ctf-build-image optional push

### DIFF
--- a/.changeset/happy-tigers-knock.md
+++ b/.changeset/happy-tigers-knock.md
@@ -1,0 +1,5 @@
+---
+"ctf-build-image": patch
+---
+
+feat: optional input docker-push

--- a/actions/ctf-build-image/action.yml
+++ b/actions/ctf-build-image/action.yml
@@ -33,6 +33,13 @@ inputs:
       Defaults to the repository name.
     required: true
 
+  docker-push:
+    description: |
+      Whether to push the image to the registry.
+      If false, the image will not be pushed. Defaults to true.
+    required: false
+    default: true
+
   # AWS inputs
   aws-account-number:
     description: |
@@ -155,6 +162,7 @@ runs:
         platform: linux/amd64
 
         dockerfile: ${{ inputs.dockerfile }}
+        docker-push: ${{ inputs.docker-push }}
         docker-build-args: |
           COMMIT_SHA=${{ github.sha }}
           CHAINLINK_USER=chainlink


### PR DESCRIPTION
### Changes

A input `docker-push` to `ctf-build-image`, which is passed to https://github.com/smartcontractkit/.github/blob/4f87f696f1f7ab9419f967f8d8bf67657e06a3c2/actions/build-push-docker/action.yml#L45


