### PR TITLE
fix: apidiff-go follow-up

### DIFF
--- a/actions/apidiff-go/action.yml
+++ b/actions/apidiff-go/action.yml
@@ -23,7 +23,6 @@ inputs:
     description: "Base branch or commit to compare against"
     required: false
     default: "${{ github.event.pull_request.base.ref }}"
-
   head-ref:
     description: "Head branch or commit to compare against"
     required: false
@@ -36,9 +35,3 @@ inputs:
       incompatible changes are detected."
     required: false
     default: true
-
-outputs:
-  apidiff-result:
-    description: "The output from the apidiff tool"
-  has-changes:
-    description: "Whether API changes were detected (true/false)"

--- a/actions/apidiff-go/dist/index.js
+++ b/actions/apidiff-go/dist/index.js
@@ -31582,28 +31582,25 @@ var runInputsConfiguration = {
   }
 };
 function getRunInput(input) {
-  const config = runInputsConfiguration[input];
-  if (!config) {
-    throw new Error(`No configuration found for input: ${input}`);
-  }
-  const isLocalDebug = process.env.CL_LOCAL_DEBUG;
-  const inputKey = isLocalDebug ? config.localParameter : config.parameter;
+  const inputKey = getInputKey(input);
   return core4.getInput(inputKey, {
-    required: false
-    // todo
+    required: true
   });
 }
 function getBooleanRunInput(input) {
+  const inputKey = getInputKey(input);
+  return core4.getBooleanInput(inputKey, {
+    required: true
+  });
+}
+function getInputKey(input) {
   const config = runInputsConfiguration[input];
   if (!config) {
     throw new Error(`No configuration found for input: ${input}`);
   }
   const isLocalDebug = process.env.CL_LOCAL_DEBUG;
   const inputKey = isLocalDebug ? config.localParameter : config.parameter;
-  return core4.getBooleanInput(inputKey, {
-    required: false
-    // todo
-  });
+  return inputKey;
 }
 
 // actions/apidiff-go/src/string-processor.ts

--- a/actions/apidiff-go/dist/index.js
+++ b/actions/apidiff-go/dist/index.js
@@ -31513,7 +31513,7 @@ async function getSummaryUrl(token, owner, repo) {
       repo,
       run_id: runId
     });
-    if (data.jobs.length != 1) {
+    if (data.jobs.length !== 1) {
       core3.warning(
         `Expected exactly one job in workflow run, found ${data.jobs.length}. Cannot determine summary URL.`
       );

--- a/actions/apidiff-go/src/github.ts
+++ b/actions/apidiff-go/src/github.ts
@@ -64,7 +64,7 @@ export async function getSummaryUrl(
       run_id: runId,
     });
 
-    if (data.jobs.length != 1) {
+    if (data.jobs.length !== 1) {
       core.warning(
         `Expected exactly one job in workflow run, found ${data.jobs.length}. Cannot determine summary URL.`,
       );

--- a/actions/apidiff-go/src/run-inputs.ts
+++ b/actions/apidiff-go/src/run-inputs.ts
@@ -93,21 +93,20 @@ const runInputsConfiguration: {
 };
 
 function getRunInput(input: keyof RunInputs) {
-  const config = runInputsConfiguration[input];
-  if (!config) {
-    // this should never happen due to type safety
-    throw new Error(`No configuration found for input: ${input}`);
-  }
-
-  // Use local debug input key if local debugging is enabled
-  const isLocalDebug = process.env.CL_LOCAL_DEBUG;
-  const inputKey = isLocalDebug ? config.localParameter : config.parameter;
+  const inputKey = getInputKey(input);
   return core.getInput(inputKey, {
-    required: false, // todo
+    required: true,
   });
 }
 
 function getBooleanRunInput(input: keyof RunInputs) {
+  const inputKey = getInputKey(input);
+  return core.getBooleanInput(inputKey, {
+    required: true,
+  });
+}
+
+function getInputKey(input: keyof RunInputs) {
   const config = runInputsConfiguration[input];
   if (!config) {
     // this should never happen due to type safety
@@ -117,7 +116,5 @@ function getBooleanRunInput(input: keyof RunInputs) {
   // Use local debug input key if local debugging is enabled
   const isLocalDebug = process.env.CL_LOCAL_DEBUG;
   const inputKey = isLocalDebug ? config.localParameter : config.parameter;
-  return core.getBooleanInput(inputKey, {
-    required: false, // todo
-  });
+  return inputKey;
 }


### PR DESCRIPTION
Some follow-up fixes from #1156.

- Remove unused outputs
- Force inputs to be declared - they are all defaulted in action.yml
- Use strict equality operator

---

DX-1559