### PR TITLE
feat: apidiff-go multiple go mods

### DIFF
--- a/actions/apidiff-go/README.md
+++ b/actions/apidiff-go/README.md
@@ -19,13 +19,13 @@ request with it's findings.
 
 ### Inputs
 
-| input                | description                                                                        | default                                     |
-| -------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------- |
-| `directory`          | the root directory of the repository                                               | `./`                                        |
-| `go-mod-path`        | the relative path (relative to the root of the repository) to the root of a module | `.`                                         |
-| `base-ref`           | the base ref to compare to - if a branch it will find the common ancestor          | `${{ github.event.pull_request.base.ref }}` |
-| `head-ref`           | the head ref to compare from - if a branch it will use the `HEAD`                  | `${{ github.event.pull_request.head.ref }}` |
-| `enforce-compatible` | whether the action should fail if incompatible (breaking) changes are found        | `true`                                      |
+| input                | description                                                                       | default                                     |
+| -------------------- | --------------------------------------------------------------------------------- | ------------------------------------------- |
+| `directory`          | the root directory of the repository                                              | `./`                                        |
+| `go-mod-paths`       | comma separated relative paths (to the root of the repository) to root of modules | `.`                                         |
+| `base-ref`           | the base ref to compare to - if a branch it will find the common ancestor         | `${{ github.event.pull_request.base.ref }}` |
+| `head-ref`           | the head ref to compare from - if a branch it will use the `HEAD`                 | `${{ github.event.pull_request.head.ref }}` |
+| `enforce-compatible` | whether the action should fail if incompatible (breaking) changes are found       | `true`                                      |
 
 ### Example Workflow
 

--- a/actions/apidiff-go/action.yml
+++ b/actions/apidiff-go/action.yml
@@ -13,8 +13,10 @@ inputs:
     description: "Directory containing the Go repository"
     required: false
     default: "./"
-  go-mod-path:
-    description: "Relative path to the go.mod file from the repository root"
+  go-mod-paths:
+    description: |
+      Relative paths to the go.mod file from the repository root.
+      If multiple modules are present, provide a comma-separated list of paths.
     required: false
     default: "."
 

--- a/actions/apidiff-go/dist/index.js
+++ b/actions/apidiff-go/dist/index.js
@@ -31244,6 +31244,7 @@ async function getModuleName(goModDir) {
   }
 }
 async function installApidiff() {
+  core.startGroup("Installing apidiff");
   try {
     const isInstalled = await checkApidiffInstalled();
     if (isInstalled) {

--- a/actions/apidiff-go/scripts/test.sh
+++ b/actions/apidiff-go/scripts/test.sh
@@ -11,7 +11,7 @@ tmp_file=$(mktemp)
 export GITHUB_STEP_SUMMARY="$tmp_file"
 
 export INPUT_DIRECTORY="/Users/erik/Documents/test-repos/chainlink-common"
-export INPUT_GO_MOD_PATH="."
+export INPUT_GO_MOD_PATHS=".,./observability-lib"
 export INPUT_HEAD_REF="17115c3a4453e0347dae7f035bf94c959ca5bbda"
 export INPUT_BASE_REF="182a3d1ef5af6c5e9a21bca84d904251847fc315"
 export INPUT_ENFORCE_COMPATIBLE="true"

--- a/actions/apidiff-go/src/__tests__/git-worktree.test.ts
+++ b/actions/apidiff-go/src/__tests__/git-worktree.test.ts
@@ -15,9 +15,12 @@ import {
   cloneRepository,
   getRefSha,
 } from "./git-worktree.testutils.js";
+import { start } from "repl";
 
 // Mock @actions/core
 vi.mock("@actions/core", () => ({
+  startGroup: vi.fn(),
+  endGroup: vi.fn(),
   info: vi.fn(),
   warning: vi.fn(),
   debug: vi.fn(),

--- a/actions/apidiff-go/src/__tests__/git-worktree.test.ts
+++ b/actions/apidiff-go/src/__tests__/git-worktree.test.ts
@@ -15,7 +15,6 @@ import {
   cloneRepository,
   getRefSha,
 } from "./git-worktree.testutils.js";
-import { start } from "repl";
 
 // Mock @actions/core
 vi.mock("@actions/core", () => ({

--- a/actions/apidiff-go/src/__tests__/go/multi-module-changed/go.mod
+++ b/actions/apidiff-go/src/__tests__/go/multi-module-changed/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/multi-module
+
+go 1.21

--- a/actions/apidiff-go/src/__tests__/go/multi-module-changed/main.go
+++ b/actions/apidiff-go/src/__tests__/go/multi-module-changed/main.go
@@ -1,0 +1,26 @@
+// Package multimodule provides the main API
+package multimodule
+
+// MainFunc is the main function in the root module
+func MainFunc(data string) string {
+	return "main: " + data
+}
+
+// MainStruct represents data in the main module
+type MainStruct struct {
+	ID   int
+	Data string
+}
+
+// NewMainStruct creates a new MainStruct
+func NewMainStruct(id int, data string) *MainStruct {
+	return &MainStruct{
+		ID:   id,
+		Data: data,
+	}
+}
+
+// AdditionalFunc is a new function added to the main module
+func AdditionalFunc(count int) int {
+	return count * 2
+}

--- a/actions/apidiff-go/src/__tests__/go/multi-module-changed/submodule1/go.mod
+++ b/actions/apidiff-go/src/__tests__/go/multi-module-changed/submodule1/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/multi-module/submodule1
+
+go 1.21

--- a/actions/apidiff-go/src/__tests__/go/multi-module-changed/submodule1/util.go
+++ b/actions/apidiff-go/src/__tests__/go/multi-module-changed/submodule1/util.go
@@ -1,0 +1,26 @@
+// Package submodule1 provides utility functions
+package submodule1
+
+// UtilFunc is a utility function in submodule1 - signature changed!
+func UtilFunc(input string, prefix string) string {
+	return prefix + ": " + input
+}
+
+// UtilStruct represents data in submodule1
+type UtilStruct struct {
+	Name    string
+	Enabled bool
+}
+
+// NewUtilStruct creates a new UtilStruct
+func NewUtilStruct(name string, enabled bool) *UtilStruct {
+	return &UtilStruct{
+		Name:    name,
+		Enabled: enabled,
+	}
+}
+
+// IsEnabled returns the enabled status
+func (u *UtilStruct) IsEnabled() bool {
+	return u.Enabled
+}

--- a/actions/apidiff-go/src/__tests__/go/multi-module-changed/submodule2/go.mod
+++ b/actions/apidiff-go/src/__tests__/go/multi-module-changed/submodule2/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/multi-module/submodule2
+
+go 1.21

--- a/actions/apidiff-go/src/__tests__/go/multi-module-changed/submodule2/helper.go
+++ b/actions/apidiff-go/src/__tests__/go/multi-module-changed/submodule2/helper.go
@@ -1,0 +1,38 @@
+// Package submodule2 provides helper functions
+package submodule2
+
+// HelperFunc is a helper function in submodule2
+func HelperFunc(data []string) string {
+	result := "helper2: "
+	for i, item := range data {
+		if i > 0 {
+			result += ", "
+		}
+		result += item
+	}
+	return result
+}
+
+// HelperConfig represents configuration in submodule2
+type HelperConfig struct {
+	MaxItems int
+	Prefix   string
+}
+
+// NewHelperConfig creates a new HelperConfig
+func NewHelperConfig(maxItems int, prefix string) *HelperConfig {
+	return &HelperConfig{
+		MaxItems: maxItems,
+		Prefix:   prefix,
+	}
+}
+
+// GetMaxItems returns the max items setting
+func (h *HelperConfig) GetMaxItems() int {
+	return h.MaxItems
+}
+
+// NewAdditionalMethod is a new method added to submodule2
+func (h *HelperConfig) NewAdditionalMethod() string {
+	return "new method in submodule2"
+}

--- a/actions/apidiff-go/src/__tests__/go/multi-module/go.mod
+++ b/actions/apidiff-go/src/__tests__/go/multi-module/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/multi-module
+
+go 1.21

--- a/actions/apidiff-go/src/__tests__/go/multi-module/main.go
+++ b/actions/apidiff-go/src/__tests__/go/multi-module/main.go
@@ -1,0 +1,21 @@
+// Package multimodule provides the main API
+package multimodule
+
+// MainFunc is the main function in the root module
+func MainFunc(data string) string {
+	return "main: " + data
+}
+
+// MainStruct represents data in the main module
+type MainStruct struct {
+	ID   int
+	Data string
+}
+
+// NewMainStruct creates a new MainStruct
+func NewMainStruct(id int, data string) *MainStruct {
+	return &MainStruct{
+		ID:   id,
+		Data: data,
+	}
+}

--- a/actions/apidiff-go/src/__tests__/go/multi-module/submodule1/go.mod
+++ b/actions/apidiff-go/src/__tests__/go/multi-module/submodule1/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/multi-module/submodule1
+
+go 1.21

--- a/actions/apidiff-go/src/__tests__/go/multi-module/submodule1/util.go
+++ b/actions/apidiff-go/src/__tests__/go/multi-module/submodule1/util.go
@@ -1,0 +1,26 @@
+// Package submodule1 provides utility functions
+package submodule1
+
+// UtilFunc is a utility function in submodule1
+func UtilFunc(input string) string {
+	return "util1: " + input
+}
+
+// UtilStruct represents data in submodule1
+type UtilStruct struct {
+	Name    string
+	Enabled bool
+}
+
+// NewUtilStruct creates a new UtilStruct
+func NewUtilStruct(name string, enabled bool) *UtilStruct {
+	return &UtilStruct{
+		Name:    name,
+		Enabled: enabled,
+	}
+}
+
+// IsEnabled returns the enabled status
+func (u *UtilStruct) IsEnabled() bool {
+	return u.Enabled
+}

--- a/actions/apidiff-go/src/__tests__/go/multi-module/submodule2/go.mod
+++ b/actions/apidiff-go/src/__tests__/go/multi-module/submodule2/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/multi-module/submodule2
+
+go 1.21

--- a/actions/apidiff-go/src/__tests__/go/multi-module/submodule2/helper.go
+++ b/actions/apidiff-go/src/__tests__/go/multi-module/submodule2/helper.go
@@ -1,0 +1,33 @@
+// Package submodule2 provides helper functions
+package submodule2
+
+// HelperFunc is a helper function in submodule2
+func HelperFunc(data []string) string {
+	result := "helper2: "
+	for i, item := range data {
+		if i > 0 {
+			result += ", "
+		}
+		result += item
+	}
+	return result
+}
+
+// HelperConfig represents configuration in submodule2
+type HelperConfig struct {
+	MaxItems int
+	Prefix   string
+}
+
+// NewHelperConfig creates a new HelperConfig
+func NewHelperConfig(maxItems int, prefix string) *HelperConfig {
+	return &HelperConfig{
+		MaxItems: maxItems,
+		Prefix:   prefix,
+	}
+}
+
+// GetMaxItems returns the max items setting
+func (h *HelperConfig) GetMaxItems() int {
+	return h.MaxItems
+}

--- a/actions/apidiff-go/src/apidiff.ts
+++ b/actions/apidiff-go/src/apidiff.ts
@@ -125,6 +125,7 @@ async function getModuleName(goModDir: string): Promise<string> {
  * Installs apidiff via Go if not already available
  */
 export async function installApidiff(): Promise<void> {
+  core.startGroup("Installing apidiff");
   try {
     const isInstalled = await checkApidiffInstalled();
     if (isInstalled) {

--- a/actions/apidiff-go/src/git-worktree.ts
+++ b/actions/apidiff-go/src/git-worktree.ts
@@ -16,6 +16,7 @@ export async function setupWorktree(
   head: string,
   repoName: string,
 ): Promise<WorktreeResult> {
+  core.startGroup("Setting up git worktree");
   // Validate that the directory exists and is the root of a Git repository
   await validateGitRepositoryRoot(directory);
 
@@ -82,6 +83,11 @@ export async function setupWorktree(
   } catch (error) {
     core.error(`Failed to setup worktree: ${error}`);
     throw error;
+  } finally {
+    core.info(`Worktree setup completed for ${repoName}`);
+    core.info(`Head worktree: ${directory}`);
+    core.info(`Base worktree: ${worktreePath}`);
+    core.endGroup();
   }
 }
 

--- a/actions/apidiff-go/src/run-inputs.ts
+++ b/actions/apidiff-go/src/run-inputs.ts
@@ -3,7 +3,7 @@ import * as github from "@actions/github";
 
 export interface RunInputs {
   directory: string;
-  goModPath: string;
+  goModPaths: string[];
   baseRef: string;
   headRef: string;
   enforceCompatible: boolean;
@@ -13,11 +13,11 @@ export function getInputs(): RunInputs {
   core.info("Getting inputs for run.");
 
   const inputs: RunInputs = {
-    directory: getRunInput("directory"),
-    goModPath: getRunInput("goModPath"),
-    baseRef: getRunInput("baseRef"),
-    headRef: getRunInput("headRef"),
-    enforceCompatible: getBooleanRunInput("enforceCompatible"),
+    directory: getRunInputString("directory"),
+    goModPaths: getRunInputStringArray("goModPaths"),
+    baseRef: getRunInputString("baseRef"),
+    headRef: getRunInputString("headRef"),
+    enforceCompatible: getRunInputBoolean("enforceCompatible"),
   };
 
   core.info(`Inputs: ${JSON.stringify(inputs)}`);
@@ -74,9 +74,9 @@ const runInputsConfiguration: {
     parameter: "directory",
     localParameter: "DIRECTORY",
   },
-  goModPath: {
-    parameter: "go-mod-path",
-    localParameter: "GO_MOD_PATH",
+  goModPaths: {
+    parameter: "go-mod-paths",
+    localParameter: "GO_MOD_PATHS",
   },
   baseRef: {
     parameter: "base-ref",
@@ -92,14 +92,31 @@ const runInputsConfiguration: {
   },
 };
 
-function getRunInput(input: keyof RunInputs) {
+function getRunInputString(input: keyof RunInputs) {
   const inputKey = getInputKey(input);
   return core.getInput(inputKey, {
     required: true,
   });
 }
 
-function getBooleanRunInput(input: keyof RunInputs) {
+function getRunInputStringArray(input: keyof RunInputs) {
+  const inputKey = getInputKey(input);
+  const value = core
+    .getInput(inputKey, {
+      required: true,
+    })
+    .trim();
+
+  if (value.includes(",")) {
+    return value
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+  }
+  return [value];
+}
+
+function getRunInputBoolean(input: keyof RunInputs) {
   const inputKey = getInputKey(input);
   return core.getBooleanInput(inputKey, {
     required: true,


### PR DESCRIPTION
### Changes

- Some logging changes (groups)
- Change input `go-mod-path` to `go-mod-paths`, now supporting CSV paths to go mods
- Output formatting for multiple go.mods - example: https://github.com/smartcontractkit/chainlink-common/pull/1454#issuecomment-3166037330
- Tests for multi module setups

---

DX-1559