### PR TITLE
feat: apidiff-go configurable apidiff version

### DIFF
--- a/.changeset/yellow-eyes-train.md
+++ b/.changeset/yellow-eyes-train.md
@@ -1,0 +1,5 @@
+---
+"apidiff-go": minor
+---
+
+initial version

--- a/actions/apidiff-go/README.md
+++ b/actions/apidiff-go/README.md
@@ -9,10 +9,8 @@ Will analyze the changes introduced by a pull request and comment on the pull
 request with it's findings.
 
 - Installs `apidiff` if not found on the system already
-- Analyzes root module, or any modules nested in a repository (although only 1
-  at a time)
-- Enforce compatible changes by failing the action if any incompatible changes
-  are found
+- Analyzes the changes for any specified modules within a repository
+- Optionally fail the action if any incompatible (breaking) changes are found
 - Full summary for all changes found, posted as job output
 
 ## Usage
@@ -26,6 +24,7 @@ request with it's findings.
 | `base-ref`           | the base ref to compare to - if a branch it will find the common ancestor         | `${{ github.event.pull_request.base.ref }}` |
 | `head-ref`           | the head ref to compare from - if a branch it will use the `HEAD`                 | `${{ github.event.pull_request.head.ref }}` |
 | `enforce-compatible` | whether the action should fail if incompatible (breaking) changes are found       | `true`                                      |
+| `apidiff-version`    | the version of apidiff to install, default is recommended                         | `latest`                                    |
 
 ### Example Workflow
 
@@ -56,7 +55,7 @@ jobs:
       - name: Analyze API Changes
         uses: smartcontractkit/.github/actions/apidiff-go@<ref>
         with:
-          go-mod-path: ./path-to-nested-go-mod # defaults to .
+          go-mod-paths: .,./module-1,./module-2 # compare 3 modules
         env:
           GITHUB_TOKEN: ${{ github.token }}
 ```

--- a/actions/apidiff-go/action.yml
+++ b/actions/apidiff-go/action.yml
@@ -37,3 +37,11 @@ inputs:
       incompatible changes are detected."
     required: false
     default: true
+
+  apidiff-version:
+    description: |
+      Version of apidiff to use. Defaults to latest.
+      Versions are available here: https://pkg.go.dev/golang.org/x/exp/cmd/apidiff?tab=versions
+      This should only be overridden if 'latest' is not suitable.
+    required: false
+    default: "latest"

--- a/actions/apidiff-go/src/__tests__/apidiff.test.ts
+++ b/actions/apidiff-go/src/__tests__/apidiff.test.ts
@@ -57,7 +57,7 @@ describe("apidiff", () => {
 
       console.log("Running in GitHub Actions CI, installing apidiff...");
       try {
-        await installApidiff();
+        await installApidiff("latest");
         shouldRunTest = true;
 
         // Add to current process PATH
@@ -99,7 +99,7 @@ describe("apidiff", () => {
         return context.skip();
       }
 
-      await installApidiff();
+      await installApidiff("latest");
 
       // In CI, it will install, so check for installation messages
       // Locally, if apidiff is already available, it will detect existing installation
@@ -120,6 +120,12 @@ describe("apidiff", () => {
         );
 
       expect(hasExistingMessage || hasInstallationMessages).toBe(true);
+    });
+
+    it("should throw an error if an invalid version is passed", async (context) => {
+      await expect(
+        installApidiff("invalid-version", true),
+      ).rejects.toThrowError(/Failed to install apidiff:/);
     });
   });
 

--- a/actions/apidiff-go/src/run-inputs.ts
+++ b/actions/apidiff-go/src/run-inputs.ts
@@ -7,6 +7,7 @@ export interface RunInputs {
   baseRef: string;
   headRef: string;
   enforceCompatible: boolean;
+  apidiffVersion: string;
 }
 
 export function getInputs(): RunInputs {
@@ -18,6 +19,7 @@ export function getInputs(): RunInputs {
     baseRef: getRunInputString("baseRef"),
     headRef: getRunInputString("headRef"),
     enforceCompatible: getRunInputBoolean("enforceCompatible"),
+    apidiffVersion: getRunInputString("apidiffVersion"),
   };
 
   core.info(`Inputs: ${JSON.stringify(inputs)}`);
@@ -89,6 +91,10 @@ const runInputsConfiguration: {
   enforceCompatible: {
     parameter: "enforce-compatible",
     localParameter: "ENFORCE_COMPATIBLE",
+  },
+  apidiffVersion: {
+    parameter: "apidiff-version",
+    localParameter: "APIDIFF_VERSION",
   },
 };
 

--- a/actions/apidiff-go/src/run.ts
+++ b/actions/apidiff-go/src/run.ts
@@ -23,7 +23,7 @@ export async function run(): Promise<void> {
     );
 
     // 3. Run API diff between the two worktrees
-    await installApidiff();
+    await installApidiff(inputs.apidiffVersion);
     const apidiffOutputs = await runApidiff(
       worktreeResult.baseRepoPath, // Base directory (old version)
       worktreeResult.headRepoPath, // Head directory (new version)


### PR DESCRIPTION
### Changes

- Add `apidiff-version` as input and attempt to install that version, throws if fails.
- Add unit test for invalid version
- Update docs

---

DX-1559