### PR TITLE
feat: add configurable timeout input to reusable docker build workflow

### DIFF
--- a/.github/workflows/reusable-docker-build-publish.yml
+++ b/.github/workflows/reusable-docker-build-publish.yml
@@ -249,6 +249,11 @@ on:
           Example: smartcontractkit/chainlink
         required: true
         type: string
+      timeout:
+        description: "Timeout in minutes for the Docker build job."
+        required: false
+        type: number
+        default: 30
     outputs:
       docker-image-sha-digest-amd64:
         description: "Docker image SHA digest for amd64 architecture"
@@ -397,7 +402,7 @@ jobs:
     name: build-publish-${{ matrix.arch }}
     needs: [init, set-build-matrix]
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 30
+    timeout-minutes: ${{ inputs.timeout }}
     strategy:
       matrix:
         include: ${{ fromJson(needs.set-build-matrix.outputs.matrix) }}


### PR DESCRIPTION
## What 

See title. 

## Why 

I know it’s not great, but building some images like aptos-node takes more than 30 minutes, unfortunately.