### PR TITLE
chore(ci): bump actions/checkout to v5

### DIFF
--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v5
         with:
           # Commit back any changes based on the commit that triggered this action
           # rather than merge commit of main into the PR branch
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -133,7 +133,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -154,7 +154,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v5
 
       - name: ci-lint
         uses: ./actions/ci-lint-ts
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -60,7 +60,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -79,7 +79,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/schedule-renovate.yml
+++ b/.github/workflows/schedule-renovate.yml
@@ -15,7 +15,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           persist-credentials: false


### PR DESCRIPTION
This bumps our repo's workflows to use `actions/checkout` v5.
v5 is considered breaking as it now uses node24.

This doesn't touch any reusable workflows or actions.

