### PR TITLE
feat: cora pull request review event

### DIFF
--- a/.changeset/three-beers-clap.md
+++ b/.changeset/three-beers-clap.md
@@ -1,0 +1,5 @@
+---
+"codeowners-review-analysis": patch
+---
+
+add pull_request_review event support

--- a/actions/codeowners-review-analysis/action.yml
+++ b/actions/codeowners-review-analysis/action.yml
@@ -13,8 +13,3 @@ inputs:
       "Whether to post a comment on the PR with the analysis results."
     required: false
     default: "true"
-  members-read-github-token:
-    description:
-      "A GitHub token with read access to members. Required to resolve reviews
-      to codeowners."
-    required: true

--- a/actions/codeowners-review-analysis/action.yml
+++ b/actions/codeowners-review-analysis/action.yml
@@ -13,3 +13,8 @@ inputs:
       "Whether to post a comment on the PR with the analysis results."
     required: false
     default: "true"
+  members-read-github-token:
+    description:
+      "A GitHub token with read access to members. Required to resolve reviews
+      to codeowners."
+    required: true

--- a/actions/codeowners-review-analysis/dist/index.js
+++ b/actions/codeowners-review-analysis/dist/index.js
@@ -23735,7 +23735,7 @@ var require_core = __commonJS({
       process.env["PATH"] = `${inputPath}${path.delimiter}${process.env["PATH"]}`;
     }
     exports2.addPath = addPath;
-    function getInput(name, options) {
+    function getInput2(name, options) {
       const val = process.env[`INPUT_${name.replace(/ /g, "_").toUpperCase()}`] || "";
       if (options && options.required && !val) {
         throw new Error(`Input required and not supplied: ${name}`);
@@ -23745,9 +23745,9 @@ var require_core = __commonJS({
       }
       return val.trim();
     }
-    exports2.getInput = getInput;
+    exports2.getInput = getInput2;
     function getMultilineInput(name, options) {
-      const inputs = getInput(name, options).split("\n").filter((x) => x !== "");
+      const inputs = getInput2(name, options).split("\n").filter((x) => x !== "");
       if (options && options.trimWhitespace === false) {
         return inputs;
       }
@@ -23757,7 +23757,7 @@ var require_core = __commonJS({
     function getBooleanInput2(name, options) {
       const trueValue = ["true", "True", "TRUE"];
       const falseValue = ["false", "False", "FALSE"];
-      const val = getInput(name, options);
+      const val = getInput2(name, options);
       if (trueValue.includes(val))
         return true;
       if (falseValue.includes(val))
@@ -25071,7 +25071,8 @@ var github = __toESM(require_github());
 function getInputs() {
   core.info("Getting inputs for run.");
   const inputs = {
-    postComment: getRunInputBoolean("postComment")
+    postComment: getRunInputBoolean("postComment"),
+    membersReadGitHubToken: getRunInputString("membersReadGitHubToken")
   };
   core.info(`Inputs: ${JSON.stringify(inputs)}`);
   return inputs;
@@ -25108,11 +25109,21 @@ var runInputsConfiguration = {
   postComment: {
     parameter: "post-comment",
     localParameter: "POST_COMMENT"
+  },
+  membersReadGitHubToken: {
+    parameter: "members-read-github-token",
+    localParameter: "MEMBERS_READ_GITHUB_TOKEN"
   }
 };
 function getRunInputBoolean(input) {
   const inputKey = getInputKey(input);
   return core.getBooleanInput(inputKey, {
+    required: true
+  });
+}
+function getRunInputString(input) {
+  const inputKey = getInputKey(input);
+  return core.getInput(inputKey, {
     required: true
   });
 }
@@ -25930,7 +25941,9 @@ async function run() {
     core7.endGroup();
     core7.startGroup("Get currrent state of PR reviews");
     const OctokitWithGQLPagination = Octokit.plugin(paginateGraphQL);
-    const octokitGQL = new OctokitWithGQLPagination({ auth: token });
+    const octokitGQL = new OctokitWithGQLPagination({
+      auth: inputs.membersReadGitHubToken
+    });
     const currentPRReviewState = await getCurrentReviewStatus(
       octokitGQL,
       owner,

--- a/actions/codeowners-review-analysis/dist/index.js
+++ b/actions/codeowners-review-analysis/dist/index.js
@@ -25085,20 +25085,14 @@ function getInvokeContext() {
     return process.exit(1);
   }
   const { pull_request } = context4.payload;
-  if (context4.eventName !== "pull_request" || !pull_request) {
-    core.setFailed(
-      `This action can only be run on pull requests events. Got ${context4.eventName}`
-    );
-    return process.exit(1);
+  if (!pull_request) {
+    throw new Error(`No pull request found in the context payload. Event name: ${context4.eventName}`);
   }
   const { number: prNumber } = pull_request;
   const { sha: base } = pull_request.base;
   const { sha: head } = pull_request.head;
   if (!base || !head || !prNumber) {
-    core.setFailed(
-      `Missing required pull request information. Base: ${base}, Head: ${head}, PR: ${prNumber}`
-    );
-    return process.exit(1);
+    throw new Error(`Missing required pull request information. Base: ${base}, Head: ${head}, PR: ${prNumber}`);
   }
   core.info(`Event name: ${context4.eventName}`);
   core.info(

--- a/actions/codeowners-review-analysis/dist/index.js
+++ b/actions/codeowners-review-analysis/dist/index.js
@@ -23735,7 +23735,7 @@ var require_core = __commonJS({
       process.env["PATH"] = `${inputPath}${path.delimiter}${process.env["PATH"]}`;
     }
     exports2.addPath = addPath;
-    function getInput2(name, options) {
+    function getInput(name, options) {
       const val = process.env[`INPUT_${name.replace(/ /g, "_").toUpperCase()}`] || "";
       if (options && options.required && !val) {
         throw new Error(`Input required and not supplied: ${name}`);
@@ -23745,9 +23745,9 @@ var require_core = __commonJS({
       }
       return val.trim();
     }
-    exports2.getInput = getInput2;
+    exports2.getInput = getInput;
     function getMultilineInput(name, options) {
-      const inputs = getInput2(name, options).split("\n").filter((x) => x !== "");
+      const inputs = getInput(name, options).split("\n").filter((x) => x !== "");
       if (options && options.trimWhitespace === false) {
         return inputs;
       }
@@ -23757,7 +23757,7 @@ var require_core = __commonJS({
     function getBooleanInput2(name, options) {
       const trueValue = ["true", "True", "TRUE"];
       const falseValue = ["false", "False", "FALSE"];
-      const val = getInput2(name, options);
+      const val = getInput(name, options);
       if (trueValue.includes(val))
         return true;
       if (falseValue.includes(val))
@@ -25071,8 +25071,7 @@ var github = __toESM(require_github());
 function getInputs() {
   core.info("Getting inputs for run.");
   const inputs = {
-    postComment: getRunInputBoolean("postComment"),
-    membersReadGitHubToken: getRunInputString("membersReadGitHubToken")
+    postComment: getRunInputBoolean("postComment")
   };
   core.info(`Inputs: ${JSON.stringify(inputs)}`);
   return inputs;
@@ -25109,21 +25108,11 @@ var runInputsConfiguration = {
   postComment: {
     parameter: "post-comment",
     localParameter: "POST_COMMENT"
-  },
-  membersReadGitHubToken: {
-    parameter: "members-read-github-token",
-    localParameter: "MEMBERS_READ_GITHUB_TOKEN"
   }
 };
 function getRunInputBoolean(input) {
   const inputKey = getInputKey(input);
   return core.getBooleanInput(inputKey, {
-    required: true
-  });
-}
-function getRunInputString(input) {
-  const inputKey = getInputKey(input);
-  return core.getInput(inputKey, {
     required: true
   });
 }
@@ -25941,9 +25930,7 @@ async function run() {
     core7.endGroup();
     core7.startGroup("Get currrent state of PR reviews");
     const OctokitWithGQLPagination = Octokit.plugin(paginateGraphQL);
-    const octokitGQL = new OctokitWithGQLPagination({
-      auth: inputs.membersReadGitHubToken
-    });
+    const octokitGQL = new OctokitWithGQLPagination({ auth: token });
     const currentPRReviewState = await getCurrentReviewStatus(
       octokitGQL,
       owner,

--- a/actions/codeowners-review-analysis/scripts/test.sh
+++ b/actions/codeowners-review-analysis/scripts/test.sh
@@ -3,10 +3,12 @@
 pnpm nx build codeowners-review-analysis
 
 export GITHUB_TOKEN=$(gh auth token)
+export GITHUB_ACTOR=$(gh api user --jq .login)
 export GITHUB_REPOSITORY="smartcontractkit/chainlink"
 # export GITHUB_REPOSITORY="smartcontractkit/releng-test"
-export GITHUB_EVENT_NAME="pull_request"
+export GITHUB_EVENT_NAME="pull_request_review"
 export GITHUB_EVENT_PATH="actions/codeowners-review-analysis/scripts/payload.json"
+
 
 tmp_file=$(mktemp)
 export GITHUB_STEP_SUMMARY="$tmp_file"

--- a/actions/codeowners-review-analysis/src/github-gql.ts
+++ b/actions/codeowners-review-analysis/src/github-gql.ts
@@ -155,16 +155,19 @@ function extractPending(pr: NonNullable<Repository["pullRequest"]>): {
     const r = rr?.requestedReviewer;
     if (!r) continue;
     if (r.__typename === "User") {
+      core.debug(`Found requested user review: ${r.login}`);
       pendingUsers.push({
         login: r.login,
         asCodeOwner: rr.asCodeOwner,
       });
-    } else if (r.__typename === "Team")
+    } else if (r.__typename === "Team") {
+      core.debug(`Found requested team review: ${r.slug}`);
       pendingTeams.push({
         slug: r.slug,
         id: r.id,
         asCodeOwner: rr.asCodeOwner,
       });
+    }
   }
 
   return { pendingUsers, pendingTeams, decision };
@@ -198,6 +201,9 @@ function accumulateLatestSignals(
 
     // Newest-to-older (because we use last/before). First time we see a user => their latest.
     if (authorLogin && !(authorLogin in userLatest)) {
+      core.debug(
+        `Found latest review by user: ${authorLogin} at ${submittedAt} - ${n.state}`,
+      );
       userLatest[authorLogin] = {
         state: n.state,
         submittedAt,
@@ -209,6 +215,9 @@ function accumulateLatestSignals(
 
     for (const team of onBehalfOfTeams) {
       if (!(team.slug in teamLatest)) {
+        core.debug(
+          `Found latest review by team: ${team.slug} at ${submittedAt} - ${n.state}`,
+        );
         teamLatest[team.slug] = {
           state: n.state,
           submittedAt,

--- a/actions/codeowners-review-analysis/src/run-inputs.ts
+++ b/actions/codeowners-review-analysis/src/run-inputs.ts
@@ -31,11 +31,10 @@ export function getInvokeContext() {
   }
 
   const { pull_request } = context.payload;
-  if (context.eventName !== "pull_request" || !pull_request) {
-    core.setFailed(
-      `This action can only be run on pull requests events. Got ${context.eventName}`,
+  if (!pull_request) {
+    throw new Error(
+      `No pull request found in the context payload. Event name: ${context.eventName}`,
     );
-    return process.exit(1);
   }
 
   const { number: prNumber } = pull_request;
@@ -43,10 +42,9 @@ export function getInvokeContext() {
   const { sha: head } = pull_request.head;
 
   if (!base || !head || !prNumber) {
-    core.setFailed(
+    throw new Error(
       `Missing required pull request information. Base: ${base}, Head: ${head}, PR: ${prNumber}`,
     );
-    return process.exit(1);
   }
 
   core.info(`Event name: ${context.eventName}`);

--- a/actions/codeowners-review-analysis/src/run-inputs.ts
+++ b/actions/codeowners-review-analysis/src/run-inputs.ts
@@ -3,7 +3,6 @@ import * as github from "@actions/github";
 
 export interface RunInputs {
   postComment: boolean;
-  membersReadGitHubToken: string;
 }
 
 export function getInputs(): RunInputs {
@@ -11,7 +10,6 @@ export function getInputs(): RunInputs {
 
   const inputs: RunInputs = {
     postComment: getRunInputBoolean("postComment"),
-    membersReadGitHubToken: getRunInputString("membersReadGitHubToken"),
   };
 
   core.info(`Inputs: ${JSON.stringify(inputs)}`);
@@ -79,22 +77,11 @@ const runInputsConfiguration: {
     parameter: "post-comment",
     localParameter: "POST_COMMENT",
   },
-  membersReadGitHubToken: {
-    parameter: "members-read-github-token",
-    localParameter: "MEMBERS_READ_GITHUB_TOKEN",
-  },
 };
 
 function getRunInputBoolean(input: keyof RunInputs) {
   const inputKey = getInputKey(input);
   return core.getBooleanInput(inputKey, {
-    required: true,
-  });
-}
-
-function getRunInputString(input: keyof RunInputs) {
-  const inputKey = getInputKey(input);
-  return core.getInput(inputKey, {
     required: true,
   });
 }

--- a/actions/codeowners-review-analysis/src/run-inputs.ts
+++ b/actions/codeowners-review-analysis/src/run-inputs.ts
@@ -3,6 +3,7 @@ import * as github from "@actions/github";
 
 export interface RunInputs {
   postComment: boolean;
+  membersReadGitHubToken: string;
 }
 
 export function getInputs(): RunInputs {
@@ -10,6 +11,7 @@ export function getInputs(): RunInputs {
 
   const inputs: RunInputs = {
     postComment: getRunInputBoolean("postComment"),
+    membersReadGitHubToken: getRunInputString("membersReadGitHubToken"),
   };
 
   core.info(`Inputs: ${JSON.stringify(inputs)}`);
@@ -77,11 +79,22 @@ const runInputsConfiguration: {
     parameter: "post-comment",
     localParameter: "POST_COMMENT",
   },
+  membersReadGitHubToken: {
+    parameter: "members-read-github-token",
+    localParameter: "MEMBERS_READ_GITHUB_TOKEN",
+  },
 };
 
 function getRunInputBoolean(input: keyof RunInputs) {
   const inputKey = getInputKey(input);
   return core.getBooleanInput(inputKey, {
+    required: true,
+  });
+}
+
+function getRunInputString(input: keyof RunInputs) {
+  const inputKey = getInputKey(input);
+  return core.getInput(inputKey, {
     required: true,
   });
 }

--- a/actions/codeowners-review-analysis/src/run.ts
+++ b/actions/codeowners-review-analysis/src/run.ts
@@ -89,6 +89,8 @@ export async function run(): Promise<void> {
       repo,
       prNumber,
     );
+
+    core.debug(JSON.stringify(currentPRReviewState));
     core.endGroup();
 
     core.startGroup("Create CODEOWNERS Summary");

--- a/actions/codeowners-review-analysis/src/run.ts
+++ b/actions/codeowners-review-analysis/src/run.ts
@@ -82,7 +82,9 @@ export async function run(): Promise<void> {
 
     core.startGroup("Get currrent state of PR reviews");
     const OctokitWithGQLPagination = Octokit.plugin(paginateGraphQL);
-    const octokitGQL = new OctokitWithGQLPagination({ auth: token });
+    const octokitGQL = new OctokitWithGQLPagination({
+      auth: inputs.membersReadGitHubToken,
+    });
     const currentPRReviewState = await getCurrentReviewStatus(
       octokitGQL,
       owner,

--- a/actions/codeowners-review-analysis/src/run.ts
+++ b/actions/codeowners-review-analysis/src/run.ts
@@ -82,9 +82,7 @@ export async function run(): Promise<void> {
 
     core.startGroup("Get currrent state of PR reviews");
     const OctokitWithGQLPagination = Octokit.plugin(paginateGraphQL);
-    const octokitGQL = new OctokitWithGQLPagination({
-      auth: inputs.membersReadGitHubToken,
-    });
+    const octokitGQL = new OctokitWithGQLPagination({ auth: token });
     const currentPRReviewState = await getCurrentReviewStatus(
       octokitGQL,
       owner,


### PR DESCRIPTION
CodeOwners Review Analysis (cora) support `pull_request_review` events.

We need this and they should contain the same context as `pull_request_events`, as per: https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request_review


### Testing

Tested with the test.sh shell script and here: https://github.com/smartcontractkit/releng-test/pull/138

---

DX-1787
