### PR TITLE
feat: Adding support for cloning a public repo to the Docker build reusable workflow

### DIFF
--- a/.github/workflows/reusable-docker-build-publish.yml
+++ b/.github/workflows/reusable-docker-build-publish.yml
@@ -436,6 +436,8 @@ jobs:
         with:
           repository: ${{ inputs.public-repo }}
           path: ./public-repo/${{ inputs.public-repo }}
+          fetch-depth: 1
+          persist-credentials: false
       # Generated tags must be compatible with:
       # https://github.com/docker/metadata-action?tab=readme-ov-file#tags-input
       - name: Set Docker image tags


### PR DESCRIPTION
## What

This pull request updates the reusable Docker build and publish GitHub Actions workflow to support optionally cloning a public repository during the build process. The main changes introduce a new input parameter and corresponding steps to handle this functionality.

**Enhancements to public repository support:**

* Added a new optional `public-repo` input parameter to the workflow, allowing users to specify a public repository (in the format `owner/repo@ref`) to be cloned as part of the Docker build process.
* Updated the workflow steps to conditionally check out the specified public repository using `actions/checkout@v4` if the `public-repo` input is provided. The repository is cloned into a subdirectory under `./public-repo/`.
* Added documentation and an example for the new `public-repo` input in the workflow file for clarity.
* Included a comment in the Docker build step to indicate the optional use of the `public-repo` parameter.

## Why 

I’d like to use this workflow to rebuild some upstream images, so cloning upstream repos is required.