### PR TITLE
fix: cora table and legend separation

### DIFF
--- a/.changeset/kind-mails-warn.md
+++ b/.changeset/kind-mails-warn.md
@@ -1,0 +1,5 @@
+---
+"codeowners-review-analysis": patch
+---
+
+add separation between table and legend on PR comments

--- a/actions/codeowners-review-analysis/dist/index.js
+++ b/actions/codeowners-review-analysis/dist/index.js
@@ -25953,7 +25953,7 @@ function formatPendingReviewsMarkdown(entryMap, overallStatus, summaryUrl) {
       );
     }
   }
-  lines.push(LEGEND, "");
+  lines.push("", "", LEGEND, "");
   if (summaryUrl) {
     lines.push("");
     lines.push(

--- a/actions/codeowners-review-analysis/src/strings.ts
+++ b/actions/codeowners-review-analysis/src/strings.ts
@@ -62,7 +62,7 @@ export function formatPendingReviewsMarkdown(
     }
   }
 
-  lines.push(LEGEND, "");
+  lines.push("", "", LEGEND, "");
 
   if (summaryUrl) {
     lines.push("");


### PR DESCRIPTION
### Changes

- Fixes small formatting error for `codeowners-review-analysis`, where the legend was the last row in the table above

### Testing

Example new format: https://github.com/smartcontractkit/releng-test/pull/142#issuecomment-3339680172

---

DX-1787