### PR TITLE
fix(setup-golang): use path from input

### DIFF
--- a/actions/setup-golang/action.yml
+++ b/actions/setup-golang/action.yml
@@ -76,7 +76,7 @@ runs:
           ${{ steps.go-cache-dir.outputs.gomodcache }}
         key:
           ${{ runner.os }}-gomod-${{ inputs.cache-version }}-${{
-          hashFiles('./go.sum') }}
+          hashFiles(inputs.go-cache-dep-path) }}
         restore-keys: |
           ${{ runner.os }}-gomod-${{ inputs.cache-version }}-
 
@@ -89,7 +89,7 @@ runs:
           ${{ steps.go-cache-dir.outputs.gomodcache }}
         key:
           ${{ runner.os }}-gomod-${{ inputs.cache-version }}-${{
-          hashFiles('./go.sum') }}
+          hashFiles(inputs.go-cache-dep-path) }}
         restore-keys: |
           ${{ runner.os }}-gomod-${{ inputs.cache-version }}-
 
@@ -104,10 +104,10 @@ runs:
           ${{ steps.go-cache-dir.outputs.gobuildcache }}
         key:
           ${{ runner.os }}-gobuild-${{ inputs.cache-version }}-${{
-          hashFiles('./go.sum') }}-${{ steps.branch-name.outputs.current_branch
-          }}
+          hashFiles(inputs.go-cache-dep-path) }}-${{
+          steps.branch-name.outputs.current_branch }}
         restore-keys: |
-          ${{ runner.os }}-gobuild-${{ inputs.cache-version }}-${{ hashFiles('./go.sum') }}-
+          ${{ runner.os }}-gobuild-${{ inputs.cache-version }}-${{ hashFiles(inputs.go-cache-dep-path) }}-
           ${{ runner.os }}-gobuild-${{ inputs.cache-version }}-
 
     - uses: actions/cache@v4
@@ -121,8 +121,8 @@ runs:
           ${{ steps.go-cache-dir.outputs.gobuildcache }}
         key:
           ${{ runner.os }}-gobuild-${{ inputs.cache-version }}-${{
-          hashFiles('./go.sum') }}-${{ steps.branch-name.outputs.current_branch
-          }}
+          hashFiles(inputs.go-cache-dep-path) }}-${{
+          steps.branch-name.outputs.current_branch }}
         restore-keys: |
-          ${{ runner.os }}-gobuild-${{ inputs.cache-version }}-${{ hashFiles('./go.sum') }}-
+          ${{ runner.os }}-gobuild-${{ inputs.cache-version }}-${{ hashFiles(inputs.go-cache-dep-path) }}-
           ${{ runner.os }}-gobuild-${{ inputs.cache-version }}-


### PR DESCRIPTION
In multiple places, we assume the go.mod and go.sum files are located on the root which is not the case when the project is a monorepo, we should use the path provided in the input instead of assuming

Example [here](https://github.com/smartcontractkit/chainlink-deployments/actions/runs/18052817312/job/51377775501#step:8:533)

> Cache restored successfully
Cache restored from key: Linux-gobuild-1--main

Note the `--`, blank because go.sum is not found on the root