### PR TITLE
fix: apidiff-go output formatting

### DIFF
--- a/.changeset/two-bananas-allow.md
+++ b/.changeset/two-bananas-allow.md
@@ -1,0 +1,5 @@
+---
+"apidiff-go": minor
+---
+
+refactor output formatting, add post-comment input

--- a/actions/apidiff-go/action.yml
+++ b/actions/apidiff-go/action.yml
@@ -36,7 +36,12 @@ inputs:
       "Enforce that the API changes are compatible. Fails the action if
       incompatible changes are detected."
     required: false
-    default: true
+    default: "true"
+
+  post-comment:
+    description: "Post a comment on the pull request with the apidiff results."
+    required: false
+    default: "true"
 
   apidiff-version:
     description: |

--- a/actions/apidiff-go/package.json
+++ b/actions/apidiff-go/package.json
@@ -17,6 +17,7 @@
     "@actions/core": "^1.11.1",
     "@actions/github": "^6.0.1",
     "@actions/glob": "^0.4.0",
+    "diff": "^8.0.2",
     "execa": "^9.6.0"
   },
   "devDependencies": {

--- a/actions/apidiff-go/scripts/payload.json
+++ b/actions/apidiff-go/scripts/payload.json
@@ -1,7 +1,7 @@
 {
   "pull_request": {
-    "base": { "sha": "ce3566411a1450a49071fabf28d188cdb6602425" },
-    "head": { "sha": "17115c3a4453e0347dae7f035bf94c959ca5bbda" },
+    "base": { "sha": "98903c79c1244979902a711a12ea031d40797cb0" },
+    "head": { "sha": "c4fc2502a11010c21ceebb2fd3f1d757e1debe87" },
     "number": 1454
   }
 }

--- a/actions/apidiff-go/scripts/test.sh
+++ b/actions/apidiff-go/scripts/test.sh
@@ -10,15 +10,17 @@ export GITHUB_EVENT_PATH="actions/apidiff-go/scripts/payload.json"
 tmp_file=$(mktemp)
 export GITHUB_STEP_SUMMARY="$tmp_file"
 
-export INPUT_DIRECTORY="/Users/erik/Documents/test-repos/chainlink-common"
-export INPUT_GO_MOD_PATHS=".,./observability-lib"
-export INPUT_HEAD_REF="17115c3a4453e0347dae7f035bf94c959ca5bbda"
-export INPUT_BASE_REF="182a3d1ef5af6c5e9a21bca84d904251847fc315"
+export INPUT_DIRECTORY="/Users/erik/Documents/repos/chainlink-common"
+export INPUT_GO_MOD_PATHS="./"
+export INPUT_HEAD_REF="PRIV-192"
+export INPUT_BASE_REF="main"
 export INPUT_ENFORCE_COMPATIBLE="true"
+export INPUT_POST_COMMENT="false"
+export INPUT_APIDIFF_VERSION="latest"
 
 export CL_LOCAL_DEBUG="true"
 
 node actions/apidiff-go/dist/index.js
 
-echo "Summary Output: $tmp_file"
-cat "$tmp_file"
+echo "Writing to summary.md"
+cat "$tmp_file" > actions/apidiff-go/summary.md

--- a/actions/apidiff-go/src/apidiff.ts
+++ b/actions/apidiff-go/src/apidiff.ts
@@ -2,6 +2,7 @@ import * as core from "@actions/core";
 import { join, basename } from "path";
 import { execa } from "execa";
 import * as fs from "fs";
+import { CL_LOCAL_DEBUG } from "./run-inputs";
 
 // Rough type for execa result
 type ExecResult = Awaited<ReturnType<typeof execa>>;
@@ -49,6 +50,11 @@ export async function runApidiff(
         ["-m", baseExportFile, headExportFile],
         { reject: false },
       );
+
+      if (CL_LOCAL_DEBUG) {
+        // write output to file
+        await fs.promises.writeFile(`./apidiff-output.txt`, stdout);
+      }
 
       if (stderr) {
         core.warning(`apidiff stderr: ${stderr}`);

--- a/actions/apidiff-go/src/apidiff.ts
+++ b/actions/apidiff-go/src/apidiff.ts
@@ -176,3 +176,90 @@ async function checkApidiffInstalled(): Promise<boolean> {
     return false;
   }
 }
+
+interface MetaDiff {
+  header: string;
+  first: string;
+  second: string;
+}
+export interface Change {
+  element: string;
+  change: string;
+}
+export interface ApiDiffResult {
+  moduleName: string;
+  meta: MetaDiff[];
+  incompatible: Change[];
+  compatible: Change[];
+}
+
+export function parseApidiffOutputs(
+  output: Record<string, string>,
+): ApiDiffResult[] {
+  const out: ApiDiffResult[] = [];
+  for (const [moduleName, moduleOutput] of Object.entries(output)) {
+    out.push(parseApidiffOutput(moduleName, moduleOutput));
+  }
+  return out;
+}
+
+function parseApidiffOutput(moduleName: string, output: string): ApiDiffResult {
+  const lines = output.split(/\r?\n/);
+  const result: ApiDiffResult = {
+    moduleName,
+    meta: [],
+    incompatible: [],
+    compatible: [],
+  };
+  let section: "meta" | "incompatible" | "compatible" | null = null;
+  let currentMeta: MetaDiff | null = null;
+
+  for (const raw of lines) {
+    const line = raw.trim();
+
+    if (line.startsWith("! ")) {
+      if (currentMeta) result.meta.push(currentMeta);
+      currentMeta = { header: line.slice(2), first: "", second: "" };
+      section = "meta";
+      continue;
+    }
+    if (section === "meta" && currentMeta) {
+      if (line.startsWith("first:")) {
+        currentMeta.first = line.slice(6).trim();
+        continue;
+      }
+      if (line.startsWith("second:")) {
+        currentMeta.second = line.slice(7).trim();
+        continue;
+      }
+    }
+    if (line === "Incompatible changes:") {
+      if (currentMeta) result.meta.push(currentMeta);
+      currentMeta = null;
+      section = "incompatible";
+      continue;
+    }
+    if (line === "Compatible changes:") {
+      section = "compatible";
+      continue;
+    }
+
+    if (
+      (section === "incompatible" || section === "compatible") &&
+      line.startsWith("- ")
+    ) {
+      const content = line.slice(2);
+      const sepIdx = content.indexOf(": ");
+      if (sepIdx >= 0) {
+        const element = content.slice(0, sepIdx);
+        const change = content.slice(sepIdx + 2);
+        (section === "incompatible"
+          ? result.incompatible
+          : result.compatible
+        ).push({ element, change });
+      }
+    }
+  }
+  if (currentMeta) result.meta.push(currentMeta);
+  return result;
+}

--- a/actions/apidiff-go/src/render-diff.ts
+++ b/actions/apidiff-go/src/render-diff.ts
@@ -1,0 +1,112 @@
+import { diffArrays, Change } from "diff";
+
+function escapeHtml(s: string) {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+// Treat hyphen as part of identifiers/paths so "chainlink-common" stays a single token.
+function tokenizeGeneric(s: string): string[] {
+  const re =
+    /(\s+|->|=>|::|\.{3}|[A-Za-z0-9_.$/-]+|\[\]|[\[\]{}()<>]|[,;:?*|&=+!%^~]|\\|\.|\|{2}|&{2})/g;
+  const tokens = s.match(re);
+  return tokens ?? [s];
+}
+
+function diffTokenized(a: string, b: string): Change[] {
+  const A = tokenizeGeneric(a);
+  const B = tokenizeGeneric(b);
+  const parts = diffArrays(A, B);
+  return parts.map((p) => ({
+    value: p.value.join(""),
+    added: p.added,
+    removed: p.removed,
+  })) as Change[];
+}
+
+/** Split into comma-aware segments, keeping ", " attached to the left segment. */
+function splitSegments(s: string): string[] {
+  const parts = s.split(/(, ?)/);
+  const segs: string[] = [];
+  for (let i = 0; i < parts.length; i += 2) {
+    segs.push(parts[i] + (parts[i + 1] ?? ""));
+  }
+  return segs;
+}
+
+/**
+ * Always show the FULL old/new lines (no trimming), with:
+ * - Comma-aware alignment so diffs never spill across arguments
+ * - Token-level highlights within replaced segments
+ */
+export function renderTwoLineDiffPre(oldText: string, newText: string): string {
+  const oldSegs = splitSegments(oldText);
+  const newSegs = splitSegments(newText);
+  const segDiff = diffArrays(oldSegs, newSegs);
+
+  type Op = {
+    kind: "equal" | "add" | "del" | "replace";
+    a?: string[];
+    b?: string[];
+  };
+  const ops: Op[] = [];
+
+  // Coalesce adjacent del+add into a single replace so we can token-diff inside.
+  for (const part of segDiff as Array<{
+    value: string[];
+    added?: boolean;
+    removed?: boolean;
+  }>) {
+    if (part.added) {
+      const prev = ops[ops.length - 1];
+      if (prev && prev.kind === "del" && !prev.b) {
+        prev.kind = "replace";
+        prev.b = part.value;
+      } else {
+        ops.push({ kind: "add", b: part.value });
+      }
+    } else if (part.removed) {
+      ops.push({ kind: "del", a: part.value });
+    } else {
+      ops.push({ kind: "equal", a: part.value });
+    }
+  }
+
+  const outOld: string[] = [];
+  const outNew: string[] = [];
+
+  for (const op of ops) {
+    if (op.kind === "equal") {
+      const stable = escapeHtml((op.a ?? []).join(""));
+      outOld.push(stable);
+      outNew.push(stable);
+      continue;
+    }
+    if (op.kind === "add") {
+      outNew.push(`<ins>${escapeHtml((op.b ?? []).join(""))}</ins>`);
+      continue;
+    }
+    if (op.kind === "del") {
+      outOld.push(`<del>${escapeHtml((op.a ?? []).join(""))}</del>`);
+      continue;
+    }
+    // replace: token-diff inside the segment for tight highlights
+    const a = (op.a ?? []).join("");
+    const b = (op.b ?? []).join("");
+    const inner = diffTokenized(a, b);
+    let aHtml = "",
+      bHtml = "";
+    for (const c of inner) {
+      const esc = escapeHtml(c.value);
+      if (c.added) bHtml += `<ins>${esc}</ins>`;
+      else if (c.removed) aHtml += `<del>${esc}</del>`;
+      else {
+        aHtml += esc;
+        bHtml += esc;
+      }
+    }
+    outOld.push(aHtml);
+    outNew.push(bHtml);
+  }
+
+  return `<pre>- ${outOld.join("")}\n+ ${outNew.join("")}</pre>`;
+}

--- a/actions/apidiff-go/src/run-inputs.ts
+++ b/actions/apidiff-go/src/run-inputs.ts
@@ -1,12 +1,15 @@
 import * as core from "@actions/core";
 import * as github from "@actions/github";
 
+export const CL_LOCAL_DEBUG = process.env.CL_LOCAL_DEBUG === "true";
+
 export interface RunInputs {
   directory: string;
   goModPaths: string[];
   baseRef: string;
   headRef: string;
   enforceCompatible: boolean;
+  postComment: boolean;
   apidiffVersion: string;
 }
 
@@ -19,6 +22,7 @@ export function getInputs(): RunInputs {
     baseRef: getRunInputString("baseRef"),
     headRef: getRunInputString("headRef"),
     enforceCompatible: getRunInputBoolean("enforceCompatible"),
+    postComment: getRunInputBoolean("postComment"),
     apidiffVersion: getRunInputString("apidiffVersion"),
   };
 
@@ -91,6 +95,10 @@ const runInputsConfiguration: {
   enforceCompatible: {
     parameter: "enforce-compatible",
     localParameter: "ENFORCE_COMPATIBLE",
+  },
+  postComment: {
+    parameter: "post-comment",
+    localParameter: "POST_COMMENT",
   },
   apidiffVersion: {
     parameter: "apidiff-version",

--- a/actions/apidiff-go/src/run.ts
+++ b/actions/apidiff-go/src/run.ts
@@ -3,7 +3,7 @@ import * as core from "@actions/core";
 import { installApidiff, runApidiff } from "./apidiff";
 import { setupWorktree, cleanupWorktrees } from "./git-worktree";
 import { getSummaryUrl, upsertPRComment } from "./github";
-import { getInputs, getInvokeContext } from "./run-inputs";
+import { CL_LOCAL_DEBUG, getInputs, getInvokeContext } from "./run-inputs";
 import { parseApidiffOutputs, formatApidiffMarkdown } from "./string-processor";
 
 export async function run(): Promise<void> {
@@ -52,13 +52,21 @@ export async function run(): Promise<void> {
         summaryUrl,
         false,
       );
-      await upsertPRComment(
-        context.token,
-        context.owner,
-        context.repo,
-        context.prNumber,
-        markdownOutputIncompatibleOnly,
-      );
+
+      if (CL_LOCAL_DEBUG) {
+        core.info("Markdown Output (Incompatible Only):");
+        core.info(markdownOutputIncompatibleOnly);
+      }
+
+      if (inputs.postComment) {
+        await upsertPRComment(
+          context.token,
+          context.owner,
+          context.repo,
+          context.prNumber,
+          markdownOutputIncompatibleOnly,
+        );
+      }
     }
     core.endGroup();
 

--- a/actions/apidiff-go/src/run.ts
+++ b/actions/apidiff-go/src/run.ts
@@ -1,10 +1,13 @@
 import * as core from "@actions/core";
 
-import { installApidiff, runApidiff } from "./apidiff";
+import { parseApidiffOutputs, installApidiff, runApidiff } from "./apidiff";
 import { setupWorktree, cleanupWorktrees } from "./git-worktree";
 import { getSummaryUrl, upsertPRComment } from "./github";
 import { CL_LOCAL_DEBUG, getInputs, getInvokeContext } from "./run-inputs";
-import { parseApidiffOutputs, formatApidiffMarkdown } from "./string-processor";
+import {
+  formatApidiffMarkdown,
+  formatApidiffJobSummary,
+} from "./string-processor";
 
 export async function run(): Promise<void> {
   try {
@@ -37,9 +40,7 @@ export async function run(): Promise<void> {
 
     // 4. Format and output results
     core.startGroup("Formatting and Outputting Results");
-    const markdownOutputAll = formatApidiffMarkdown(parsedOutputs, "", true);
-    await core.summary.addRaw(markdownOutputAll).write();
-
+    formatApidiffJobSummary(parsedOutputs);
     if (context.prNumber) {
       const summaryUrl = await getSummaryUrl(
         context.token,

--- a/actions/apidiff-go/src/string-processor.ts
+++ b/actions/apidiff-go/src/string-processor.ts
@@ -189,12 +189,7 @@ export function formatApidiffMarkdown(
     }
   }
 
-  lines.push(
-    `---`,
-    ``,
-    `📄 [View full apidiff report](${summaryUrl})`,
-    ``,
-  );
+  lines.push(`---`, ``, `📄 [View full apidiff report](${summaryUrl})`, ``);
   return lines.join("\n");
 }
 
@@ -209,21 +204,28 @@ export async function formatApidiffJobSummary(
   const s = core.summary;
 
   if (!diffs.length) {
-    s.addHeading("📊 API Diff Results", 2)
-      .addRaw("<blockquote>No modules to analyze</blockquote>", true)
+    s.addHeading("📊 API Diff Results", 2).addRaw(
+      "<blockquote>No modules to analyze</blockquote>",
+      true,
+    );
     await s.write();
     return;
   }
 
   const hasIncompat = diffs.some((d) => d.incompatible.length > 0);
-  const totalIncompat = diffs.reduce((sum, d) => sum + d.incompatible.length, 0);
+  const totalIncompat = diffs.reduce(
+    (sum, d) => sum + d.incompatible.length,
+    0,
+  );
   const totalCompat = diffs.reduce((sum, d) => sum + d.compatible.length, 0);
   const modulesWithChanges = diffs.filter(
     (d) => d.incompatible.length || d.compatible.length,
   ).length;
 
   const statusEmoji = hasIncompat ? "⚠️" : "✅";
-  const statusText = hasIncompat ? "Breaking changes detected" : "No breaking changes";
+  const statusText = hasIncompat
+    ? "Breaking changes detected"
+    : "No breaking changes";
 
   s.addHeading(`${statusEmoji} API Diff Results – ${statusText}`, 2);
 
@@ -248,9 +250,15 @@ export async function formatApidiffJobSummary(
   ]);
 
   const breaking = diffs.filter((d) => d.incompatible.length);
-  const compatOnly = diffs.filter((d) => !d.incompatible.length && d.compatible.length);
+  const compatOnly = diffs.filter(
+    (d) => !d.incompatible.length && d.compatible.length,
+  );
 
-  const renderGrouped = (title: string, changes: Change[], isBreaking = false) => {
+  const renderGrouped = (
+    title: string,
+    changes: Change[],
+    isBreaking = false,
+  ) => {
     if (!changes.length) return;
     const icon = isBreaking ? "🔴" : "🟢";
     s.addHeading(`${icon} ${title} (${changes.length})`, 3);

--- a/actions/apidiff-go/src/string-processor.ts
+++ b/actions/apidiff-go/src/string-processor.ts
@@ -1,257 +1,328 @@
-const apidiffUrl = "https://pkg.go.dev/golang.org/x/exp/cmd/apidiff";
+/**
+ * This logic is best maintained by an LLM. It is a bunch
+ * of tedious string manipulation and formatting.
+ */
+import * as core from "@actions/core";
 
-interface MetaDiff {
-  /** The full header line (without the leading "! ") */
-  header: string;
-  /** The “first:” message */
-  first: string;
-  /** The “second:” message */
-  second: string;
+import { renderTwoLineDiffPre } from "./render-diff";
+import type { ApiDiffResult, Change } from "./apidiff";
+
+/* ------------------------------ Shared helpers ----------------------------- */
+
+function parseElement(element: string): {
+  packagePath: string;
+  elementName: string;
+} {
+  let path = element.startsWith("./") ? element.slice(2) : element;
+  const i = path.lastIndexOf(".");
+  if (i === -1) return { packagePath: "", elementName: path };
+  return { packagePath: path.slice(0, i), elementName: path.slice(i + 1) };
 }
 
-interface Change {
-  /** The fully-qualified API element path (e.g. "./grafana.GaugePanelOptions.Decimals") */
-  element: string;
-  /** The rest of the text after “: ” (e.g. “changed from float64 to *float64”) */
-  change: string;
-}
-
-interface ApiDiffResult {
-  moduleName: string;
-  /** “!” messages */
-  meta: MetaDiff[];
-  /** Under “Incompatible changes:” */
-  incompatible: Change[];
-  /** Under “Compatible changes:” */
-  compatible: Change[];
-}
-export function parseApidiffOutputs(
-  output: Record<string, string>,
-): ApiDiffResult[] {
-  const results: ApiDiffResult[] = [];
-
-  for (const [moduleName, moduleOutput] of Object.entries(output)) {
-    const parsed = parseApidiffOutput(moduleName, moduleOutput);
-    results.push(parsed);
+function groupByPackage(changes: Change[]): Map<string, Change[]> {
+  const m = new Map<string, Change[]>();
+  for (const c of changes) {
+    const { packagePath } = parseElement(c.element);
+    if (!m.has(packagePath)) m.set(packagePath, []);
+    m.get(packagePath)!.push(c);
   }
-
-  return results;
+  for (const list of m.values())
+    list.sort((a, b) => a.element.localeCompare(b.element));
+  return m;
 }
 
-function parseApidiffOutput(moduleName: string, output: string): ApiDiffResult {
-  const lines = output.split(/\r?\n/);
-  const result: ApiDiffResult = {
-    moduleName,
-    meta: [],
-    incompatible: [],
-    compatible: [],
-  };
-
-  let section: "meta" | "incompatible" | "compatible" | null = null;
-  let currentMeta: MetaDiff | null = null;
-
-  for (const raw of lines) {
-    const line = raw.trim();
-
-    // start of a meta-message block
-    if (line.startsWith("! ")) {
-      // if we were building one, flush previous
-      if (currentMeta) result.meta.push(currentMeta);
-      currentMeta = {
-        header: line.slice(2),
-        first: "",
-        second: "",
-      };
-      section = "meta";
-      continue;
-    }
-
-    // inside a meta block, pick up first/second lines
-    if (section === "meta" && currentMeta) {
-      if (line.startsWith("first:")) {
-        currentMeta.first = line.slice("first:".length).trim();
-        continue;
-      }
-      if (line.startsWith("second:")) {
-        currentMeta.second = line.slice("second:".length).trim();
-        continue;
-      }
-    }
-
-    // transition to incompatible bucket
-    if (line === "Incompatible changes:") {
-      if (currentMeta) {
-        result.meta.push(currentMeta);
-        currentMeta = null;
-      }
-      section = "incompatible";
-      continue;
-    }
-
-    // transition to compatible bucket
-    if (line === "Compatible changes:") {
-      section = "compatible";
-      continue;
-    }
-
-    // parse a “- ” entry in either changes section
-    if (
-      (section === "incompatible" || section === "compatible") &&
-      line.startsWith("- ")
-    ) {
-      // split on first ": "
-      const content = line.slice(2);
-      const sepIdx = content.indexOf(": ");
-      if (sepIdx >= 0) {
-        const element = content.slice(0, sepIdx);
-        const change = content.slice(sepIdx + 2);
-        const target =
-          section === "incompatible" ? result.incompatible : result.compatible;
-        target.push({ element, change });
-      }
-    }
+function formatTypeChangeMarkdown(change: string): string {
+  const m = change.match(/^changed from (.+?) to (.+)$/);
+  if (m) {
+    const [, oldType, newType] = m;
+    return "\n" + renderTwoLineDiffPre(oldType, newType); // full lines, no trimming
   }
-  // flush any trailing meta
-  if (currentMeta) result.meta.push(currentMeta);
-
-  return result;
+  if (change.startsWith("removed")) return "🗑️ Removed";
+  if (change.startsWith("added")) return "➕ Added";
+  return change.charAt(0).toUpperCase() + change.slice(1);
 }
+
+function formatTypeChangeJobSummary(change: string): string {
+  // Same diff rendering works for Job Summary (HTML is allowed there).
+  return formatTypeChangeMarkdown(change);
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/* -------------------------- GitHub COMMENT (Markdown) -------------------------- */
 
 export function formatApidiffMarkdown(
   diffs: ApiDiffResult[],
   summaryUrl: string,
-  includeFullOutput: boolean = false,
+  includeFullOutput = false,
 ): string {
   if (diffs.length === 0) {
-    return `## [apidiff](${summaryUrl}) results - no modules to analyze`;
+    return `## 📊 API Diff Results\n\n> No modules to analyze\n\n[View full report](${summaryUrl})`;
   }
 
-  // Check if any module has incompatible changes
-  const hasIncompatibleChanges = diffs.some(
-    (diff) => diff.incompatible.length > 0,
-  );
-  const totalIncompatible = diffs.reduce(
-    (sum, diff) => sum + diff.incompatible.length,
-    0,
-  );
-  const totalCompatible = diffs.reduce(
-    (sum, diff) => sum + diff.compatible.length,
-    0,
-  );
+  const hasIncompat = diffs.some((d) => d.incompatible.length > 0);
+  const totalIncompat = diffs.reduce((s, d) => s + d.incompatible.length, 0);
+  const totalCompat = diffs.reduce((s, d) => s + d.compatible.length, 0);
+  const modulesWithChanges = diffs.filter(
+    (d) => d.incompatible.length || d.compatible.length,
+  ).length;
 
-  const header = hasIncompatibleChanges
-    ? `backwards-incompatible changes detected ❌`
-    : `no incompatible changes detected ✅`;
+  const statusEmoji = hasIncompat ? "⚠️" : "✅";
+  const statusText = hasIncompat
+    ? "Breaking changes detected"
+    : "No breaking changes";
 
   const lines: string[] = [
-    `## [apidiff](${summaryUrl}) results - ${header}`,
+    `## ${statusEmoji} API Diff Results - ${statusText}`,
     ``,
   ];
 
-  // Helper to wrap types in backticks when we see "changed from ... to ..."
-  function formatChange(change: string): string {
-    const re = /^changed from (.+?) to (.+)$/;
-    const match = change.match(re);
-    if (match) {
-      const [, oldType, newType] = match;
-      return `changed from \`${oldType}\` to \`${newType}\``;
-    }
-    return change;
+  function apidiffShield(label: string, count: number, color: string) {
+    const escapedLabel = label.replace(/ /g, "_").replace(/-/g, "--");
+    return `![${label}](https://img.shields.io/badge/${escapedLabel}-${count}-${color})`;
   }
 
-  function createTable(title: string, elements: Change[]): string[] {
-    // Sort elements alphabetically by element name and deduplicate
-    const uniqueElements = Array.from(
-      new Map(
-        elements.map((item) => [`${item.element}:${item.change}`, item]),
-      ).values(),
+  if (includeFullOutput) {
+    const analyzedShield = apidiffShield(
+      "modules analyzed",
+      modulesWithChanges,
+      "blue",
     );
-    const sortedElements = uniqueElements.sort((a, b) =>
-      a.element.localeCompare(b.element),
+    const breakingShield = apidiffShield(
+      "breaking changes",
+      totalIncompat,
+      "red",
     );
-
-    const rows = sortedElements.map(({ element, change }) => {
-      const formatted = formatChange(change);
-      return `| \`${element}\` | ${formatted} |`;
-    });
-    return [
-      `#### ${title} (${sortedElements.length})`,
+    const compatibleShield = apidiffShield(
+      "compatible changes",
+      totalCompat,
+      "green",
+    );
+    lines.push(
       ``,
-      `| Element | Change |`,
-      `| ------- | ------ |`,
-      ...rows,
-    ];
+      `${analyzedShield} ${breakingShield} ${compatibleShield}`,
+      ``,
+    );
   }
 
-  // Process each module
-  for (const diff of diffs) {
-    if (
-      diff.incompatible.length === 0 &&
-      diff.compatible.length === 0 &&
-      diff.meta.length === 0
-    ) {
-      // Skip modules with no changes
-      continue;
-    }
+  function formatGroupedChanges(
+    title: string,
+    changes: Change[],
+    isBreaking = false,
+  ): string[] {
+    if (!changes.length) return [];
+    const out: string[] = [];
+    const icon = isBreaking ? "🔴" : "🟢";
+    out.push(`#### ${icon} ${title} (${changes.length})`, ``);
 
-    lines.push(`### Module: \`${diff.moduleName}\``);
-    lines.push(``);
+    const grouped = groupByPackage(changes);
+    for (const packagePath of Array.from(grouped.keys()).sort()) {
+      const packageChanges = grouped.get(packagePath)!;
 
-    // Module-specific status
-    const moduleStatus =
-      diff.incompatible.length > 0
-        ? `❌ ${diff.incompatible.length} incompatible, ${diff.compatible.length} compatible`
-        : `✅ ${diff.compatible.length} compatible changes`;
-    lines.push(`**Status:** ${moduleStatus}`);
-    lines.push(``);
-
-    // Incompatible changes for this module
-    if (diff.incompatible.length > 0) {
-      lines.push(...createTable("Incompatible Changes", diff.incompatible));
-      lines.push(``);
-    }
-
-    // Compatible changes for this module (if includeFullOutput)
-    if (diff.compatible.length > 0 && includeFullOutput) {
-      lines.push(...createTable("Compatible Changes", diff.compatible));
-      lines.push(``);
-    }
-
-    // Meta section for this module (if includeFullOutput)
-    if (diff.meta.length > 0 && includeFullOutput) {
-      lines.push(`<details>`);
-      lines.push(
-        `<summary>Meta diff messages for ${diff.moduleName}</summary>`,
+      // Plain header instead of collapsible
+      out.push(
+        `##### \`${packagePath || "(root)"}\` (${packageChanges.length})`,
+        ``,
       );
-      lines.push(``);
-      lines.push("```text");
-      for (const m of diff.meta) {
-        lines.push(`! ${m.header}`);
-        lines.push(`  first: ${m.first}`);
-        lines.push(`  second: ${m.second}`);
-        lines.push(``);
+
+      for (const change of packageChanges) {
+        const { elementName } = parseElement(change.element);
+        const formatted = formatTypeChangeMarkdown(change.change);
+        const isBlock = formatted.startsWith("\n<pre>");
+        if (isBlock) {
+          out.push(`- **\`${elementName}\`** — Type changed:`);
+          out.push(formatted);
+        } else {
+          out.push(`- **\`${elementName}\`** — ${formatted}`);
+        }
+        out.push(``);
       }
-      if (lines[lines.length - 1] === "") {
-        lines.pop();
-      }
-      lines.push("```");
-      lines.push(`</details>`);
-      lines.push(``);
+    }
+    return out;
+  }
+
+  const breaking = diffs.filter((d) => d.incompatible.length);
+  const compatOnly = diffs.filter(
+    (d) => !d.incompatible.length && d.compatible.length,
+  );
+
+  if (breaking.length) {
+    if (includeFullOutput) {
+      lines.push(`---`, ``, `## ⚠️ Modules with Breaking Changes`, ``);
     }
 
-    lines.push(`---`);
-    lines.push(``);
+    for (const d of breaking) {
+      lines.push(`### 📦 Module: \`${d.moduleName}\``, ``);
+      lines.push(
+        ...formatGroupedChanges("Breaking Changes", d.incompatible, true),
+      );
+
+      if (includeFullOutput && d.compatible.length) {
+        lines.push(
+          ...formatGroupedChanges("Compatible Changes", d.compatible, false),
+        );
+      }
+
+      if (includeFullOutput && d.meta.length) {
+        lines.push(`#### 📋 Metadata (${d.meta.length})`, ``);
+        lines.push("```diff");
+        for (const m of d.meta) {
+          lines.push(`! ${m.header}`);
+          lines.push(`  first:  ${m.first}`);
+          lines.push(`  second: ${m.second}`);
+          lines.push("");
+        }
+        lines.push("```", ``);
+      }
+    }
   }
 
-  // Remove trailing separator
-  if (lines[lines.length - 2] === "---") {
-    lines.splice(-2, 2);
+  if (includeFullOutput && compatOnly.length) {
+    lines.push(`---`, ``, `## ✅ Modules with Only Compatible Changes`, ``);
+    for (const d of compatOnly) {
+      lines.push(`### 📦 ${d.moduleName} (${d.compatible.length})`, ``);
+      lines.push(
+        ...formatGroupedChanges("Compatible Changes", d.compatible, false),
+      );
+    }
   }
 
-  if (summaryUrl) {
-    lines.push(`*(Full summary: [${summaryUrl}](${summaryUrl}))*`);
-    lines.push(``);
-  }
-
+  lines.push(
+    `---`,
+    ``,
+    `📄 [View full apidiff report](${summaryUrl})`,
+    ``,
+  );
   return lines.join("\n");
+}
+
+/* ---------------------- GitHub ACTIONS JOB SUMMARY (HTML+) --------------------- */
+
+/**
+ * Writes a Job Summary (Markdown + HTML allowed) using @actions/core.summary.
+ */
+export async function formatApidiffJobSummary(
+  diffs: ApiDiffResult[],
+): Promise<void> {
+  const s = core.summary;
+
+  if (!diffs.length) {
+    s.addHeading("📊 API Diff Results", 2)
+      .addRaw("<blockquote>No modules to analyze</blockquote>", true)
+    await s.write();
+    return;
+  }
+
+  const hasIncompat = diffs.some((d) => d.incompatible.length > 0);
+  const totalIncompat = diffs.reduce((sum, d) => sum + d.incompatible.length, 0);
+  const totalCompat = diffs.reduce((sum, d) => sum + d.compatible.length, 0);
+  const modulesWithChanges = diffs.filter(
+    (d) => d.incompatible.length || d.compatible.length,
+  ).length;
+
+  const statusEmoji = hasIncompat ? "⚠️" : "✅";
+  const statusText = hasIncompat ? "Breaking changes detected" : "No breaking changes";
+
+  s.addHeading(`${statusEmoji} API Diff Results – ${statusText}`, 2);
+
+  // Top summary table
+  s.addTable([
+    [
+      { data: "Metric", header: true },
+      { data: "Count", header: true },
+    ],
+    [
+      { data: "Modules analyzed" },
+      { data: `<div align="right">${modulesWithChanges}</div>` },
+    ],
+    [
+      { data: "Breaking changes" },
+      { data: `<div align="right">${totalIncompat}</div>` },
+    ],
+    [
+      { data: "Compatible changes" },
+      { data: `<div align="right">${totalCompat}</div>` },
+    ],
+  ]);
+
+  const breaking = diffs.filter((d) => d.incompatible.length);
+  const compatOnly = diffs.filter((d) => !d.incompatible.length && d.compatible.length);
+
+  const renderGrouped = (title: string, changes: Change[], isBreaking = false) => {
+    if (!changes.length) return;
+    const icon = isBreaking ? "🔴" : "🟢";
+    s.addHeading(`${icon} ${title} (${changes.length})`, 3);
+
+    const grouped = groupByPackage(changes);
+    for (const packagePath of Array.from(grouped.keys()).sort()) {
+      const pkg = packagePath || "(root)";
+      const list = grouped.get(packagePath)!;
+
+      s.addHeading(`📦 ${pkg} (${list.length})`, 4);
+      s.addRaw("<ul>", true);
+
+      for (const change of list) {
+        const { elementName } = parseElement(change.element);
+        const formatted = formatTypeChangeJobSummary(change.change);
+        const isBlock = formatted.startsWith("\n<pre>");
+        if (isBlock) {
+          s.addRaw(
+            `<li><strong><code>${elementName}</code></strong> — Type changed:${formatted}</li>`,
+            true,
+          );
+        } else {
+          s.addRaw(
+            `<li><strong><code>${elementName}</code></strong> — ${formatted}</li>`,
+            true,
+          );
+        }
+      }
+
+      s.addRaw("</ul></details>", true);
+    }
+  };
+
+  // Breaking section
+  if (breaking.length) {
+    s.addSeparator();
+    s.addHeading("⚠️ Modules with Breaking Changes", 2);
+    for (const d of breaking) {
+      s.addHeading(`📦 ${d.moduleName}`, 3);
+      renderGrouped("Breaking Changes", d.incompatible, true);
+
+      if (d.compatible.length) {
+        renderGrouped("Compatible Changes", d.compatible, false);
+      }
+
+      if (d.meta.length) {
+        s.addHeading(`📋 Metadata (${d.meta.length})`, 4);
+        s.addTable([
+          [
+            { data: "Header", header: true },
+            { data: "First", header: true },
+            { data: "Second", header: true },
+          ],
+          ...d.meta.map((m) => [
+            { data: `<code>${escapeHtml(m.header)}</code>` },
+            { data: escapeHtml(m.first) },
+            { data: escapeHtml(m.second) },
+          ]),
+        ]);
+      }
+    }
+  }
+
+  // Compatible-only section
+  if (compatOnly.length) {
+    s.addSeparator();
+    s.addHeading("✅ Modules with Only Compatible Changes", 2);
+    for (const d of compatOnly) {
+      s.addHeading(`📦 ${d.moduleName} (${d.compatible.length})`, 3);
+      renderGrouped("Compatible Changes", d.compatible, false);
+    }
+  }
+
+  await s.write();
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       '@actions/glob':
         specifier: ^0.4.0
         version: 0.4.0
+      diff:
+        specifier: ^8.0.2
+        version: 8.0.2
       execa:
         specifier: ^9.6.0
         version: 9.6.0
@@ -4097,6 +4100,10 @@ packages:
 
   diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
+
+  diff@8.0.2:
+    resolution: {integrity: sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==}
     engines: {node: '>=0.3.1'}
 
   dir-glob@2.2.2:
@@ -10949,6 +10956,54 @@ snapshots:
     optionalDependencies:
       vite: 5.4.19(@types/node@20.14.13)
 
+  '@vitest/mocker@2.1.9(vite@5.4.19(@types/node@20.14.9))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 5.4.19(@types/node@20.14.9)
+
+  '@vitest/mocker@2.1.9(vite@5.4.19(@types/node@20.16.5))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 5.4.19(@types/node@20.16.5)
+
+  '@vitest/mocker@2.1.9(vite@5.4.19(@types/node@20.17.57))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 5.4.19(@types/node@20.17.57)
+
+  '@vitest/mocker@2.1.9(vite@5.4.19(@types/node@24.2.1))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 5.4.19(@types/node@24.2.1)
+
+  '@vitest/mocker@2.1.9(vite@5.4.19(@types/node@24.3.0))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 5.4.19(@types/node@24.3.0)
+
+  '@vitest/mocker@2.1.9(vite@5.4.19(@types/node@24.3.1))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 5.4.19(@types/node@24.3.1)
+
   '@vitest/pretty-format@2.1.9':
     dependencies:
       tinyrainbow: 1.2.0
@@ -11740,6 +11795,8 @@ snapshots:
   diff-sequences@29.6.3: {}
 
   diff@4.0.2: {}
+
+  diff@8.0.2: {}
 
   dir-glob@2.2.2:
     dependencies:
@@ -15028,7 +15085,7 @@ snapshots:
   vitest@2.1.9(@types/node@20.14.9)(jsdom@24.1.0):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.19(@types/node@20.14.13))
+      '@vitest/mocker': 2.1.9(vite@5.4.19(@types/node@20.14.9))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -15064,7 +15121,7 @@ snapshots:
   vitest@2.1.9(@types/node@20.16.5)(jsdom@24.1.0):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.19(@types/node@20.14.13))
+      '@vitest/mocker': 2.1.9(vite@5.4.19(@types/node@20.16.5))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -15100,7 +15157,7 @@ snapshots:
   vitest@2.1.9(@types/node@20.17.57)(jsdom@24.1.0):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.19(@types/node@20.14.13))
+      '@vitest/mocker': 2.1.9(vite@5.4.19(@types/node@20.17.57))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -15136,7 +15193,7 @@ snapshots:
   vitest@2.1.9(@types/node@24.2.1)(jsdom@24.1.0):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.19(@types/node@20.14.13))
+      '@vitest/mocker': 2.1.9(vite@5.4.19(@types/node@24.2.1))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -15172,7 +15229,7 @@ snapshots:
   vitest@2.1.9(@types/node@24.3.0)(jsdom@24.1.0):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.19(@types/node@20.14.13))
+      '@vitest/mocker': 2.1.9(vite@5.4.19(@types/node@24.3.0))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -15208,7 +15265,7 @@ snapshots:
   vitest@2.1.9(@types/node@24.3.1)(jsdom@24.1.0):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.19(@types/node@20.14.13))
+      '@vitest/mocker': 2.1.9(vite@5.4.19(@types/node@24.3.1))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9


### PR DESCRIPTION
### Changes

* Adds `post-comment` input to toggle whether to post a comment. This is mostly a local run debug parameter
* Refactor output formatting with better diff displaying support
    * Most of this logic is contained in `render-diff.ts`
* Moves apidiff output parsing to `apidiff.ts` was previously in `string-processing.ts`

### Testing

I've tested locally against a fee PRs

---

DX-1961