### PR TITLE
chore: make devex-cicd default codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @smartcontractkit/devex
+* @smartcontractkit/devex-cicd
 
 /.github/workflows/reusable-docker-build-publish.yml @smartcontractkit/devex-cicd
 /actions/dependency-review/ @smartcontractkit/devex-cicd


### PR DESCRIPTION
### Changes

* make `devex-cicd` default codeowner for this repo. many of the `devex-tooling` guys get requested/pinged without much context