### PR TITLE
fix: run-e2e-tests quarantine logic

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -836,7 +836,7 @@ jobs:
         id: run_tests
         timeout-minutes: ${{ matrix.tests.timeout_minutes || inputs.test-timeout-minutes }}
         uses: smartcontractkit/.github/actions/ctf-run-tests@ctf-run-tests/0.11.0
-        continue-on-error: ${{ inputs.quarantine == 'true' }} # auto-quarantine will handle result
+        continue-on-error: ${{ inputs.quarantine }} # auto-quarantine will handle result
         env:
           DETACH_RUNNER: true
           RUN_QUARANTINED_TESTS: "true" # always run quarantined tests in CI
@@ -899,20 +899,18 @@ jobs:
         # This fails the job if there is no junit report and the test step did not succeed.
         # If there is no report then the branch-out-upload step will not be able to properly
         # determine the test result, so we need to fail the job here instead.
-        if: ${{ !cancelled() && inputs.quarantine == 'true' }}
+        if: ${{ !cancelled() && inputs.quarantine }}
         shell: bash
         env:
           RESULT: ${{ steps.run_tests.outcome }}
         run: |
-          if [ -f /tmp/junit.xml ]; then
-            echo "junit_exists=true" | tee -a "$GITHUB_OUTPUT"
-          else
+          if [ ! -f /tmp/junit.xml ]; then
             echo "::error::Junit report not found, and run_tests outcome is $RESULT. Failing the job."
             exit 1
           fi
 
       - name: Run branch-out-upload (quarantine only)
-        if: ${{ !cancelled() && steps.check-junit.outputs.junit_exists == 'true' }}
+        if: ${{ !cancelled() && inputs.quarantine }}
         uses: smartcontractkit/.github/actions/branch-out-upload@branch-out-upload/0.1.0
         with:
           junit-file-path: "/tmp/junit.xml"
@@ -1145,7 +1143,7 @@ jobs:
         id: run_tests
         timeout-minutes: ${{ matrix.tests.timeout_minutes || inputs.test-timeout-minutes }}
         uses: smartcontractkit/.github/actions/ctf-run-tests@ctf-run-tests/0.11.0
-        continue-on-error: ${{ inputs.quarantine == 'true' }} # auto-quarantine will handle result
+        continue-on-error: ${{ inputs.quarantine }} # auto-quarantine will handle result
         env:
           DETACH_RUNNER: true
           RUN_QUARANTINED_TESTS: "true" # always run quarantined tests in CI
@@ -1199,20 +1197,18 @@ jobs:
         # This fails the job if there is no junit report and the test step did not succeed.
         # If there is no report then the branch-out-upload step will not be able to properly
         # determine the test result, so we need to fail the job here instead.
-        if: ${{ !cancelled() && inputs.quarantine == 'true' }}
+        if: ${{ !cancelled() && inputs.quarantine }}
         shell: bash
         env:
           RESULT: ${{ steps.run_tests.outcome }}
         run: |
-          if [ -f /tmp/junit.xml ]; then
-            echo "junit_exists=true" | tee -a "$GITHUB_OUTPUT"
-          else
+          if [ ! -f /tmp/junit.xml ]; then
             echo "::error::Junit report not found, and run_tests outcome is $RESULT. Failing the job."
             exit 1
           fi
 
       - name: Run branch-out-upload (quarantine only)
-        if: ${{ !cancelled() && steps.check-junit.outputs.junit_exists == 'true' }}
+        if: ${{ !cancelled() && inputs.quarantine }}
         uses: smartcontractkit/.github/actions/branch-out-upload@branch-out-upload/0.1.0
         with:
           junit-file-path: "/tmp/junit.xml"


### PR DESCRIPTION
### Changes

* Fix usages of `inputs.quarantine` as it's a boolean, and string comparison result in `false`
* Simplify quarantine step logic a bit
