### PR TITLE
Enable publishing docker images on releases

### DIFF
--- a/.github/workflows/reusable-docker-build-publish.yml
+++ b/.github/workflows/reusable-docker-build-publish.yml
@@ -220,6 +220,7 @@ on:
           Examples:
             - pull_request
             - push
+            - release
             - schedule
         required: true
         type: string
@@ -350,6 +351,8 @@ jobs:
             echo "build-type=pr" | tee -a "$GITHUB_OUTPUT"
           elif [[ "${GITHUB_EVENT_NAME}" == 'workflow_dispatch' ]]; then
             echo "build-type=manual" | tee -a "$GITHUB_OUTPUT"
+          elif [[ "${GITHUB_EVENT_NAME}" == 'release' ]]; then
+            echo "build-type=tag" | tee -a "$GITHUB_OUTPUT"
           else
             echo "::error::Unsupported GitHub event name: ${GITHUB_EVENT_NAME}"
             exit 1


### PR DESCRIPTION
This PR enables GHA workflows to build and publish docker images based on the `release` type event as well. For example, in the `rpc-monitor` repository, we create new releases when we want to deploy new production images.

I've tested this workflow in this [PR](https://github.com/smartcontractkit/rpc-monitor/pull/49) and everything looks good ([actions](https://github.com/smartcontractkit/rpc-monitor/actions/runs/18277236825)).

<img width="1066" height="307" alt="image" src="https://github.com/user-attachments/assets/8c56365d-c557-4b2b-9047-b7023905e27e" />

https://smartcontract-it.atlassian.net/browse/BCY-2328
