### PR TITLE
fix: run-e2e-tests quarantine input

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -177,8 +177,8 @@ on:
       quarantine:
         description: "Set to true to enable auto-quaranting functionality"
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: "false"
       test-timeout-minutes:
         description: "Overall timeout for each test in minutes. Default is 180 minutes."
         required: false
@@ -836,7 +836,7 @@ jobs:
         id: run_tests
         timeout-minutes: ${{ matrix.tests.timeout_minutes || inputs.test-timeout-minutes }}
         uses: smartcontractkit/.github/actions/ctf-run-tests@ctf-run-tests/0.11.0
-        continue-on-error: ${{ inputs.quarantine }} # auto-quarantine will handle result
+        continue-on-error: ${{ inputs.quarantine == 'true' }} # auto-quarantine will handle result
         env:
           DETACH_RUNNER: true
           RUN_QUARANTINED_TESTS: "true" # always run quarantined tests in CI
@@ -899,7 +899,7 @@ jobs:
         # This fails the job if there is no junit report and the test step did not succeed.
         # If there is no report then the branch-out-upload step will not be able to properly
         # determine the test result, so we need to fail the job here instead.
-        if: ${{ !cancelled() && inputs.quarantine }}
+        if: ${{ !cancelled() && inputs.quarantine == 'true' }}
         shell: bash
         env:
           RESULT: ${{ steps.run_tests.outcome }}
@@ -910,7 +910,7 @@ jobs:
           fi
 
       - name: Run branch-out-upload (quarantine only)
-        if: ${{ !cancelled() && inputs.quarantine }}
+        if: ${{ !cancelled() && inputs.quarantine == 'true' }}
         uses: smartcontractkit/.github/actions/branch-out-upload@branch-out-upload/0.1.0
         with:
           junit-file-path: "/tmp/junit.xml"
@@ -1143,7 +1143,7 @@ jobs:
         id: run_tests
         timeout-minutes: ${{ matrix.tests.timeout_minutes || inputs.test-timeout-minutes }}
         uses: smartcontractkit/.github/actions/ctf-run-tests@ctf-run-tests/0.11.0
-        continue-on-error: ${{ inputs.quarantine }} # auto-quarantine will handle result
+        continue-on-error: ${{ inputs.quarantine == 'true' }} # auto-quarantine will handle result
         env:
           DETACH_RUNNER: true
           RUN_QUARANTINED_TESTS: "true" # always run quarantined tests in CI
@@ -1197,7 +1197,7 @@ jobs:
         # This fails the job if there is no junit report and the test step did not succeed.
         # If there is no report then the branch-out-upload step will not be able to properly
         # determine the test result, so we need to fail the job here instead.
-        if: ${{ !cancelled() && inputs.quarantine }}
+        if: ${{ !cancelled() && inputs.quarantine == 'true' }}
         shell: bash
         env:
           RESULT: ${{ steps.run_tests.outcome }}
@@ -1208,7 +1208,7 @@ jobs:
           fi
 
       - name: Run branch-out-upload (quarantine only)
-        if: ${{ !cancelled() && inputs.quarantine }}
+        if: ${{ !cancelled() && inputs.quarantine == 'true' }}
         uses: smartcontractkit/.github/actions/branch-out-upload@branch-out-upload/0.1.0
         with:
           junit-file-path: "/tmp/junit.xml"


### PR DESCRIPTION
Boolean input is not working properly. For example:

https://github.com/smartcontractkit/chainlink/actions/runs/18288873501/job/52071081479

```
Error: The step failed and an error occurred when attempting to determine whether to continue on error.
Error: The template is not valid. smartcontractkit/.github/.github/workflows/run-e2e-tests.yml@e77c336588c4642a825e13b35f381dccfa6a928a (Line: 839, Col: 28): Unexpected value ''
```

