### PR TITLE
chore: bump some action deps to node24 versions

### DIFF
--- a/.changeset/witty-timers-tell.md
+++ b/.changeset/witty-timers-tell.md
@@ -1,0 +1,16 @@
+---
+"cicd-build-publish-artifacts-go": minor
+"ctf-setup-run-tests-environment": minor
+"build-push-docker-manifest": minor
+"chip-schema-registration": minor
+"crib-deploy-environment": minor
+"pull-private-ecr-image": minor
+"ci-beholder-validator": minor
+"k8s-tailscale-connect": minor
+"docker-image-patch": minor
+"build-push-docker": minor
+"promote-image-ecr": minor
+"ecr-image-exists": minor
+---
+
+chore: bump some action dependencies to node24 version

--- a/actions/build-push-docker-manifest/action.yml
+++ b/actions/build-push-docker-manifest/action.yml
@@ -178,7 +178,7 @@ runs:
 
     - name: Login to ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+      uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
       with:
         registry-type: >-
           ${{

--- a/actions/build-push-docker/action.yml
+++ b/actions/build-push-docker/action.yml
@@ -203,14 +203,14 @@ runs:
 
     - name: Login to private ECR registries for base images
       if: ${{ steps.dockerfile-ecr-parse.outputs.needs-ecr-login == 'true' }}
-      uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896 # v2.1.1
+      uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
       with:
         registries: ${{ steps.dockerfile-ecr-parse.outputs.ecr-registries }}
 
     - name: Login to ECR for publishing
       if: ${{ inputs.docker-push == 'true' }}
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896 # v2.1.1
+      uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
       with:
         registry-type: >-
           ${{

--- a/actions/chip-schema-registration/action.yml
+++ b/actions/chip-schema-registration/action.yml
@@ -47,7 +47,7 @@ runs:
     - uses: actions/checkout@v6
 
     - name: Login to ECR
-      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+      uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
       with:
         registries: ${{ inputs.aws-account-id }}
 
@@ -61,7 +61,7 @@ runs:
         docker tag $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/atlas-chip-cli:qa-latest chip-cli
 
     - name: Connect to Tailscale
-      uses: tailscale/github-action@84a3f23bb4d843bcf4da6cf824ec1be473daf4de
+      uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
       with:
         oauth-client-id: ${{ inputs.ts-ouath-client-id }}
         oauth-secret: ${{ inputs.ts-ouath-secret }}

--- a/actions/ci-beholder-validator/action.yml
+++ b/actions/ci-beholder-validator/action.yml
@@ -71,7 +71,7 @@ runs:
 
     - name: Login to aws ecr
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+      uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
       with:
         registries: ${{ inputs.aws-account-number }}
 

--- a/actions/cicd-build-publish-artifacts-go/action.yml
+++ b/actions/cicd-build-publish-artifacts-go/action.yml
@@ -174,7 +174,7 @@ runs:
 
     - name: Login to aws ecr
       if: inputs.publish == 'true' && inputs.docker-registry == 'aws'
-      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+      uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
       with:
         registries: ${{ steps.process-params.outputs.aws-account-number }}
 

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -232,7 +232,7 @@ runs:
           cli: './cli/**'
 
     - name: Login to AWS ECR for Helm
-      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+      uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
       env:
         AWS_REGION: ${{ inputs.aws-region }}
       with:

--- a/actions/ctf-setup-run-tests-environment/action.yml
+++ b/actions/ctf-setup-run-tests-environment/action.yml
@@ -220,7 +220,7 @@ runs:
     - name: Login to Amazon ECR
       if: inputs.aws_registries && inputs.QA_AWS_REGION
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+      uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
       with:
         registries: ${{ inputs.aws_registries }}
       env:

--- a/actions/docker-image-patch/action.yml
+++ b/actions/docker-image-patch/action.yml
@@ -138,7 +138,7 @@ runs:
 
     - name: Login to ECR for source image
       id: login-ecr-src
-      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+      uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
       env:
         AWS_REGION: ${{ steps.set-outputs.outputs.registry-src-type == 'public' && 'us-east-1' || inputs.aws-region }}
       with:
@@ -175,7 +175,7 @@ runs:
 
     - name: Login to ECR for destination image
       id: login-ecr-dst
-      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+      uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
       env:
         AWS_REGION: ${{ inputs.aws-region }}
       with:

--- a/actions/ecr-image-exists/action.yml
+++ b/actions/ecr-image-exists/action.yml
@@ -42,7 +42,7 @@ runs:
 
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+      uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
       with:
         mask-password: "true"
 

--- a/actions/k8s-tailscale-connect/action.yml
+++ b/actions/k8s-tailscale-connect/action.yml
@@ -31,8 +31,7 @@ runs:
   using: "composite"
   steps:
     - name: Connect to Tailscale
-      # v3
-      uses: tailscale/github-action@84a3f23bb4d843bcf4da6cf824ec1be473daf4de
+      uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
       with:
         oauth-client-id: ${{ inputs.tailscale-oauth-client-id }}
         oauth-secret: ${{ inputs.tailscale-oauth-secret }}

--- a/actions/promote-image-ecr/action.yaml
+++ b/actions/promote-image-ecr/action.yaml
@@ -90,7 +90,7 @@ runs:
 
     - name: Login to Amazon ECR (SOURCE)
       id: src
-      uses: aws-actions/amazon-ecr-login@v2
+      uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
 
     - name: Configure AWS credentials (DESTINATION)
       uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
@@ -100,7 +100,7 @@ runs:
 
     - name: Login to Amazon ECR (DESTINATION)
       id: dst
-      uses: aws-actions/amazon-ecr-login@v2
+      uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
 
     - name: Copy image
       shell: bash

--- a/actions/pull-private-ecr-image/action.yml
+++ b/actions/pull-private-ecr-image/action.yml
@@ -76,7 +76,7 @@ runs:
         mask-aws-account-id: true
 
     - name: Login to Amazon ECR
-      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+      uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
       with:
         registries: ${{ inputs.aws-account-number }}
 


### PR DESCRIPTION
* Bumps `aws-actions/amazon-ecr-login` to `v2.1.2` (node24)
* Bumps `tailscale/github-action` to `v4.1.2` (node24)
* Minor bump for all affected actions

---

DX-3420