### PR TITLE
fix(branch-out-upload): add artifact-name input to prevent 409 collision in parallel matrix jobs

### DIFF
--- a/.changeset/brave-donuts-flow.md
+++ b/.changeset/brave-donuts-flow.md
@@ -1,0 +1,5 @@
+---
+"branch-out-upload": patch
+---
+
+Add artifact-name input to prevent 409 collision when multiple matrix jobs upload test logs in the same workflow run

--- a/actions/branch-out-upload/action.yml
+++ b/actions/branch-out-upload/action.yml
@@ -60,6 +60,13 @@ inputs:
       run in different environments (e.g., OSes, browsers, DON topologies).
     required: false
 
+  artifact-name:
+    description: |
+      Name for the uploaded test logs artifact. Override when multiple jobs in
+      the same workflow run use this action to avoid a 409 name collision.
+    required: false
+    default: "individual_test_logs"
+
 runs:
   using: composite
   steps:
@@ -212,6 +219,6 @@ runs:
       if: ${{ failure() && steps.inputs-ext.outputs.run-enhancer == 'true' }}
       uses: actions/upload-artifact@v7
       with:
-        name: individual_test_logs
+        name: ${{ inputs.artifact-name }}
         path: "${{ steps.inputs-ext.outputs.junit-dir }}/raw-test-logs/"
         retention-days: 10


### PR DESCRIPTION
## Summary

- Adds an `artifact-name` input (default: `individual_test_logs`) to the `branch-out-upload` action
- Replaces the hardcoded artifact name with `${{ inputs.artifact-name }}` in the upload step

## Problem

When multiple matrix jobs with `trunk-auto-quarantine: true` fail in the same workflow run, each calls `branch-out-upload` which unconditionally uploads an artifact named `individual_test_logs`. The second job gets a 409 conflict, meaning its diagnostic artifacts are lost.

Observed on `smartcontractkit/chainlink` where `go_core_tests`, `go_core_tests_integration`, and `go_core_ccip_deployment_tests` can collide on the same artifact name.

Note: the upload step only runs under the `failure()` condition, so this does not cause passing jobs to fail — but it does mean we lose test logs from all but the first failing matrix job, making debugging harder.

## Fix

Callers can now pass a unique name per job:
```yaml
artifact-name: ${{ matrix.type.cmd }}_test_logs
```

Backwards compatible — defaults to `individual_test_logs` if not set.

## Related

- Tracked in smartcontractkit/chainlink CORE-2418