### PR TITLE
chore: version workflow reusable-stale-prs-issues

### DIFF
--- a/.changeset/fresh-queens-buy.md
+++ b/.changeset/fresh-queens-buy.md
@@ -1,0 +1,5 @@
+---
+"reusable-stale-prs-issues": major
+---
+
+Initial versioned release, no changes from latest

--- a/workflows/reusable-stale-prs-issues/CHANGELOG.md
+++ b/workflows/reusable-stale-prs-issues/CHANGELOG.md
@@ -1,0 +1,1 @@
+# reusable-stale-prs-issues

--- a/workflows/reusable-stale-prs-issues/README.md
+++ b/workflows/reusable-stale-prs-issues/README.md
@@ -1,0 +1,32 @@
+# Reusable Stale PRs/Issues
+
+This workflow analyzes pull requests and issues to identify and close stale ones
+that have not had any activity for a specified period. It will first add a stale
+label to the issue or PR, and if there is still no activity after a specified
+duration, it will close the issue or PR. It can also delete the branch if the PR
+is closed.
+
+It should be run on a nightly schedule. It's a thin wrapper with defaults set
+for https://github.com/actions/stale.
+
+## Usage
+
+```yaml
+name: Manage stale Issues and PRs
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Will be triggered every day at midnight UTC
+  jobs:
+    permissions:
+      actions: write
+      contents: write
+      issues: write
+      pull-requests: write
+    stale-prs:
+      uses: smartcontractkit/.github/.github/workflows/reusable-stale-prs-issues.yml@<ref>
+      with:
+        days-before-pr-stale: 30 # Optional, default value is "30"
+      secrets:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```

--- a/workflows/reusable-stale-prs-issues/package.json
+++ b/workflows/reusable-stale-prs-issues/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "reusable-stale-prs-issues",
+  "version": "0.0.0",
+  "description": "",
+  "private": true,
+  "scripts": {},
+  "keywords": [],
+  "author": "@smartcontractkit",
+  "license": "MIT",
+  "packageManager": "pnpm@10.29.3"
+}

--- a/workflows/reusable-stale-prs-issues/reusable-stale-prs-issues.yml
+++ b/workflows/reusable-stale-prs-issues/reusable-stale-prs-issues.yml
@@ -1,7 +1,3 @@
-# GENERATED FILE - DO NOT EDIT DIRECTLY.
-# Source: workflows/reusable-stale-prs-issues/reusable-stale-prs-issues.yml
-# Edit the source under workflows/, then regenerate.
-
 name: Reusable Stale PRs and Stale Issues
 
 # This workflow analyzes pull requests and issues to identify and close stale ones that have not had any activity for


### PR DESCRIPTION
This sets up versioning for the `reusable-stale-prs-issues` reusable workflow.

More information on #1448.

### Changes

* Boilerplate for the workflow
* `pnpm workflows:fix`
* Add changeset

---

DX-3229