### PR TITLE
feat: apidiff-go reusable workflow

### DIFF
--- a/.changeset/bright-turtles-exercise.md
+++ b/.changeset/bright-turtles-exercise.md
@@ -1,0 +1,5 @@
+---
+"reusable-apidiff-go-analysis": major
+---
+
+initial release

--- a/.github/workflows/reusable-apidiff-go-analysis.yml
+++ b/.github/workflows/reusable-apidiff-go-analysis.yml
@@ -74,7 +74,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: ${{ matrix.module }}/go.mod
           cache: false

--- a/.github/workflows/reusable-apidiff-go-analysis.yml
+++ b/.github/workflows/reusable-apidiff-go-analysis.yml
@@ -1,0 +1,86 @@
+# GENERATED FILE - DO NOT EDIT DIRECTLY.
+# Source: workflows/reusable-apidiff-go-analysis/reusable-apidiff-go-analysis.yml
+# Edit the source under workflows/, then regenerate.
+
+name: Reusable apidiff-go Analysis
+
+on:
+  workflow_call:
+    inputs:
+      file-patterns:
+        description: 'File patterns to determine changed modules (newline separated)'
+        required: false # defaulted
+        type: string
+        default: |
+          **/*.go
+          **/go.mod
+          **/go.sum
+
+      module-patterns:
+        description: |
+          Module patterns to determine changed modules (newline separated)
+            - Prefix with "!" to exclude patterns
+        required: false # defaulted
+        type: string
+        default: |
+          **
+
+      enforce-compatible:
+        description: 'Whether to enforce compatibility (breaking changes will cause the workflow to fail)'
+        required: false # defaulted
+        type: boolean
+        default: false
+
+permissions: {}
+
+jobs:
+  changed-modules:
+    name: Determine Changed Modules
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      modules-json: ${{ steps.changed-modules.outputs.modules-json }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Changed modules
+        id: changed-modules
+        uses: smartcontractkit/.github/actions/changed-modules-go@changed-modules-go/v1
+        with:
+          file-patterns: ${{ inputs.file-patterns }}
+          module-patterns: ${{ inputs.module-patterns }}
+
+  analyze-api-changes:
+    if: ${{ needs.changed-modules.outputs.modules-json != '[]' }}
+    name: Analyze (${{ matrix.module }})
+    runs-on: ubuntu-latest
+    needs: changed-modules
+    permissions:
+      pull-requests: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        module: ${{ fromJson(needs.changed-modules.outputs.modules-json) }}
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: ${{ matrix.module }}/go.mod
+          cache: false
+
+      - uses: smartcontractkit/.github/actions/apidiff-go@apidiff-go/v2
+        with:
+          module-directory: ${{ matrix.module }}
+          enforce-compatible: ${{ inputs.enforce-compatible }}
+          post-comment: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -901,9 +901,17 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@25.5.0)(jiti@2.6.1)(jsdom@24.1.0)(tsx@4.19.1)(yaml@2.8.2)
 
+  workflows/reusable-apidiff-go-analysis: {}
+
   workflows/reusable-codeowners-review-analysis: {}
 
+  workflows/reusable-dependency-review: {}
+
   workflows/reusable-docker-build-publish: {}
+
+  workflows/reusable-stale-prs-issues: {}
+
+  workflows/run-e2e-tests: {}
 
 packages:
 

--- a/workflows/reusable-apidiff-go-analysis/CHANGELOG.md
+++ b/workflows/reusable-apidiff-go-analysis/CHANGELOG.md
@@ -1,0 +1,1 @@
+# reusable-apidiff-go-analysis

--- a/workflows/reusable-apidiff-go-analysis/README.md
+++ b/workflows/reusable-apidiff-go-analysis/README.md
@@ -1,0 +1,42 @@
+# Reusable apidiff-go analysis
+
+A simple reusable workflow wrapper around the `apidiff-go` resuable Github
+Action for conditional api analysis on a per-module basis.
+
+- https://github.com/smartcontractkit/.github/tree/main/actions/apidiff-go
+
+## Usage
+
+### Inputs
+
+Inputs are passed directly to the associated action, see that actions
+documentation for more details.
+
+- `file-patterns`, `module-patterns` - see
+  [`changed-modules-go`](https://github.com/smartcontractkit/.github/tree/main/actions/changed-modules-go)
+- ``enforce-compatible` - see
+  [`apidiff-go`](https://github.com/smartcontractkit/.github/tree/main/actions/apidiff-go)
+
+```yaml
+name: Analyze API Changes
+
+on:
+  pull_request: {}
+
+permissions: {}
+
+jobs:
+  analysis:
+    uses: smartcontractkit/.github/.github/workflows/reusable-apidiff-go-analysis@<ref>
+    permissions:
+      pull-requests: write
+      contents: read
+    with: # note: showing default values of inputs
+      file-patterns: |
+        **/*.go
+        **/go.mod
+        **/go.sum
+      module-patterns: |
+        **
+      enforce-compatible: false
+```

--- a/workflows/reusable-apidiff-go-analysis/package.json
+++ b/workflows/reusable-apidiff-go-analysis/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "reusable-apidiff-go-analysis",
+  "version": "0.0.0",
+  "description": "",
+  "private": true,
+  "scripts": {},
+  "keywords": [],
+  "author": "@smartcontractkit",
+  "license": "MIT",
+  "packageManager": "pnpm@10.29.3"
+}

--- a/workflows/reusable-apidiff-go-analysis/reusable-apidiff-go-analysis.yml
+++ b/workflows/reusable-apidiff-go-analysis/reusable-apidiff-go-analysis.yml
@@ -1,0 +1,82 @@
+name: Reusable apidiff-go Analysis
+
+on:
+  workflow_call:
+    inputs:
+      file-patterns:
+        description: 'File patterns to determine changed modules (newline separated)'
+        required: false # defaulted
+        type: string
+        default: |
+          **/*.go
+          **/go.mod
+          **/go.sum
+
+      module-patterns:
+        description: |
+          Module patterns to determine changed modules (newline separated)
+            - Prefix with "!" to exclude patterns
+        required: false # defaulted
+        type: string
+        default: |
+          **
+
+      enforce-compatible:
+        description: 'Whether to enforce compatibility (breaking changes will cause the workflow to fail)'
+        required: false # defaulted
+        type: boolean
+        default: false
+
+permissions: {}
+
+jobs:
+  changed-modules:
+    name: Determine Changed Modules
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      modules-json: ${{ steps.changed-modules.outputs.modules-json }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Changed modules
+        id: changed-modules
+        uses: smartcontractkit/.github/actions/changed-modules-go@changed-modules-go/v1
+        with:
+          file-patterns: ${{ inputs.file-patterns }}
+          module-patterns: ${{ inputs.module-patterns }}
+
+  analyze-api-changes:
+    if: ${{ needs.changed-modules.outputs.modules-json != '[]' }}
+    name: Analyze (${{ matrix.module }})
+    runs-on: ubuntu-latest
+    needs: changed-modules
+    permissions:
+      pull-requests: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        module: ${{ fromJson(needs.changed-modules.outputs.modules-json) }}
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: ${{ matrix.module }}/go.mod
+          cache: false
+
+      - uses: smartcontractkit/.github/actions/apidiff-go@apidiff-go/v2
+        with:
+          module-directory: ${{ matrix.module }}
+          enforce-compatible: ${{ inputs.enforce-compatible }}
+          post-comment: true

--- a/workflows/reusable-apidiff-go-analysis/reusable-apidiff-go-analysis.yml
+++ b/workflows/reusable-apidiff-go-analysis/reusable-apidiff-go-analysis.yml
@@ -70,7 +70,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: ${{ matrix.module }}/go.mod
           cache: false


### PR DESCRIPTION
This adds a reusable workflow to run `apidiff-go`. This exact pattern already exists across a few repos, so a reusable workflow will:
1. reduce duplication,
2. because of newly versioned reusable workflows, we can extend functionality or update dependencies without having to push changes in repositories that are pinned to the mutable major version tag