### PR TITLE
feat: build-push-docker allow-overwrites

### DIFF
--- a/.changeset/mighty-ways-unite.md
+++ b/.changeset/mighty-ways-unite.md
@@ -1,0 +1,6 @@
+---
+"build-push-docker": minor
+---
+
+feat: add input "allow-overwrites" that allows you to fail the action early if
+you'd overwrite a tag in the target ECR

--- a/actions/build-push-docker/README.md
+++ b/actions/build-push-docker/README.md
@@ -1,13 +1,61 @@
 # build-push-docker
 
+Builds and pushes a single-platform Docker image to ECR. Intended to be paired
+with [build-push-docker-manifest](../build-push-docker-manifest) to produce a
+multi-platform manifest from per-arch builds.
+
+## Runner requirements
+
+- OS: Linux only
+- Architecture: must match the `platform` input (`linux/amd64` → X64 runner,
+  `linux/arm64` → ARM64 runner)
+
+## Inputs
+
+| Input                     | Required     | Default                                               | Description                                                                                                                                                                                                                                                                 |
+| ------------------------- | ------------ | ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `platform`                | **yes**      | —                                                     | Target platform, e.g. `linux/amd64` or `linux/arm64`. Must match the runner architecture.                                                                                                                                                                                   |
+| `docker-registry-url`     | when pushing | —                                                     | Registry hostname. Examples: `public.ecr.aws`, `<account-id>.dkr.ecr.<region>.amazonaws.com`                                                                                                                                                                                |
+| `docker-repository-name`  | when pushing | —                                                     | Repository name excluding the hostname and tags. Public ECR includes a registry alias, e.g. `chainlink/chainlink`. Private ECR is just the repo name, e.g. `my-repo`.                                                                                                       |
+| `aws-account-number`      | when pushing | —                                                     | AWS account number for the ECR registry.                                                                                                                                                                                                                                    |
+| `aws-role-arn`            | when pushing | —                                                     | AWS role ARN with ECR push permissions.                                                                                                                                                                                                                                     |
+| `aws-region`              | no           | `us-east-1`                                           | AWS region. Use `us-east-1` for public ECR.                                                                                                                                                                                                                                 |
+| `dockerfile`              | no           | `./Dockerfile`                                        | Path to the Dockerfile.                                                                                                                                                                                                                                                     |
+| `context`                 | no           | —                                                     | Docker build context path or URL. Defaults to the Docker buildx default (repo root).                                                                                                                                                                                        |
+| `docker-target`           | no           | —                                                     | Target stage in a multi-stage Dockerfile.                                                                                                                                                                                                                                   |
+| `docker-build-args`       | no           | —                                                     | Newline-delimited `KEY=VALUE` build arguments passed to `docker buildx build --build-arg`. See [Docker docs](https://docs.docker.com/reference/cli/docker/buildx/build/#build-arg).                                                                                         |
+| `docker-build-contexts`   | no           | —                                                     | Additional named build contexts, e.g. `name=path`.                                                                                                                                                                                                                          |
+| `docker-push`             | no           | `true`                                                | Push the built image. Set to `false` for a build-only (no push) run.                                                                                                                                                                                                        |
+| `tags`                    | no           | `type=sha,prefix=pr=,event=pr` / `type=ref,event=tag` | Tag spec consumed by [docker/metadata-action](https://github.com/docker/metadata-action).                                                                                                                                                                                   |
+| `allow-overwrites`        | no           | `true`                                                | When `false`, the action fails before building if any computed tag already exists in ECR. Useful for pseudo-immutability on public ECRs (which don't support native immutability) or as a fast-fail guard on private immutable ECRs. Ignored when `docker-push` is `false`. |
+| `docker-restore-cache`    | no           | `false`                                               | Restore the Docker layer cache before building.                                                                                                                                                                                                                             |
+| `docker-save-cache`       | no           | `false`                                               | Save the Docker layer cache after building.                                                                                                                                                                                                                                 |
+| `docker-build-cache-from` | no           | GHA cache scoped to OS/arch                           | Override the cache source. Effective only when `docker-restore-cache` is `true`.                                                                                                                                                                                            |
+| `docker-build-cache-to`   | no           | GHA cache scoped to OS/arch                           | Override the cache destination. Effective only when `docker-save-cache` is `true`.                                                                                                                                                                                          |
+| `docker-attestations`     | no           | `true`                                                | Generate SBOM and provenance attestations. See [Docker docs](https://docs.docker.com/build/ci/github-actions/attestations/).                                                                                                                                                |
+| `github-token`            | no           | —                                                     | GitHub token mounted as a Docker build secret (`GIT_AUTH_TOKEN`) for builds that fetch private dependencies.                                                                                                                                                                |
+
+### Automatic `CL_AUTO_DOCKER_TAG` build arg
+
+The action always injects a `CL_AUTO_DOCKER_TAG` build argument containing the
+first computed tag (with any `-amd64`/`-arm64` suffix stripped). Dockerfiles can
+consume it via `ARG CL_AUTO_DOCKER_TAG`. No configuration is needed; existing
+`docker-build-args` are preserved.
+
+## Outputs
+
+| Output                          | Description                                        |
+| ------------------------------- | -------------------------------------------------- |
+| `docker-repository-name`        | Echo of the `docker-repository-name` input.        |
+| `docker-image-tags`             | Newline-delimited list of all computed image tags. |
+| `docker-image-sha-digest-amd64` | Image digest when `platform` is `linux/amd64`.     |
+| `docker-image-sha-digest-arm64` | Image digest when `platform` is `linux/arm64`.     |
+
 ## Example usage
 
-**NOTE**: _This composite workflow is intended to be used in conjunction with
-[build-push-docker-manifest](../build-push-docker-manifest) which will create a
-Docker manifest (or index) of the images created within this composite
-workflow._
+### This action is intended to be used with the [reusable-docker-build-publish](../../workflows/reusable-docker-build-publish/) workflow.
 
-### Set the following repo secrets
+#### Set the following repo secrets
 
 **NOTE**: _Requires the [gh cli](https://cli.github.com/)._
 
@@ -18,7 +66,7 @@ gh secret set AWS_REGION # example: us-east-1
 gh secret set AWS_OIDC_IAM_ROLE_ARN # example: arn:aws:iam::<AWS_ACCOUNT_ID>:role/<ROLE NAME>
 ```
 
-### Create a workflow
+#### Create a workflow
 
 This will build and push docker images for linux/amd64 AND linux/arm64.
 
@@ -45,7 +93,7 @@ jobs:
     outputs:
       git-short-sha: ${{ steps.git-short-sha.outputs.short-sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           fetch-depth: 1
@@ -76,13 +124,13 @@ jobs:
             arch: arm64
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           fetch-depth: 1
       - name: Build Docker image
         id: build-core
-        uses: smartcontractkit/.github/actions/build-push-docker@<sha> # build-push-docker@x.y.z
+        uses: smartcontractkit/.github/actions/build-push-docker@build-push-docker/v1
         with:
           # Change this to public.ecr.aws if you are using the public ECR.
           docker-registry-url:

--- a/actions/build-push-docker/action.yml
+++ b/actions/build-push-docker/action.yml
@@ -113,6 +113,16 @@ inputs:
 
       Required when inputs.docker-push is true.
     required: false
+  # other inputs
+  allow-overwrites:
+    description: |
+      Whether to allow overwriting existing image tags. If set to `false`, the action will fail if any of the tags already exist in ECR.
+      Ideally the ECR is immutable and tags cannot be overwritten. Public ECRs don't support immutability so this allows a psuedo-immutability by failing if a tag already exists.
+      This can be leveraged by immutable ECRs to fail-fast instead of building and subsequently failing to push.
+
+      Defaults to `true` for backwards compatibility. Ignored when inputs.docker-push is false.
+    required: false
+    default: "true"
 
 outputs:
   docker-repository-name:
@@ -235,6 +245,41 @@ runs:
         tags: ${{ inputs.tags }}
         flavor: |
           latest=false
+
+    - name: Check for existing tags
+      if:
+        ${{ inputs.allow-overwrites == 'false' && inputs.docker-push == 'true'
+        }}
+      id: existing-ecr-tags
+      shell: bash
+      env:
+        ECR_REPOSITORY:
+          ${{ format('{0}/{1}', inputs.docker-registry-url,
+          inputs.docker-repository-name) }}
+        TAG_NAMES: ${{ steps.docker-meta.outputs.tag-names }} # defaults to newline delimited
+      run: |
+        set -euo pipefail
+
+        tag_exists=false
+        while IFS= read -r tag; do
+          [ -n "$tag" ] || continue
+
+          if aws ecr describe-images \
+            --repository-name "$ECR_REPOSITORY" \
+            --image-ids "imageTag=$tag" \
+            --no-cli-pager \
+            >/dev/null 2>&1; then
+            echo "::warning::Tag already exists in ECR: $tag"
+            tag_exists=true
+          fi
+        done <<< "$TAG_NAMES"
+
+        echo "tag_exists=$tag_exists" >> "$GITHUB_OUTPUT"
+
+        if [ "$tag_exists" = true ]; then
+          echo "::error::One or more tags already exist in ECR (and allow-overwrites=false). Failing."
+          exit 1
+        fi
 
     - name: Inject Standard Build Args
       id: inject-build-args

--- a/actions/build-push-docker/action.yml
+++ b/actions/build-push-docker/action.yml
@@ -253,33 +253,53 @@ runs:
       id: existing-ecr-tags
       shell: bash
       env:
-        ECR_REPOSITORY:
-          ${{ format('{0}/{1}', inputs.docker-registry-url,
-          inputs.docker-repository-name) }}
-        TAG_NAMES: ${{ steps.docker-meta.outputs.tag-names }} # defaults to newline delimited
+        ECR_REGISTRY: ${{ inputs.docker-registry-url }}
+        ECR_REPOSITORY_NAME: ${{ inputs.docker-repository-name }}
+        TAG_NAMES: ${{ steps.docker-meta.outputs.tag-names }}
       run: |
+        echo "::startgroup::Checking for existing tags in ECR repository"
         set -euo pipefail
 
+        repository_name="$ECR_REPOSITORY_NAME"
+
+        echo "Registry: $ECR_REGISTRY"
+        echo "Repository name for AWS CLI: $repository_name"
+        echo "AWS caller identity:"
+        aws sts get-caller-identity
+        echo "AWS region: ${AWS_REGION:-unset} / ${AWS_DEFAULT_REGION:-unset}"
+
         tag_exists=false
+
         while IFS= read -r tag; do
           [ -n "$tag" ] || continue
 
-          if aws ecr describe-images \
-            --repository-name "$ECR_REPOSITORY" \
+          # Strip CR just in case the output contains Windows-style line endings
+          tag="${tag%$'\r'}"
+
+          echo "Checking for tag: [$tag]"
+
+          if output=$(aws ecr describe-images \
+            --repository-name "$repository_name" \
             --image-ids "imageTag=$tag" \
-            --no-cli-pager \
-            >/dev/null 2>&1; then
+            --no-cli-pager 2>&1); then
             echo "::warning::Tag already exists in ECR: $tag"
+            echo "$output"
             tag_exists=true
+          else
+            status=$?
+            echo "Lookup failed for tag [$tag] with exit code $status"
+            echo "$output"
           fi
         done <<< "$TAG_NAMES"
 
-        echo "tag_exists=$tag_exists" >> "$GITHUB_OUTPUT"
+        echo "Found existing tag? $tag_exists"
 
         if [ "$tag_exists" = true ]; then
-          echo "::error::One or more tags already exist in ECR (and allow-overwrites=false). Failing."
+          echo "::error::One or more tags already exist in ECR (allow-overwrites=false)."
           exit 1
         fi
+
+        echo "::endgroup::"
 
     - name: Inject Standard Build Args
       id: inject-build-args

--- a/actions/build-push-docker/action.yml
+++ b/actions/build-push-docker/action.yml
@@ -250,56 +250,13 @@ runs:
       if:
         ${{ inputs.allow-overwrites == 'false' && inputs.docker-push == 'true'
         }}
-      id: existing-ecr-tags
-      shell: bash
-      env:
-        ECR_REGISTRY: ${{ inputs.docker-registry-url }}
-        ECR_REPOSITORY_NAME: ${{ inputs.docker-repository-name }}
-        TAG_NAMES: ${{ steps.docker-meta.outputs.tag-names }}
-      run: |
-        echo "::startgroup::Checking for existing tags in ECR repository"
-        set -euo pipefail
-
-        repository_name="$ECR_REPOSITORY_NAME"
-
-        echo "Registry: $ECR_REGISTRY"
-        echo "Repository name for AWS CLI: $repository_name"
-        echo "AWS caller identity:"
-        aws sts get-caller-identity
-        echo "AWS region: ${AWS_REGION:-unset} / ${AWS_DEFAULT_REGION:-unset}"
-
-        tag_exists=false
-
-        while IFS= read -r tag; do
-          [ -n "$tag" ] || continue
-
-          # Strip CR just in case the output contains Windows-style line endings
-          tag="${tag%$'\r'}"
-
-          echo "Checking for tag: [$tag]"
-
-          if output=$(aws ecr describe-images \
-            --repository-name "$repository_name" \
-            --image-ids "imageTag=$tag" \
-            --no-cli-pager 2>&1); then
-            echo "::warning::Tag already exists in ECR: $tag"
-            echo "$output"
-            tag_exists=true
-          else
-            status=$?
-            echo "Lookup failed for tag [$tag] with exit code $status"
-            echo "$output"
-          fi
-        done <<< "$TAG_NAMES"
-
-        echo "Found existing tag? $tag_exists"
-
-        if [ "$tag_exists" = true ]; then
-          echo "::error::One or more tags already exist in ECR (allow-overwrites=false)."
-          exit 1
-        fi
-
-        echo "::endgroup::"
+      uses: smartcontractkit/.github/actions/ecr-image-exists@feat/ecr-image-exists-v1
+      with:
+        docker-registry-url: ${{ inputs.docker-registry-url }}
+        docker-repository-name: ${{ inputs.docker-repository-name }}
+        tags: ${{ steps.docker-meta.outputs.tag-names }}
+        assert-non-existence: true
+        registry-auth: false
 
     - name: Inject Standard Build Args
       id: inject-build-args

--- a/actions/build-push-docker/action.yml
+++ b/actions/build-push-docker/action.yml
@@ -250,7 +250,7 @@ runs:
       if:
         ${{ inputs.allow-overwrites == 'false' && inputs.docker-push == 'true'
         }}
-      uses: smartcontractkit/.github/actions/ecr-image-exists@feat/ecr-image-exists-v1
+      uses: smartcontractkit/.github/actions/ecr-image-exists@ecr-image-exists/v1
       with:
         docker-registry-url: ${{ inputs.docker-registry-url }}
         docker-repository-name: ${{ inputs.docker-repository-name }}


### PR DESCRIPTION
Adds a `allow-overwrites` input to the `build-push-docker` action, adding the ability of failing if the intended tag already exists in the ECR.

```
Whether to allow overwriting existing image tags. If set to `false`, the action will fail if any of the tags already exist in ECR.

Ideally the ECR is immutable and tags cannot be overwritten. Public ECRs don't support immutability so this allows a psuedo-immutability by failing if a tag already exists.

This can be leveraged by immutable ECRs to fail-fast instead of building and subsequently failing to push.

Defaults to `true` for backwards compatibility. Ignored when inputs.docker-push is false.
```

### Motivation

Mostly targeting the ability to avoid overwriting tags when pushing to a public ECR which doesn't support immutability.

### Testing

See: https://github.com/smartcontractkit/.github/pull/1529

