### PR TITLE
feat: reusable-docker-build-publish allow-overwrites

### DIFF
--- a/.changeset/clean-rules-dream.md
+++ b/.changeset/clean-rules-dream.md
@@ -1,0 +1,6 @@
+---
+"reusable-docker-build-publish": minor
+---
+
+feat: add "allow-overwrites" input. See `build-push-docker` action for more
+details

--- a/.github/workflows/reusable-docker-build-publish.yml
+++ b/.github/workflows/reusable-docker-build-publish.yml
@@ -339,6 +339,13 @@ on:
         required: false
         type: string
         default: "false"
+      allow-overwrites:
+        description: |
+          Whether to allow overwriting existing Docker images with the same tag in AWS ECR.
+          Default is true (for backwards compatibility).
+        required: false
+        type: string
+        default: "true"
 
     outputs:
       docker-image-sha-digest-amd64:
@@ -664,6 +671,7 @@ jobs:
           aws-role-arn: ${{ secrets.AWS_ROLE_PUBLISH_ARN }}
           aws-region: ${{ inputs.aws-region-ecr }}
           github-token: ${{ secrets.GITHUB_TOKEN_DOCKER_BUILD_OVERRIDE || steps.token.outputs.access-token || '' }}
+          allow-overwrites: ${{ inputs.allow-overwrites }}
 
   docker-manifest:
     name: docker-manifest

--- a/workflows/reusable-docker-build-publish/reusable-docker-build-publish.yml
+++ b/workflows/reusable-docker-build-publish/reusable-docker-build-publish.yml
@@ -335,6 +335,13 @@ on:
         required: false
         type: string
         default: "false"
+      allow-overwrites:
+        description: |
+          Whether to allow overwriting existing Docker images with the same tag in AWS ECR.
+          Default is true (for backwards compatibility).
+        required: false
+        type: string
+        default: "true"
 
     outputs:
       docker-image-sha-digest-amd64:
@@ -660,6 +667,7 @@ jobs:
           aws-role-arn: ${{ secrets.AWS_ROLE_PUBLISH_ARN }}
           aws-region: ${{ inputs.aws-region-ecr }}
           github-token: ${{ secrets.GITHUB_TOKEN_DOCKER_BUILD_OVERRIDE || steps.token.outputs.access-token || '' }}
+          allow-overwrites: ${{ inputs.allow-overwrites }}
 
   docker-manifest:
     name: docker-manifest


### PR DESCRIPTION
This adds `allow-overwrites` input to the `reusable-docker-build-publish` workflow. This input is from #1526.

Testing in #1529 


