### PR TITLE
fix: apidiff-go resolve merge base

### DIFF
--- a/.changeset/small-dots-fry.md
+++ b/.changeset/small-dots-fry.md
@@ -1,0 +1,5 @@
+---
+"apidiff-go": minor
+---
+
+fix: resolve proper merge base before analyzing

--- a/actions/apidiff-go/dist/index.js
+++ b/actions/apidiff-go/dist/index.js
@@ -21323,7 +21323,7 @@ var require_core = __commonJS({
     exports2.isDebug = isDebug2;
     exports2.debug = debug2;
     exports2.error = error;
-    exports2.warning = warning4;
+    exports2.warning = warning5;
     exports2.notice = notice;
     exports2.info = info6;
     exports2.startGroup = startGroup3;
@@ -21416,7 +21416,7 @@ Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
     function error(message, properties = {}) {
       (0, command_1.issueCommand)("error", (0, utils_1.toCommandProperties)(properties), message instanceof Error ? message.toString() : message);
     }
-    function warning4(message, properties = {}) {
+    function warning5(message, properties = {}) {
       (0, command_1.issueCommand)("warning", (0, utils_1.toCommandProperties)(properties), message instanceof Error ? message.toString() : message);
     }
     function notice(message, properties = {}) {
@@ -51723,6 +51723,20 @@ async function checkoutRef(repoDir, ref) {
     throw new Error(`Failed to checkout ref ${ref}: ${error}`);
   }
 }
+async function findMergeBase(repoDir, ref1, ref2) {
+  try {
+    const { stdout } = await execa("git", ["merge-base", ref1, ref2], {
+      cwd: repoDir
+    });
+    const sha = stdout.trim();
+    core3.info(`Found merge base of '${ref1}' and '${ref2}': ${sha}`);
+    return sha;
+  } catch (error) {
+    throw new Error(
+      `Could not find merge base of '${ref1}' and '${ref2}': ${error}`
+    );
+  }
+}
 
 // actions/apidiff-go/src/apidiff.ts
 async function generateExportAtRef(modulePath, ref) {
@@ -52509,8 +52523,25 @@ async function run() {
     const moduleName = await getGoModuleName(qualifiedModuleDirectory);
     core7.info(`Module name: ${moduleName}`);
     const headRef = determineRef("head", context2, inputs.headRefOverride);
-    const baseRef = determineRef("base", context2, inputs.baseRefOverride);
+    let baseRef = determineRef("base", context2, inputs.baseRefOverride);
     core7.info(`Head ref: ${headRef}, Base ref: ${baseRef}`);
+    if (!inputs.baseRefOverride) {
+      try {
+        const mergeBase = await findMergeBase(
+          inputs.repositoryRoot,
+          headRef,
+          baseRef
+        );
+        core7.info(
+          `Using merge base ${mergeBase} instead of target branch HEAD ${baseRef}`
+        );
+        baseRef = mergeBase;
+      } catch (error) {
+        core7.warning(
+          `Could not find merge base, falling back to base ref ${baseRef}: ${error}`
+        );
+      }
+    }
     core7.endGroup();
     core7.startGroup("Installing apidiff");
     await installApidiff(qualifiedModuleDirectory, inputs.apidiffVersion);

--- a/actions/apidiff-go/src/__tests__/git.test.ts
+++ b/actions/apidiff-go/src/__tests__/git.test.ts
@@ -9,6 +9,7 @@ import {
   resolveRef,
   checkoutRef,
   getRepoTags,
+  findMergeBase,
 } from "../git.js";
 
 import {
@@ -113,6 +114,45 @@ describe("git utilities", () => {
       const tags = await getRepoTags(localRepoDir);
       expect(tags).toContain("lightweight-tag");
       expect(tags).toContain("annotated-tag");
+    });
+  });
+
+  describe("findMergeBase", () => {
+    it("should find the common ancestor of two divergent branches", async () => {
+      // feature/test-branch diverged from main after "Common commit 1"
+      // main has since advanced with "Common commit 2", "Advance main - commit 1", etc.
+      const featureSha = await getRefSha(localRepoDir, "feature/test-branch");
+      const mainSha = await getRefSha(localRepoDir, "main");
+
+      const mergeBase = await findMergeBase(localRepoDir, featureSha, mainSha);
+
+      // The merge base should not be the HEAD of main
+      expect(mergeBase).not.toBe(mainSha);
+      // The merge base should be an ancestor of both branches
+      const { stdout: isAncestorOfMain } = await execa(
+        "git",
+        ["merge-base", "--is-ancestor", mergeBase, mainSha],
+        { cwd: localRepoDir, reject: false },
+      );
+      const { stdout: isAncestorOfFeature } = await execa(
+        "git",
+        ["merge-base", "--is-ancestor", mergeBase, featureSha],
+        { cwd: localRepoDir, reject: false },
+      );
+      expect(isAncestorOfMain).toBe("");
+      expect(isAncestorOfFeature).toBe("");
+    });
+
+    it("should return the commit itself when comparing a branch to itself", async () => {
+      const mainSha = await getRefSha(localRepoDir, "main");
+      const mergeBase = await findMergeBase(localRepoDir, mainSha, mainSha);
+      expect(mergeBase).toBe(mainSha);
+    });
+
+    it("should throw an error for invalid refs", async () => {
+      await expect(
+        findMergeBase(localRepoDir, "nonexistent1", "nonexistent2"),
+      ).rejects.toThrow();
     });
   });
 

--- a/actions/apidiff-go/src/git.ts
+++ b/actions/apidiff-go/src/git.ts
@@ -121,6 +121,29 @@ export async function checkoutRef(
   }
 }
 
+/**
+ * Finds the merge base (common ancestor) of two refs.
+ * Returns the SHA of the merge base commit.
+ */
+export async function findMergeBase(
+  repoDir: string,
+  ref1: string,
+  ref2: string,
+): Promise<string> {
+  try {
+    const { stdout } = await execa("git", ["merge-base", ref1, ref2], {
+      cwd: repoDir,
+    });
+    const sha = stdout.trim();
+    core.info(`Found merge base of '${ref1}' and '${ref2}': ${sha}`);
+    return sha;
+  } catch (error) {
+    throw new Error(
+      `Could not find merge base of '${ref1}' and '${ref2}': ${error}`,
+    );
+  }
+}
+
 export async function getRepoTags(repoDir: string) {
   const { stdout: rawTags } = await execa("git", ["tag"], { cwd: repoDir });
   const tags = rawTags

--- a/actions/apidiff-go/src/run.ts
+++ b/actions/apidiff-go/src/run.ts
@@ -9,7 +9,7 @@ import {
   installApidiff,
   diffExports,
 } from "./apidiff";
-import { validateGitRepositoryRoot } from "./git";
+import { validateGitRepositoryRoot, findMergeBase } from "./git";
 import { upsertPRComment } from "./github";
 import { CL_LOCAL_DEBUG, getInputs, getInvokeContext } from "./run-inputs";
 import {
@@ -42,8 +42,26 @@ export async function run(): Promise<void> {
     core.info(`Module name: ${moduleName}`);
 
     const headRef = determineRef("head", context, inputs.headRefOverride);
-    const baseRef = determineRef("base", context, inputs.baseRefOverride);
+    let baseRef = determineRef("base", context, inputs.baseRefOverride);
     core.info(`Head ref: ${headRef}, Base ref: ${baseRef}`);
+
+    if (!inputs.baseRefOverride) {
+      try {
+        const mergeBase = await findMergeBase(
+          inputs.repositoryRoot,
+          headRef,
+          baseRef,
+        );
+        core.info(
+          `Using merge base ${mergeBase} instead of target branch HEAD ${baseRef}`,
+        );
+        baseRef = mergeBase;
+      } catch (error) {
+        core.warning(
+          `Could not find merge base, falling back to base ref ${baseRef}: ${error}`,
+        );
+      }
+    }
 
     core.endGroup();
 


### PR DESCRIPTION
Ensures `apidiff-go` is diffing between proper commits when the two commits are not ancestors of each other.


### Changes

* Uses `git merge-base` 

### Notes

This fixes a bug where a PR could be created from a non-HEAD trunk commit, and it would still diff the APIs from HEAD of PR to HEAD of trunk. Any API changes that were on trunk, but not on the PR branch would come across as reverted.

For example:

https://github.com/smartcontractkit/chainlink-common/pull/2014
- This API diff go comment is effectively showing the inverse of the commit missing from the PR branch (https://github.com/smartcontractkit/chainlink-common/commit/3667714e0b37a904d1d7ccb734489dad33310f2c#diff-25dfe4628ad40d3352e8f11ce7b9cce351fccafa4b6c912a2d912f3aa4669737)

```
## ⚠️ API Diff Results - `github.com/smartcontractkit/chainlink-common`

#### ⚠️ Breaking Changes (1)

##### `pkg/settings/cresettings.Workflows` (1)

- `FeatureEVMWriteReportL1FeeActivePeriod` — 🗑️ Removed

---

📄 [View full apidiff report](https://github.com/smartcontractkit/chainlink-common/actions/runs/25137062246#summary-73677993101)
```





