### PR TITLE
chore: gha dependency bumps

### DIFF
--- a/.changeset/neat-snakes-hit.md
+++ b/.changeset/neat-snakes-hit.md
@@ -1,0 +1,16 @@
+---
+"branch-out-upload": patch
+"build-push-docker": patch
+"build-push-docker-manifest": patch
+"ctf-fetch-aws-secret": patch
+"ctf-setup-run-tests-environment": patch
+"do-not-merge": patch
+"docker-image-patch": patch
+"ecr-image-exists": patch
+"pull-private-ecr-image": patch
+"setup-github-token": patch
+"setup-nodejs": patch
+"wait-for-workflows": patch
+---
+
+chore: bump gha deps

--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -87,7 +87,7 @@ jobs:
         run: pnpm nx run signed-commits:build
 
       - name: Commit back any changes
-        uses: planetscale/ghcommit-action@b68767a2e130a71926b365322e62b583404a5e09 # v0.1.43
+        uses: planetscale/ghcommit-action@25309d8005ac7c3bcd61d3fe19b69e0fe47dbdde # v0.2.20
         with:
           commit_message: "🤖 Update build"
           repo: ${{ github.repository }}
@@ -163,7 +163,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/actions/branch-out-upload/action.yml
+++ b/actions/branch-out-upload/action.yml
@@ -183,7 +183,7 @@ runs:
 
     - name: Upload Test Results to Trunk.io
       id: upload-to-trunk
-      uses: trunk-io/analytics-uploader@293e9b144a101ef4b8fe3485a5afd0224fc48255 # v2.0.7
+      uses: trunk-io/analytics-uploader@95a0fb8b29e45b6068304261fb518644b426a803 # v2.0.8
       continue-on-error: ${{ inputs.trunk-upload-only == 'true' }}
       env:
         TRUNK_TELEMETRY: "off"

--- a/actions/build-push-docker-manifest/action.yml
+++ b/actions/build-push-docker-manifest/action.yml
@@ -164,12 +164,13 @@ runs:
         echo "name=${DOCKER_REGISTRY_URL}/${DOCKER_REPOSITORY_NAME}" | tee -a "$GITHUB_OUTPUT"
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       with:
-        version: v0.27.0
+        # https://github.com/docker/buildx/tags
+        version: v0.33.0
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}
         role-duration-seconds: 900
@@ -372,9 +373,10 @@ runs:
 
     - name: Install cosign
       if: inputs.docker-manifest-sign == 'true'
-      uses: sigstore/cosign-installer@c56c2d3e59e4281cc41dea2217323ba5694b171e # v3.8.0
+      uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
       with:
-        cosign-release: "v2.4.2"
+        # https://github.com/sigstore/cosign/releases
+        cosign-release: "v2.6.1"
 
     - name: Sign Docker Manifest using GH OIDC
       if: inputs.docker-manifest-sign == 'true'

--- a/actions/build-push-docker/action.yml
+++ b/actions/build-push-docker/action.yml
@@ -204,7 +204,7 @@ runs:
       if:
         ${{ steps.dockerfile-ecr-parse.outputs.needs-ecr-login == 'true' ||
         inputs.docker-push == 'true' }}
-      uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}
         role-duration-seconds: 900
@@ -233,7 +233,8 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       with:
-        version: latest
+        # https://github.com/docker/buildx/tags
+        version: v0.33.0
 
     - name: Docker meta
       id: docker-meta
@@ -362,7 +363,7 @@ runs:
 
     - name: Build & push image
       id: build-image
-      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+      uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
       env:
         DOCKER_BUILD_CHECKS_ANNOTATIONS: true
         DOCKER_BUILD_SUMMARY: true

--- a/actions/ctf-fetch-aws-secret/action.yml
+++ b/actions/ctf-fetch-aws-secret/action.yml
@@ -25,7 +25,7 @@ runs:
   using: "composite"
   steps:
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
       with:
         aws-region: ${{ inputs.aws_region }}
         role-to-assume: ${{ inputs.aws_role_to_assume }}

--- a/actions/ctf-setup-run-tests-environment/action.yml
+++ b/actions/ctf-setup-run-tests-environment/action.yml
@@ -195,7 +195,7 @@ runs:
 
     # Setup AWS cred and K8s context
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
       with:
         aws-region: ${{ inputs.QA_AWS_REGION }}
         role-to-assume: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}
@@ -229,13 +229,13 @@ runs:
     # To avoid rate limiting from Docker Hub, we can login with a paid user account.
     - name: Login to Docker Hub
       if: inputs.dockerhub_username && inputs.dockerhub_password
-      uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
       with:
         username: ${{ inputs.dockerhub_username }}
         password: ${{ inputs.dockerhub_password }}
 
     # Helm Setup
-    - uses: azure/setup-helm@29960d0f5f19214b88e1d9ba750a9914ab0f1a2f # v4.0.0
+    - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       with:
         version: v3.13.1
     - name: Add required helm charts including chainlink-qa

--- a/actions/do-not-merge/action.yml
+++ b/actions/do-not-merge/action.yml
@@ -13,7 +13,7 @@ runs:
   using: composite
   steps:
     - name: Fail if label present
-      uses: actions/github-script@v8
+      uses: actions/github-script@v9
       env:
         FAIL_LABELS: ${{ inputs.fail-labels }}
       with:

--- a/actions/docker-image-patch/action.yml
+++ b/actions/docker-image-patch/action.yml
@@ -129,7 +129,7 @@ runs:
         echo "::endgroup::"
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}
         role-duration-seconds: 900

--- a/actions/ecr-image-exists/action.yml
+++ b/actions/ecr-image-exists/action.yml
@@ -141,7 +141,7 @@ runs:
 
     - name: Configure AWS Credentials
       if: ${{ inputs.aws-role-arn != '' }}
-      uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
       with:
         aws-region: ${{ inputs.aws-region }}
         role-to-assume: ${{ inputs.aws-role-arn }}

--- a/actions/pull-private-ecr-image/action.yml
+++ b/actions/pull-private-ecr-image/action.yml
@@ -68,7 +68,7 @@ runs:
         fi
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
       with:
         aws-region: ${{ inputs.aws-region }}
         role-to-assume: ${{ inputs.aws-role-arn }}

--- a/actions/setup-github-token/action.yml
+++ b/actions/setup-github-token/action.yml
@@ -47,7 +47,7 @@ runs:
         fi
 
     - name: Assume role capable of getting token from gati
-      uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+      uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
       with:
         aws-region: ${{ inputs.aws-region }}
         mask-aws-account-id: true

--- a/actions/setup-nodejs/action.yml
+++ b/actions/setup-nodejs/action.yml
@@ -77,7 +77,7 @@ runs:
         echo "pnpm-version=${PNPM_VERSION_FROM_FILE}" | tee -a "${GITHUB_OUTPUT}"
 
     - name: Install pnpm
-      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
       with:
         version: ${{ steps.pnpm-version.outputs.pnpm-version }}
         run_install: false

--- a/actions/wait-for-workflows/action.yml
+++ b/actions/wait-for-workflows/action.yml
@@ -33,7 +33,7 @@ runs:
   steps:
     - name: wait-for-workflows
       id: wfw
-      uses: actions/github-script@v8
+      uses: actions/github-script@v9
       env:
         MAX_TIMEOUT: ${{ inputs.max-timeout }}
         POLLING_INTERVAL: ${{ inputs.polling-interval }}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -909,6 +909,8 @@ importers:
 
   workflows/reusable-docker-build-publish: {}
 
+  workflows/reusable-docusaurus: {}
+
   workflows/reusable-stale-prs-issues: {}
 
   workflows/run-e2e-tests: {}


### PR DESCRIPTION
Misc GHA dependency bumps across actions we own, and those that typically have wider usage. This replaces a lot of the stuff in #1519, which might be a little too big of a change.

### Notes

This addresses more than just GHA bumps.

In particular, I've now pinned `docker/setup-buildx` to a specific version:

```
      with:
        # https://github.com/docker/buildx/tags
        version: v0.33.0
```

also updating the pinned cosign version

```
        # https://github.com/sigstore/cosign/releases
        cosign-release: "v2.6.1"
```