### PR TITLE
feat: build-push-docker-manifest debug logs

### DIFF
--- a/.changeset/healthy-terms-unite.md
+++ b/.changeset/healthy-terms-unite.md
@@ -1,0 +1,5 @@
+---
+"build-push-docker-manifest": minor
+---
+
+feat: conditionally enable docker buildx debug logs

--- a/actions/build-push-docker-manifest/action.yml
+++ b/actions/build-push-docker-manifest/action.yml
@@ -341,8 +341,14 @@ runs:
         echo "Creating Docker manifest with tag: ${DOCKER_MANIFEST_TAG}"
 
         # Build the complete command with all flags
-        CMD_ARGS=("--tag" "${DOCKER_MANIFEST_NAME_WITH_TAG}")
+        CMD_ARGS=()
 
+        if [[ "${RUNNER_DEBUG}" == "1" || "${CL_MANIFEST_DEBUG}" == "1" || "${CL_MANIFEST_DEBUG,,}" == "true" ]]; then
+          echo "Debug logging enabled for docker buildx imagetools create"
+          CMD_ARGS+=("--debug")
+        fi
+
+        CMD_ARGS+=("--tag" "${DOCKER_MANIFEST_NAME_WITH_TAG}")
         # Add additional tag flags if present
         if [[ -n "${TAG_FLAGS}" ]]; then
           echo "Adding additional tags to manifest..."


### PR DESCRIPTION
Enables `docker buildx` debug logging based on a few env vars.

### Motivation

We are trying to root cause an issue where we are seeing intermittent 255 exit codes during the: `docker buildx imagetools create` command.

AFAICT the manifest index, and annotations are pushed correctly. Without these logs on an actual run, we will not be able to come to a proper conclusion as to why it's failing.