### PR TITLE
feat: manifest debug for reusable-docker-build-publish

### DIFF
--- a/.changeset/quiet-trainers-perform.md
+++ b/.changeset/quiet-trainers-perform.md
@@ -1,0 +1,5 @@
+---
+"reusable-docker-build-publish": minor
+---
+
+feat: manifest-debug input

--- a/.github/workflows/reusable-docker-build-publish.yml
+++ b/.github/workflows/reusable-docker-build-publish.yml
@@ -346,6 +346,12 @@ on:
         required: false
         type: string
         default: "true"
+      manifest-debug:
+        description: |
+          Enable debug output for Docker manifest generation step. Set to 'true' to enable.
+        required: false
+        type: string
+        default: "false"
 
     outputs:
       docker-image-sha-digest-amd64:
@@ -781,6 +787,8 @@ jobs:
       - name: Docker manifest index
         uses: smartcontractkit/.github/actions/build-push-docker-manifest@build-push-docker-manifest/v1
         id: docker-manifest
+        env:
+          CL_MANIFEST_DEBUG: ${{ inputs.manifest-debug }}
         with:
           # Avoid using `github.workflow_ref` here because the `cosign sign`
           # command will use the reusable workflow path for its identity and

--- a/workflows/reusable-docker-build-publish/reusable-docker-build-publish.yml
+++ b/workflows/reusable-docker-build-publish/reusable-docker-build-publish.yml
@@ -342,6 +342,12 @@ on:
         required: false
         type: string
         default: "true"
+      manifest-debug:
+        description: |
+          Enable debug output for Docker manifest generation step. Set to 'true' to enable.
+        required: false
+        type: string
+        default: "false"
 
     outputs:
       docker-image-sha-digest-amd64:
@@ -777,6 +783,8 @@ jobs:
       - name: Docker manifest index
         uses: smartcontractkit/.github/actions/build-push-docker-manifest@build-push-docker-manifest/v1
         id: docker-manifest
+        env:
+          CL_MANIFEST_DEBUG: ${{ inputs.manifest-debug }}
         with:
           # Avoid using `github.workflow_ref` here because the `cosign sign`
           # command will use the reusable workflow path for its identity and


### PR DESCRIPTION
Related to #1564.

> Motivation
>
> We are trying to root cause an issue where we are seeing intermittent 255 exit codes during the: docker buildx imagetools create command.
> AFAICT the manifest index, and annotations are pushed correctly. Without these logs on an actual run, we will not be able to come to a proper conclusion as to why it's failing.

This is not the ideal scenario, but I didn't realize top-level workflow env vars were not propagated to reusable workflows. So this is where we are now.

We can treat this behaviour as temporary, and remove the input in the future.