### PR TITLE
fix: build-push-docker-manifest polling

### DIFF
--- a/.changeset/purple-plums-breathe.md
+++ b/.changeset/purple-plums-breathe.md
@@ -1,0 +1,5 @@
+---
+"reusable-docker-build-publish": minor
+---
+
+revert: previous change, removing manifest-debug input

--- a/.changeset/stupid-eggs-applaud.md
+++ b/.changeset/stupid-eggs-applaud.md
@@ -1,0 +1,5 @@
+---
+"build-push-docker-manifest": minor
+---
+
+feat: poll for manifest existence before attempting to get digest

--- a/.changeset/tall-ways-beam.md
+++ b/.changeset/tall-ways-beam.md
@@ -1,0 +1,5 @@
+---
+"build-push-docker-manifest": patch
+---
+
+revert: previous change, ignore debug env vars for buildx logging

--- a/.github/workflows/reusable-docker-build-publish.yml
+++ b/.github/workflows/reusable-docker-build-publish.yml
@@ -346,12 +346,6 @@ on:
         required: false
         type: string
         default: "true"
-      manifest-debug:
-        description: |
-          Enable debug output for Docker manifest generation step. Set to 'true' to enable.
-        required: false
-        type: string
-        default: "false"
 
     outputs:
       docker-image-sha-digest-amd64:
@@ -787,8 +781,6 @@ jobs:
       - name: Docker manifest index
         uses: smartcontractkit/.github/actions/build-push-docker-manifest@build-push-docker-manifest/v1
         id: docker-manifest
-        env:
-          CL_MANIFEST_DEBUG: ${{ inputs.manifest-debug }}
         with:
           # Avoid using `github.workflow_ref` here because the `cosign sign`
           # command will use the reusable workflow path for its identity and

--- a/actions/build-push-docker-manifest/action.yml
+++ b/actions/build-push-docker-manifest/action.yml
@@ -341,14 +341,8 @@ runs:
         echo "Creating Docker manifest with tag: ${DOCKER_MANIFEST_TAG}"
 
         # Build the complete command with all flags
-        CMD_ARGS=()
+        CMD_ARGS=("--tag" "${DOCKER_MANIFEST_NAME_WITH_TAG}")
 
-        if [[ "${RUNNER_DEBUG}" == "1" || "${CL_MANIFEST_DEBUG}" == "1" || "${CL_MANIFEST_DEBUG,,}" == "true" ]]; then
-          echo "Debug logging enabled for docker buildx imagetools create"
-          CMD_ARGS+=("--debug")
-        fi
-
-        CMD_ARGS+=("--tag" "${DOCKER_MANIFEST_NAME_WITH_TAG}")
         # Add additional tag flags if present
         if [[ -n "${TAG_FLAGS}" ]]; then
           echo "Adding additional tags to manifest..."

--- a/actions/build-push-docker-manifest/action.yml
+++ b/actions/build-push-docker-manifest/action.yml
@@ -135,21 +135,20 @@ inputs:
 outputs:
   manifest-digest:
     description: "Docker @sha256:<sha> digest."
-    value: ${{ steps.create-push-docker-manifest.outputs.manifest-digest }}
+    value: ${{ steps.inspect-docker-manifest.outputs.manifest-digest }}
   manifest-tag:
     description: "Docker manifest tag."
     value: ${{ inputs.docker-manifest-tag }}
   manifest-name:
     description: "Docker manifest name."
-    value: ${{ steps.create-push-docker-manifest.outputs.manifest-name }}
+    value: ${{ steps.inspect-docker-manifest.outputs.manifest-name }}
   manifest-name-with-digest:
     description: "Docker manifest name with digest."
     value:
-      ${{ steps.create-push-docker-manifest.outputs.manifest-name-with-digest }}
+      ${{ steps.inspect-docker-manifest.outputs.manifest-name-with-digest }}
   manifest-name-with-tag:
     description: "Docker manifest name with tag."
-    value:
-      ${{ steps.create-push-docker-manifest.outputs.manifest-name-with-tag }}
+    value: ${{ steps.inspect-docker-manifest.outputs.manifest-name-with-tag }}
 
 runs:
   using: composite
@@ -364,8 +363,41 @@ runs:
         # Execute the command
         docker buildx imagetools create "${CMD_ARGS[@]}"
 
-        # Get manifest digest (format: sha256:hash)
-        MANIFEST_DIGEST=$(docker buildx imagetools inspect "${DOCKER_MANIFEST_NAME_WITH_TAG}" | grep -m1 'Digest:' | awk '{print $2}')
+    - name: Inspect Docker manifest digest
+      id: inspect-docker-manifest
+      shell: bash
+      env:
+        DOCKER_MANIFEST_NAME: ${{ steps.manifest-name.outputs.name }}
+        DOCKER_MANIFEST_TAG: ${{ inputs.docker-manifest-tag }}
+      run: |
+        DOCKER_MANIFEST_NAME_WITH_TAG="${DOCKER_MANIFEST_NAME}:${DOCKER_MANIFEST_TAG}"
+
+        MAX_RETRIES=5
+        RETRY_DELAY=10
+        MANIFEST_DIGEST=""
+
+        for i in $(seq 1 $MAX_RETRIES); do
+          echo "Attempt ${i}/${MAX_RETRIES}: Inspecting manifest (${DOCKER_MANIFEST_NAME_WITH_TAG}) to retrieve digest..."
+
+          if INSPECT_OUTPUT=$(docker buildx imagetools inspect "${DOCKER_MANIFEST_NAME_WITH_TAG}" 2>/dev/null); then
+            MANIFEST_DIGEST=$(echo "${INSPECT_OUTPUT}" | grep -m1 'Digest:' | awk '{print $2}')
+            if [[ "${MANIFEST_DIGEST}" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+              echo "Successfully retrieved manifest digest on attempt ${i}: ${MANIFEST_DIGEST}"
+              break
+            fi
+          fi
+
+          echo "Attempt ${i}/${MAX_RETRIES}: Manifest not yet available (got: '${MANIFEST_DIGEST}'), retrying in ${RETRY_DELAY}s..."
+
+          sleep $RETRY_DELAY
+          MANIFEST_DIGEST=""
+        done
+
+        if [[ -z "${MANIFEST_DIGEST}" ]]; then
+          echo "::error::Failed to retrieve manifest digest for ${DOCKER_MANIFEST_NAME_WITH_TAG} after ${MAX_RETRIES} attempts"
+          exit 1
+        fi
+
         echo "manifest-digest=${MANIFEST_DIGEST}" | tee -a "${GITHUB_OUTPUT}"
         echo "manifest-name=${DOCKER_MANIFEST_NAME}" | tee -a "${GITHUB_OUTPUT}"
         echo "manifest-name-with-digest=${DOCKER_MANIFEST_NAME}@${MANIFEST_DIGEST}" | tee -a "${GITHUB_OUTPUT}"
@@ -383,8 +415,7 @@ runs:
       shell: sh
       env:
         MANIFEST_NAME_WITH_DIGEST:
-          ${{
-          steps.create-push-docker-manifest.outputs.manifest-name-with-digest }}
+          ${{ steps.inspect-docker-manifest.outputs.manifest-name-with-digest }}
       run: cosign sign "${MANIFEST_NAME_WITH_DIGEST}" --yes
 
     - name: Verify Docker image signature
@@ -395,7 +426,7 @@ runs:
       env:
         MANIFEST_NAME_WITH_DIGEST: >-
           ${{
-            steps.create-push-docker-manifest.outputs.manifest-name-with-digest
+            steps.inspect-docker-manifest.outputs.manifest-name-with-digest
           }}
         GITHUB_WORKFLOW_REPOSITORY: ${{ inputs.github-workflow-repository }}
         OIDC_ISSUER: ${{ inputs.cosign-oidc-issuer }}
@@ -412,19 +443,17 @@ runs:
         DOCKER_MANIFEST_SIGNED: ${{ inputs.docker-manifest-sign }}
         GITHUB_WORKFLOW_REPOSITORY: ${{ inputs.github-workflow-repository }}
         MANIFEST_ADDITIONAL_TAGS:
-          ${{ steps.create-push-docker-manifest.outputs.manifest-additional-tags
-          }}
+          ${{ steps.inspect-docker-manifest.outputs.manifest-additional-tags }}
         MANIFEST_DIGEST:
-          ${{ steps.create-push-docker-manifest.outputs.manifest-digest }}
-        MANIFEST_NAME:
-          ${{ steps.create-push-docker-manifest.outputs.manifest-name}}
+          ${{ steps.inspect-docker-manifest.outputs.manifest-digest }}
+        MANIFEST_NAME: ${{ steps.inspect-docker-manifest.outputs.manifest-name}}
         MANIFEST_NAME_WITH_DIGEST: >-
           ${{
-            steps.create-push-docker-manifest.outputs.manifest-name-with-digest
+            steps.inspect-docker-manifest.outputs.manifest-name-with-digest
           }}
         MANIFEST_NAME_WITH_TAG: >-
           ${{
-            steps.create-push-docker-manifest.outputs.manifest-name-with-tag
+            steps.inspect-docker-manifest.outputs.manifest-name-with-tag
           }}
         MANIFEST_TAG: ${{ inputs.docker-manifest-tag }}
         OIDC_ISSUER: ${{ inputs.cosign-oidc-issuer }}

--- a/workflows/reusable-docker-build-publish/reusable-docker-build-publish.yml
+++ b/workflows/reusable-docker-build-publish/reusable-docker-build-publish.yml
@@ -342,12 +342,6 @@ on:
         required: false
         type: string
         default: "true"
-      manifest-debug:
-        description: |
-          Enable debug output for Docker manifest generation step. Set to 'true' to enable.
-        required: false
-        type: string
-        default: "false"
 
     outputs:
       docker-image-sha-digest-amd64:
@@ -783,8 +777,6 @@ jobs:
       - name: Docker manifest index
         uses: smartcontractkit/.github/actions/build-push-docker-manifest@build-push-docker-manifest/v1
         id: docker-manifest
-        env:
-          CL_MANIFEST_DEBUG: ${{ inputs.manifest-debug }}
         with:
           # Avoid using `github.workflow_ref` here because the `cosign sign`
           # command will use the reusable workflow path for its identity and


### PR DESCRIPTION
This adds polling to manifest, before trying to get the digest from ECR.

### Changes

* Reverts: 321b3dcd8ec358fb2df44257048ec3c92d904770 (#1564)
* Reverts: 8fc19e023c51e174aa5886b9578486e05c1918fc (#1566)
* Adds fault-tolerant polling step for fetching the manifest digest

### Notes

Seeing exit code 255 during manifest push step. Example: https://github.com/smartcontractkit/chainlink/actions/runs/26590320161/job/78349080233?pr=22679

```
[77](https://github.com/smartcontractkit/chainlink/actions/runs/26590320161/job/78349080233?pr=22679#step:4:494)
#1 0.000 copying sha256:2531e76391220f8e6ab3d252722f30143ea2f220cf53472633372303bff1aed6 from ***.dkr.ecr.us-west-2.amazonaws.com/chainlink@sha256:db57e3d3a3ecc538a0cbb810da9860179bb1c6e1abfd1476b1bba7a8404ca9e0 to ***.dkr.ecr.us-west-2.amazonaws.com/chainlink
#1 1.306 pushing sha256:3ee95908cced393678e9214d8325c66e40e7ee08d5506cc9f4ee055d42648726 to ***.dkr.ecr.us-west-2.amazonaws.com/chainlink:pr-22679-b2b70d0-plugins-testing
#1 DONE 1.7s
Error: Process completed with exit code 255.
```

* When we push the arch specific images, and before we push the manifest index, we poll for the images to ensure that the manifest is valid. 
  * https://github.com/smartcontractkit/.github/blob/644aaa0ae31f54509de0565a2c89ac47ae659485/actions/build-push-docker-manifest/action.yml#L259-L316
*  But when we pushed the manifest, we immediately queried the ECR for the digest which I believe is why we were seeing errors
  * https://github.com/smartcontractkit/.github/blob/644aaa0ae31f54509de0565a2c89ac47ae659485/actions/build-push-docker-manifest/action.yml#L370-L374
* This fixes that issue by similarly polling for the manifest, ensuring it's existence, and safely extracting the digest

### Testing

* Created branch pointing at this one: https://github.com/smartcontractkit/.github/compare/main...test%2Fdocker-manifest-polling?assignees=erikburt&body=&expand=1
* Update CL workflows: https://github.com/smartcontractkit/chainlink/pull/22681
  * https://github.com/smartcontractkit/chainlink/actions/runs/26596265155/job/78369339402?pr=22681#step:4:533

```
Attempt 1/5: Inspecting manifest (***.dkr.ecr.us-west-2.amazonaws.com/chainlink:pr-22681-8bb010f) to retrieve digest...
Successfully retrieved manifest digest on attempt 1: sha256:6008273de81214df86c3a3e809167a32c60fd00827be1b08bacfd970c133ad41
manifest-digest=sha256:6008273de81214df86c3a3e809167a32c60fd00827be1b08bacfd970c133ad41
manifest-name=***.dkr.ecr.us-west-2.amazonaws.com/chainlink
manifest-name-with-digest=***.dkr.ecr.us-west-2.amazonaws.com/chainlink@sha256:6008273de81214df86c3a3e809167a32c60fd00827be1b08bacfd970c133ad41
manifest-name-with-tag=***.dkr.ecr.us-west-2.amazonaws.com/chainlink:pr-22681-8bb010f
```

^ This at least proves there's no regression. We will see if it fixes the issue that actually caused the 255 exits.


