### PR TITLE
fix(signed-commits): push release tags individually

### DIFF
--- a/.changeset/individual-tag-push-fix.md
+++ b/.changeset/individual-tag-push-fix.md
@@ -1,0 +1,7 @@
+---
+"changesets-signed-commits": patch
+---
+
+Push Changesets release tags one at a time instead of `git push origin --tags`.
+GitHub suppresses push webhooks when more than three tags are pushed at once,
+which prevented tag-triggered service CI from running on multi-package releases.

--- a/actions/signed-commits/dist/index.js
+++ b/actions/signed-commits/dist/index.js
@@ -81845,7 +81845,7 @@ async function pushTags(tagSeparator, createMajorVersionTags, cwd, rootPackageIn
     )}`
   );
   const createdTags = await createLightweightTags(filteredRewrittenTags, cwd);
-  await execWithOutput("git", ["push", "origin", "--tags"], { cwd });
+  await pushTagsToRemote(createdTags, cwd);
   if (createMajorVersionTags) {
     const majorVersionTags = getMajorVersionTags(
       filteredRewrittenTags,
@@ -81861,6 +81861,11 @@ async function pushTags(tagSeparator, createMajorVersionTags, cwd, rootPackageIn
     return [...createdTags, ...createdMajorTags];
   }
   return createdTags;
+}
+async function pushTagsToRemote(tags, cwd) {
+  for (const tag of tags) {
+    await execWithOutput("git", ["push", "origin", tag.name], { cwd });
+  }
 }
 async function getLocalTags(cwd) {
   const stdout = await execWithOutput("git", ["tag", "--list"], { cwd });

--- a/actions/signed-commits/src/git/github-git/repo-tags.test.ts
+++ b/actions/signed-commits/src/git/github-git/repo-tags.test.ts
@@ -14,7 +14,8 @@ import {
 } from "./repo-tags";
 import { createRepo, createCommit } from "./utils.testutils";
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+import * as utils from "../../utils";
 
 describe("repo-tags", () => {
   describe("deleteTags", () => {
@@ -503,6 +504,38 @@ describe("repo-tags", () => {
   });
 
   describe("pushTags", () => {
+    it("should push each release tag individually instead of bulk --tags", async () => {
+      const testTags = await createTestRepoWithRemote("repo-tags", true);
+      const execSpy = vi.spyOn(utils, "execWithOutput");
+
+      await pushTags("@", false, testTags.localRepoPath);
+
+      const releaseTagPushCalls = execSpy.mock.calls.filter(
+        ([cmd, args]) =>
+          cmd === "git" &&
+          args[0] === "push" &&
+          args[1] === "origin" &&
+          args[2] !== "--tags" &&
+          args[2] !== "--force",
+      );
+
+      expect(releaseTagPushCalls).toHaveLength(testTags.localOnlyTags.length);
+      expect(
+        releaseTagPushCalls.every(([, args]) => typeof args[2] === "string"),
+      ).toBe(true);
+      expect(
+        execSpy.mock.calls.some(
+          ([cmd, args]) =>
+            cmd === "git" &&
+            args[0] === "push" &&
+            args[1] === "origin" &&
+            args[2] === "--tags",
+        ),
+      ).toBe(false);
+
+      execSpy.mockRestore();
+    });
+
     it("should push lightweight versions of tags (@)", async () => {
       const testTags = await createTestRepoWithRemote("repo-tags", true);
       const tagNames = testTags.localOnlyTags.map((t) => t.name);

--- a/actions/signed-commits/src/git/github-git/repo-tags.ts
+++ b/actions/signed-commits/src/git/github-git/repo-tags.ts
@@ -45,7 +45,7 @@ export async function pushTags(
     )}`,
   );
   const createdTags = await createLightweightTags(filteredRewrittenTags, cwd);
-  await execWithOutput("git", ["push", "origin", "--tags"], { cwd });
+  await pushTagsToRemote(createdTags, cwd);
 
   if (createMajorVersionTags) {
     const majorVersionTags = getMajorVersionTags(
@@ -66,6 +66,20 @@ export async function pushTags(
   }
 
   return createdTags;
+}
+
+/**
+ * Push release tags one at a time. GitHub does not emit push webhooks when more
+ * than three tags are pushed in a single `git push --tags`, which breaks
+ * tag-triggered CI for multi-package Changesets releases.
+ */
+export async function pushTagsToRemote(
+  tags: GitTag[],
+  cwd?: string,
+): Promise<void> {
+  for (const tag of tags) {
+    await execWithOutput("git", ["push", "origin", tag.name], { cwd });
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

When Changesets publishes multiple packages in one release, `signed-commits` rewrites annotated tags as lightweight tags and pushes them with `git push origin --tags`. GitHub does **not** emit push webhooks when more than three tags are pushed in a single operation, so tag-triggered service CI never runs.

This change pushes each release tag individually (`git push origin <tag>`), matching the existing per-tag force-push loop used for major-version tags.

## Background

Observed in `smartcontractkit/atlas` when PR #12859 released four packages at once (`csa-auth/v0.0.3`, `chip-config/v0.2.4`, `atlas-chip-query/v1.0.2`, `atlas-chip-ingress/v1.4.0`). The Changesets workflow pushed all four tags in one bulk push; none of the tag-triggered `build-publish` workflows ran.

Atlas recovery and prevention docs: https://github.com/smartcontractkit/atlas/pull/12981

## Changes

- Replace bulk `git push origin --tags` with sequential `git push origin <tag>` for release tags in `repo-tags.ts`
- Add `pushTagsToRemote()` helper with rationale comment
- Add regression test asserting release tags are pushed individually (no `--tags` bulk push)
- Rebuild `actions/signed-commits/dist/index.js`
- Changeset for `changesets-signed-commits` patch release

## Follow-up after merge

1. Merge the resulting Version Packages PR (changeset release)
2. Bump `cicd-changesets` to reference the new `changesets-signed-commits` tag (if not auto-bumped)
3. Bump `smartcontractkit/atlas` `.github/workflows/changesets.yml` from `@cicd-changesets/v1` to the new release

## Test plan

- [x] `pnpm nx run signed-commits:test` — all tests pass, including new individual-push regression test
- [x] `pnpm nx run signed-commits:build` — dist rebuilt
- [ ] After release: multi-package Changesets publish in atlas triggers one tag-push workflow per service tag


