### PR TITLE
chore: update actions/dependency-review-action to v5.0.0

### DIFF
--- a/.changeset/few-adults-itch.md
+++ b/.changeset/few-adults-itch.md
@@ -1,0 +1,5 @@
+---
+"dependency-review": minor
+---
+
+chore: update actions/dependency-review-action to v5.0.0

--- a/actions/dependency-review/action.yml
+++ b/actions/dependency-review/action.yml
@@ -77,7 +77,7 @@ runs:
           echo "path=${GITHUB_ACTION_PATH}/configs/${CONFIG_PRESET}.yml" | tee -a "${GITHUB_OUTPUT}"
         fi
     - name: Dependency Review
-      uses: actions/dependency-review-action@v4
+      uses: actions/dependency-review-action@v5.0.0
       with:
         config-file: ${{ steps.set-config-file.outputs.path }}
         external-repo-token: ${{ inputs.external-repo-token }}


### PR DESCRIPTION
Update this to v5.0.0 as v4 is still on node20.

* https://github.com/actions/dependency-review-action/releases/tag/v5.0.0
* https://github.com/actions/dependency-review-action/compare/v4...v5.0.0