### PR TITLE
fix: reusable-docker-build-publish caching

### DIFF
--- a/.changeset/red-apes-grin.md
+++ b/.changeset/red-apes-grin.md
@@ -1,0 +1,5 @@
+---
+"reusable-docker-build-publish": minor
+---
+
+feat: better docker caching

--- a/.github/workflows/reusable-docker-build-publish.yml
+++ b/.github/workflows/reusable-docker-build-publish.yml
@@ -417,6 +417,8 @@ jobs:
       build-type: ${{ steps.set-extra-outputs.outputs.build-type }}
       docker-restore-cache: ${{ steps.should-cache.outputs.docker-restore-cache }}
       docker-save-cache: ${{ steps.should-cache.outputs.docker-save-cache }}
+      docker-build-cache-to: ${{ steps.should-cache.outputs.docker-build-cache-to }}
+      docker-build-cache-from: ${{ steps.should-cache.outputs.docker-build-cache-from }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -504,14 +506,27 @@ jobs:
           fi
           echo "trunk=${trunk}" | tee -a "${GITHUB_OUTPUT}"
 
-      - name: Check docker cache constraints
+      - name: Setup docker cache values
         id: should-cache
         env:
           GITHUB_REF_NAME: ${{ inputs.github-ref-name }}
           GITHUB_EVENT_NAME: ${{ inputs.github-event-name }}
           REPO_TRUNK: ${{ steps.get-trunk.outputs.trunk }}
           DOCKER_CACHE_BEHAVIOUR: ${{ inputs.docker-cache-behaviour }}
+          DOCKER_CACHE_SCOPE: >-
+            ${{ runner.os }}-${{ runner.arch }}-${{
+              replace(
+                replace(inputs.dockerfile, './', ''),
+                '/',
+                '-'
+              )
+            }}
+          BUILD_CACHE_TO: "type=gha,timeout=10m,mode=max,ignore-error=true,compression=zstd,compression-level=3"
+          BUILD_CACHE_FROM: "type=gha,timeout=10m"
         run: |
+          echo "docker-build-cache-to=${BUILD_CACHE_TO},scope=${DOCKER_CACHE_SCOPE}" | tee -a "${GITHUB_OUTPUT}"
+          echo "docker-build-cache-from=${BUILD_CACHE_FROM},scope=${DOCKER_CACHE_SCOPE}" | tee -a "${GITHUB_OUTPUT}"
+
           if [[ "${DOCKER_CACHE_BEHAVIOUR}" == "disable" ]]; then
             echo "docker-restore-cache=false" | tee -a "${GITHUB_OUTPUT}"
             echo "docker-save-cache=false" | tee -a "${GITHUB_OUTPUT}"
@@ -519,14 +534,14 @@ jobs:
             echo "docker-restore-cache=true" | tee -a "${GITHUB_OUTPUT}"
             echo "docker-save-cache=true" | tee -a "${GITHUB_OUTPUT}"
           elif [[ "${DOCKER_CACHE_BEHAVIOUR}" == "write-on-trunk" ]]; then
-              echo "docker-restore-cache=true" | tee -a "${GITHUB_OUTPUT}"
+            echo "docker-restore-cache=true" | tee -a "${GITHUB_OUTPUT}"
             if [[ "${GITHUB_REF_NAME}" == "${REPO_TRUNK}" ]] && [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
               echo "docker-save-cache=true" | tee -a "${GITHUB_OUTPUT}"
             else
               echo "docker-save-cache=false" | tee -a "${GITHUB_OUTPUT}"
             fi
           else
-            echo "::error::Invalid DOCKER_CACHE_BEHAVIOUR: ${DOCKER_CACHE_BEHAVIOUR}. Must be one of: disabled, enabled, write-on-trunk."
+            echo "::error::Invalid DOCKER_CACHE_BEHAVIOUR: ${DOCKER_CACHE_BEHAVIOUR}. Must be one of: disable, enable, write-on-trunk."
             exit 1
           fi
 
@@ -576,6 +591,9 @@ jobs:
       - name: Free up disk space
         if: ${{ inputs.free-disk-space == 'true' }}
         uses: smartcontractkit/.github/actions/free-disk-space@free-disk-space/v1
+
+      - name: Enable S3 Cache for Self-Hosted Runners
+        uses: runs-on/action@4e5f72399b6b17f2e79c511c1b38a315a64d22dc # v2.2.0
 
       - uses: actions/checkout@v6
         id: checkout
@@ -712,6 +730,8 @@ jobs:
           docker-build-args: ${{ inputs.docker-build-args }}
           docker-restore-cache: ${{ needs.init.outputs.docker-restore-cache }}
           docker-save-cache: ${{ needs.init.outputs.docker-save-cache }}
+          docker-build-cache-to: ${{ needs.init.outputs.docker-build-cache-to }}
+          docker-build-cache-from: ${{ needs.init.outputs.docker-build-cache-from }}
           context: ${{ inputs.docker-build-context }}
           docker-build-contexts: ${{ inputs.docker-build-contexts }}
           docker-push: ${{ inputs.docker-push }}

--- a/.github/workflows/reusable-docker-build-publish.yml
+++ b/.github/workflows/reusable-docker-build-publish.yml
@@ -515,22 +515,15 @@ jobs:
           DOCKER_CACHE_BEHAVIOUR: ${{ inputs.docker-cache-behaviour }}
           RUNNER_OS: ${{ runner.os }}
           RUNNER_ARCH: ${{ runner.arch }}
-          NORMALIZED_DOCKERFILE: ${{ replace(replace(inputs.dockerfile, './', ''), '/', '-') }}
-          DOCKER_CACHE_SCOPE: >-
-            ${{ runner.os }}-${{ runner.arch }}-${{
-              replace(
-                replace(inputs.dockerfile, './', ''),
-                '/',
-                '-'
-              )
-            }}-${{ inputs.docker-tag-custom-suffix || 'root' }}
           DOCKER_TAG_CUSTOM_SUFFIX: ${{ inputs.docker-tag-custom-suffix }}
+          NORMALIZED_DOCKERFILE: ${{ replace(replace(inputs.dockerfile, './', ''), '/', '-') }}
           BUILD_CACHE_TO: "type=gha,timeout=10m,mode=max,ignore-error=true,compression=zstd,compression-level=3"
           BUILD_CACHE_FROM: "type=gha,timeout=10m"
         run: |
-          docker_cache_suffix="${DOCKER_TAG_CUSTOM_SUFFIX:-${NORMALIZED_DOCKERFILE:-}}"
-
+          # Build cache scope from OS, architecture, and optional suffix
+          docker_cache_suffix="${DOCKER_TAG_CUSTOM_SUFFIX:-${NORMALIZED_DOCKERFILE}}"
           DOCKER_CACHE_SCOPE="${RUNNER_OS}-${RUNNER_ARCH}"
+
           if [[ -n "${docker_cache_suffix}" ]]; then
             DOCKER_CACHE_SCOPE="${DOCKER_CACHE_SCOPE}-${docker_cache_suffix}"
           fi

--- a/.github/workflows/reusable-docker-build-publish.yml
+++ b/.github/workflows/reusable-docker-build-publish.yml
@@ -419,6 +419,7 @@ jobs:
       docker-save-cache: ${{ steps.should-cache.outputs.docker-save-cache }}
       docker-build-cache-to: ${{ steps.should-cache.outputs.docker-build-cache-to }}
       docker-build-cache-from: ${{ steps.should-cache.outputs.docker-build-cache-from }}
+      docker-cache-suffix: ${{ steps.should-cache.outputs.docker-cache-suffix }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -513,8 +514,6 @@ jobs:
           GITHUB_EVENT_NAME: ${{ inputs.github-event-name }}
           REPO_TRUNK: ${{ steps.get-trunk.outputs.trunk }}
           DOCKER_CACHE_BEHAVIOUR: ${{ inputs.docker-cache-behaviour }}
-          RUNNER_OS: ${{ runner.os }}
-          RUNNER_ARCH: ${{ runner.arch }}
           DOCKERFILE: ${{ inputs.dockerfile }}
           DOCKER_TAG_CUSTOM_SUFFIX: ${{ inputs.docker-tag-custom-suffix }}
           BUILD_CACHE_TO: "type=gha,timeout=10m,mode=max,ignore-error=true,compression=zstd,compression-level=3"
@@ -524,16 +523,12 @@ jobs:
           normalized_dockerfile="${DOCKERFILE#./}"
           normalized_dockerfile="${normalized_dockerfile//\//-}"
 
-          # Build cache scope from OS, architecture, and optional suffix
+          # Build cache suffix (architecture will be added per-build in build-publish job)
           docker_cache_suffix="${DOCKER_TAG_CUSTOM_SUFFIX:-${normalized_dockerfile}}"
-          DOCKER_CACHE_SCOPE="${RUNNER_OS}-${RUNNER_ARCH}"
 
-          if [[ -n "${docker_cache_suffix}" ]]; then
-            DOCKER_CACHE_SCOPE="${DOCKER_CACHE_SCOPE}-${docker_cache_suffix}"
-          fi
-
-          echo "docker-build-cache-to=${BUILD_CACHE_TO},scope=${DOCKER_CACHE_SCOPE}" | tee -a "${GITHUB_OUTPUT}"
-          echo "docker-build-cache-from=${BUILD_CACHE_FROM},scope=${DOCKER_CACHE_SCOPE}" | tee -a "${GITHUB_OUTPUT}"
+          echo "docker-build-cache-to=${BUILD_CACHE_TO}" | tee -a "${GITHUB_OUTPUT}"
+          echo "docker-build-cache-from=${BUILD_CACHE_FROM}" | tee -a "${GITHUB_OUTPUT}"
+          echo "docker-cache-suffix=${docker_cache_suffix}" | tee -a "${GITHUB_OUTPUT}"
 
           if [[ "${DOCKER_CACHE_BEHAVIOUR}" == "disable" ]]; then
             echo "docker-restore-cache=false" | tee -a "${GITHUB_OUTPUT}"
@@ -609,6 +604,23 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
           ref: ${{ inputs.git-sha }}
+
+      - name: Compute per-architecture cache scope
+        id: compute-cache-scope
+        env:
+          RUNNER_OS: ${{ runner.os }}
+          MATRIX_ARCH: ${{ matrix.arch }}
+          DOCKER_CACHE_SUFFIX: ${{ needs.init.outputs.docker-cache-suffix }}
+        run: |
+          # Build cache scope with the correct architecture for this specific runner
+          DOCKER_CACHE_SCOPE="${RUNNER_OS}-${MATRIX_ARCH}"
+
+          if [[ -n "${DOCKER_CACHE_SUFFIX}" ]]; then
+            DOCKER_CACHE_SCOPE="${DOCKER_CACHE_SCOPE}-${DOCKER_CACHE_SUFFIX}"
+          fi
+
+          echo "scope=${DOCKER_CACHE_SCOPE}" | tee -a "${GITHUB_OUTPUT}"
+
       # Generated tags must be compatible with:
       # https://github.com/docker/metadata-action?tab=readme-ov-file#tags-input
       - name: Set Docker image tags
@@ -738,8 +750,8 @@ jobs:
           docker-build-args: ${{ inputs.docker-build-args }}
           docker-restore-cache: ${{ needs.init.outputs.docker-restore-cache }}
           docker-save-cache: ${{ needs.init.outputs.docker-save-cache }}
-          docker-build-cache-to: ${{ needs.init.outputs.docker-build-cache-to }}
-          docker-build-cache-from: ${{ needs.init.outputs.docker-build-cache-from }}
+          docker-build-cache-to: ${{ needs.init.outputs.docker-build-cache-to }},scope=${{ steps.compute-cache-scope.outputs.scope }}
+          docker-build-cache-from: ${{ needs.init.outputs.docker-build-cache-from }},scope=${{ steps.compute-cache-scope.outputs.scope }}
           context: ${{ inputs.docker-build-context }}
           docker-build-contexts: ${{ inputs.docker-build-contexts }}
           docker-push: ${{ inputs.docker-push }}

--- a/.github/workflows/reusable-docker-build-publish.yml
+++ b/.github/workflows/reusable-docker-build-publish.yml
@@ -513,6 +513,9 @@ jobs:
           GITHUB_EVENT_NAME: ${{ inputs.github-event-name }}
           REPO_TRUNK: ${{ steps.get-trunk.outputs.trunk }}
           DOCKER_CACHE_BEHAVIOUR: ${{ inputs.docker-cache-behaviour }}
+          RUNNER_OS: ${{ runner.os }}
+          RUNNER_ARCH: ${{ runner.arch }}
+          NORMALIZED_DOCKERFILE: ${{ replace(replace(inputs.dockerfile, './', ''), '/', '-') }}
           DOCKER_CACHE_SCOPE: >-
             ${{ runner.os }}-${{ runner.arch }}-${{
               replace(
@@ -520,10 +523,18 @@ jobs:
                 '/',
                 '-'
               )
-            }}
+            }}-${{ inputs.docker-tag-custom-suffix || 'root' }}
+          DOCKER_TAG_CUSTOM_SUFFIX: ${{ inputs.docker-tag-custom-suffix }}
           BUILD_CACHE_TO: "type=gha,timeout=10m,mode=max,ignore-error=true,compression=zstd,compression-level=3"
           BUILD_CACHE_FROM: "type=gha,timeout=10m"
         run: |
+          docker_cache_suffix="${DOCKER_TAG_CUSTOM_SUFFIX:-${NORMALIZED_DOCKERFILE:-}}"
+
+          DOCKER_CACHE_SCOPE="${RUNNER_OS}-${RUNNER_ARCH}"
+          if [[ -n "${docker_cache_suffix}" ]]; then
+            DOCKER_CACHE_SCOPE="${DOCKER_CACHE_SCOPE}-${docker_cache_suffix}"
+          fi
+
           echo "docker-build-cache-to=${BUILD_CACHE_TO},scope=${DOCKER_CACHE_SCOPE}" | tee -a "${GITHUB_OUTPUT}"
           echo "docker-build-cache-from=${BUILD_CACHE_FROM},scope=${DOCKER_CACHE_SCOPE}" | tee -a "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/reusable-docker-build-publish.yml
+++ b/.github/workflows/reusable-docker-build-publish.yml
@@ -515,13 +515,17 @@ jobs:
           DOCKER_CACHE_BEHAVIOUR: ${{ inputs.docker-cache-behaviour }}
           RUNNER_OS: ${{ runner.os }}
           RUNNER_ARCH: ${{ runner.arch }}
+          DOCKERFILE: ${{ inputs.dockerfile }}
           DOCKER_TAG_CUSTOM_SUFFIX: ${{ inputs.docker-tag-custom-suffix }}
-          NORMALIZED_DOCKERFILE: ${{ replace(replace(inputs.dockerfile, './', ''), '/', '-') }}
           BUILD_CACHE_TO: "type=gha,timeout=10m,mode=max,ignore-error=true,compression=zstd,compression-level=3"
           BUILD_CACHE_FROM: "type=gha,timeout=10m"
         run: |
+          # Normalize dockerfile path: remove './' prefix and replace '/' with '-'
+          normalized_dockerfile="${DOCKERFILE#./}"
+          normalized_dockerfile="${normalized_dockerfile//\//-}"
+
           # Build cache scope from OS, architecture, and optional suffix
-          docker_cache_suffix="${DOCKER_TAG_CUSTOM_SUFFIX:-${NORMALIZED_DOCKERFILE}}"
+          docker_cache_suffix="${DOCKER_TAG_CUSTOM_SUFFIX:-${normalized_dockerfile}}"
           DOCKER_CACHE_SCOPE="${RUNNER_OS}-${RUNNER_ARCH}"
 
           if [[ -n "${docker_cache_suffix}" ]]; then

--- a/workflows/reusable-docker-build-publish/reusable-docker-build-publish.yml
+++ b/workflows/reusable-docker-build-publish/reusable-docker-build-publish.yml
@@ -511,22 +511,15 @@ jobs:
           DOCKER_CACHE_BEHAVIOUR: ${{ inputs.docker-cache-behaviour }}
           RUNNER_OS: ${{ runner.os }}
           RUNNER_ARCH: ${{ runner.arch }}
-          NORMALIZED_DOCKERFILE: ${{ replace(replace(inputs.dockerfile, './', ''), '/', '-') }}
-          DOCKER_CACHE_SCOPE: >-
-            ${{ runner.os }}-${{ runner.arch }}-${{
-              replace(
-                replace(inputs.dockerfile, './', ''),
-                '/',
-                '-'
-              )
-            }}-${{ inputs.docker-tag-custom-suffix || 'root' }}
           DOCKER_TAG_CUSTOM_SUFFIX: ${{ inputs.docker-tag-custom-suffix }}
+          NORMALIZED_DOCKERFILE: ${{ replace(replace(inputs.dockerfile, './', ''), '/', '-') }}
           BUILD_CACHE_TO: "type=gha,timeout=10m,mode=max,ignore-error=true,compression=zstd,compression-level=3"
           BUILD_CACHE_FROM: "type=gha,timeout=10m"
         run: |
-          docker_cache_suffix="${DOCKER_TAG_CUSTOM_SUFFIX:-${NORMALIZED_DOCKERFILE:-}}"
-
+          # Build cache scope from OS, architecture, and optional suffix
+          docker_cache_suffix="${DOCKER_TAG_CUSTOM_SUFFIX:-${NORMALIZED_DOCKERFILE}}"
           DOCKER_CACHE_SCOPE="${RUNNER_OS}-${RUNNER_ARCH}"
+
           if [[ -n "${docker_cache_suffix}" ]]; then
             DOCKER_CACHE_SCOPE="${DOCKER_CACHE_SCOPE}-${docker_cache_suffix}"
           fi

--- a/workflows/reusable-docker-build-publish/reusable-docker-build-publish.yml
+++ b/workflows/reusable-docker-build-publish/reusable-docker-build-publish.yml
@@ -415,6 +415,7 @@ jobs:
       docker-save-cache: ${{ steps.should-cache.outputs.docker-save-cache }}
       docker-build-cache-to: ${{ steps.should-cache.outputs.docker-build-cache-to }}
       docker-build-cache-from: ${{ steps.should-cache.outputs.docker-build-cache-from }}
+      docker-cache-suffix: ${{ steps.should-cache.outputs.docker-cache-suffix }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -509,8 +510,6 @@ jobs:
           GITHUB_EVENT_NAME: ${{ inputs.github-event-name }}
           REPO_TRUNK: ${{ steps.get-trunk.outputs.trunk }}
           DOCKER_CACHE_BEHAVIOUR: ${{ inputs.docker-cache-behaviour }}
-          RUNNER_OS: ${{ runner.os }}
-          RUNNER_ARCH: ${{ runner.arch }}
           DOCKERFILE: ${{ inputs.dockerfile }}
           DOCKER_TAG_CUSTOM_SUFFIX: ${{ inputs.docker-tag-custom-suffix }}
           BUILD_CACHE_TO: "type=gha,timeout=10m,mode=max,ignore-error=true,compression=zstd,compression-level=3"
@@ -520,16 +519,12 @@ jobs:
           normalized_dockerfile="${DOCKERFILE#./}"
           normalized_dockerfile="${normalized_dockerfile//\//-}"
 
-          # Build cache scope from OS, architecture, and optional suffix
+          # Build cache suffix (architecture will be added per-build in build-publish job)
           docker_cache_suffix="${DOCKER_TAG_CUSTOM_SUFFIX:-${normalized_dockerfile}}"
-          DOCKER_CACHE_SCOPE="${RUNNER_OS}-${RUNNER_ARCH}"
 
-          if [[ -n "${docker_cache_suffix}" ]]; then
-            DOCKER_CACHE_SCOPE="${DOCKER_CACHE_SCOPE}-${docker_cache_suffix}"
-          fi
-
-          echo "docker-build-cache-to=${BUILD_CACHE_TO},scope=${DOCKER_CACHE_SCOPE}" | tee -a "${GITHUB_OUTPUT}"
-          echo "docker-build-cache-from=${BUILD_CACHE_FROM},scope=${DOCKER_CACHE_SCOPE}" | tee -a "${GITHUB_OUTPUT}"
+          echo "docker-build-cache-to=${BUILD_CACHE_TO}" | tee -a "${GITHUB_OUTPUT}"
+          echo "docker-build-cache-from=${BUILD_CACHE_FROM}" | tee -a "${GITHUB_OUTPUT}"
+          echo "docker-cache-suffix=${docker_cache_suffix}" | tee -a "${GITHUB_OUTPUT}"
 
           if [[ "${DOCKER_CACHE_BEHAVIOUR}" == "disable" ]]; then
             echo "docker-restore-cache=false" | tee -a "${GITHUB_OUTPUT}"
@@ -605,6 +600,23 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
           ref: ${{ inputs.git-sha }}
+
+      - name: Compute per-architecture cache scope
+        id: compute-cache-scope
+        env:
+          RUNNER_OS: ${{ runner.os }}
+          MATRIX_ARCH: ${{ matrix.arch }}
+          DOCKER_CACHE_SUFFIX: ${{ needs.init.outputs.docker-cache-suffix }}
+        run: |
+          # Build cache scope with the correct architecture for this specific runner
+          DOCKER_CACHE_SCOPE="${RUNNER_OS}-${MATRIX_ARCH}"
+
+          if [[ -n "${DOCKER_CACHE_SUFFIX}" ]]; then
+            DOCKER_CACHE_SCOPE="${DOCKER_CACHE_SCOPE}-${DOCKER_CACHE_SUFFIX}"
+          fi
+
+          echo "scope=${DOCKER_CACHE_SCOPE}" | tee -a "${GITHUB_OUTPUT}"
+
       # Generated tags must be compatible with:
       # https://github.com/docker/metadata-action?tab=readme-ov-file#tags-input
       - name: Set Docker image tags
@@ -734,8 +746,8 @@ jobs:
           docker-build-args: ${{ inputs.docker-build-args }}
           docker-restore-cache: ${{ needs.init.outputs.docker-restore-cache }}
           docker-save-cache: ${{ needs.init.outputs.docker-save-cache }}
-          docker-build-cache-to: ${{ needs.init.outputs.docker-build-cache-to }}
-          docker-build-cache-from: ${{ needs.init.outputs.docker-build-cache-from }}
+          docker-build-cache-to: ${{ needs.init.outputs.docker-build-cache-to }},scope=${{ steps.compute-cache-scope.outputs.scope }}
+          docker-build-cache-from: ${{ needs.init.outputs.docker-build-cache-from }},scope=${{ steps.compute-cache-scope.outputs.scope }}
           context: ${{ inputs.docker-build-context }}
           docker-build-contexts: ${{ inputs.docker-build-contexts }}
           docker-push: ${{ inputs.docker-push }}

--- a/workflows/reusable-docker-build-publish/reusable-docker-build-publish.yml
+++ b/workflows/reusable-docker-build-publish/reusable-docker-build-publish.yml
@@ -511,13 +511,17 @@ jobs:
           DOCKER_CACHE_BEHAVIOUR: ${{ inputs.docker-cache-behaviour }}
           RUNNER_OS: ${{ runner.os }}
           RUNNER_ARCH: ${{ runner.arch }}
+          DOCKERFILE: ${{ inputs.dockerfile }}
           DOCKER_TAG_CUSTOM_SUFFIX: ${{ inputs.docker-tag-custom-suffix }}
-          NORMALIZED_DOCKERFILE: ${{ replace(replace(inputs.dockerfile, './', ''), '/', '-') }}
           BUILD_CACHE_TO: "type=gha,timeout=10m,mode=max,ignore-error=true,compression=zstd,compression-level=3"
           BUILD_CACHE_FROM: "type=gha,timeout=10m"
         run: |
+          # Normalize dockerfile path: remove './' prefix and replace '/' with '-'
+          normalized_dockerfile="${DOCKERFILE#./}"
+          normalized_dockerfile="${normalized_dockerfile//\//-}"
+
           # Build cache scope from OS, architecture, and optional suffix
-          docker_cache_suffix="${DOCKER_TAG_CUSTOM_SUFFIX:-${NORMALIZED_DOCKERFILE}}"
+          docker_cache_suffix="${DOCKER_TAG_CUSTOM_SUFFIX:-${normalized_dockerfile}}"
           DOCKER_CACHE_SCOPE="${RUNNER_OS}-${RUNNER_ARCH}"
 
           if [[ -n "${docker_cache_suffix}" ]]; then

--- a/workflows/reusable-docker-build-publish/reusable-docker-build-publish.yml
+++ b/workflows/reusable-docker-build-publish/reusable-docker-build-publish.yml
@@ -509,6 +509,9 @@ jobs:
           GITHUB_EVENT_NAME: ${{ inputs.github-event-name }}
           REPO_TRUNK: ${{ steps.get-trunk.outputs.trunk }}
           DOCKER_CACHE_BEHAVIOUR: ${{ inputs.docker-cache-behaviour }}
+          RUNNER_OS: ${{ runner.os }}
+          RUNNER_ARCH: ${{ runner.arch }}
+          NORMALIZED_DOCKERFILE: ${{ replace(replace(inputs.dockerfile, './', ''), '/', '-') }}
           DOCKER_CACHE_SCOPE: >-
             ${{ runner.os }}-${{ runner.arch }}-${{
               replace(
@@ -516,10 +519,18 @@ jobs:
                 '/',
                 '-'
               )
-            }}
+            }}-${{ inputs.docker-tag-custom-suffix || 'root' }}
+          DOCKER_TAG_CUSTOM_SUFFIX: ${{ inputs.docker-tag-custom-suffix }}
           BUILD_CACHE_TO: "type=gha,timeout=10m,mode=max,ignore-error=true,compression=zstd,compression-level=3"
           BUILD_CACHE_FROM: "type=gha,timeout=10m"
         run: |
+          docker_cache_suffix="${DOCKER_TAG_CUSTOM_SUFFIX:-${NORMALIZED_DOCKERFILE:-}}"
+
+          DOCKER_CACHE_SCOPE="${RUNNER_OS}-${RUNNER_ARCH}"
+          if [[ -n "${docker_cache_suffix}" ]]; then
+            DOCKER_CACHE_SCOPE="${DOCKER_CACHE_SCOPE}-${docker_cache_suffix}"
+          fi
+
           echo "docker-build-cache-to=${BUILD_CACHE_TO},scope=${DOCKER_CACHE_SCOPE}" | tee -a "${GITHUB_OUTPUT}"
           echo "docker-build-cache-from=${BUILD_CACHE_FROM},scope=${DOCKER_CACHE_SCOPE}" | tee -a "${GITHUB_OUTPUT}"
 

--- a/workflows/reusable-docker-build-publish/reusable-docker-build-publish.yml
+++ b/workflows/reusable-docker-build-publish/reusable-docker-build-publish.yml
@@ -413,6 +413,8 @@ jobs:
       build-type: ${{ steps.set-extra-outputs.outputs.build-type }}
       docker-restore-cache: ${{ steps.should-cache.outputs.docker-restore-cache }}
       docker-save-cache: ${{ steps.should-cache.outputs.docker-save-cache }}
+      docker-build-cache-to: ${{ steps.should-cache.outputs.docker-build-cache-to }}
+      docker-build-cache-from: ${{ steps.should-cache.outputs.docker-build-cache-from }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -500,14 +502,27 @@ jobs:
           fi
           echo "trunk=${trunk}" | tee -a "${GITHUB_OUTPUT}"
 
-      - name: Check docker cache constraints
+      - name: Setup docker cache values
         id: should-cache
         env:
           GITHUB_REF_NAME: ${{ inputs.github-ref-name }}
           GITHUB_EVENT_NAME: ${{ inputs.github-event-name }}
           REPO_TRUNK: ${{ steps.get-trunk.outputs.trunk }}
           DOCKER_CACHE_BEHAVIOUR: ${{ inputs.docker-cache-behaviour }}
+          DOCKER_CACHE_SCOPE: >-
+            ${{ runner.os }}-${{ runner.arch }}-${{
+              replace(
+                replace(inputs.dockerfile, './', ''),
+                '/',
+                '-'
+              )
+            }}
+          BUILD_CACHE_TO: "type=gha,timeout=10m,mode=max,ignore-error=true,compression=zstd,compression-level=3"
+          BUILD_CACHE_FROM: "type=gha,timeout=10m"
         run: |
+          echo "docker-build-cache-to=${BUILD_CACHE_TO},scope=${DOCKER_CACHE_SCOPE}" | tee -a "${GITHUB_OUTPUT}"
+          echo "docker-build-cache-from=${BUILD_CACHE_FROM},scope=${DOCKER_CACHE_SCOPE}" | tee -a "${GITHUB_OUTPUT}"
+
           if [[ "${DOCKER_CACHE_BEHAVIOUR}" == "disable" ]]; then
             echo "docker-restore-cache=false" | tee -a "${GITHUB_OUTPUT}"
             echo "docker-save-cache=false" | tee -a "${GITHUB_OUTPUT}"
@@ -515,14 +530,14 @@ jobs:
             echo "docker-restore-cache=true" | tee -a "${GITHUB_OUTPUT}"
             echo "docker-save-cache=true" | tee -a "${GITHUB_OUTPUT}"
           elif [[ "${DOCKER_CACHE_BEHAVIOUR}" == "write-on-trunk" ]]; then
-              echo "docker-restore-cache=true" | tee -a "${GITHUB_OUTPUT}"
+            echo "docker-restore-cache=true" | tee -a "${GITHUB_OUTPUT}"
             if [[ "${GITHUB_REF_NAME}" == "${REPO_TRUNK}" ]] && [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
               echo "docker-save-cache=true" | tee -a "${GITHUB_OUTPUT}"
             else
               echo "docker-save-cache=false" | tee -a "${GITHUB_OUTPUT}"
             fi
           else
-            echo "::error::Invalid DOCKER_CACHE_BEHAVIOUR: ${DOCKER_CACHE_BEHAVIOUR}. Must be one of: disabled, enabled, write-on-trunk."
+            echo "::error::Invalid DOCKER_CACHE_BEHAVIOUR: ${DOCKER_CACHE_BEHAVIOUR}. Must be one of: disable, enable, write-on-trunk."
             exit 1
           fi
 
@@ -572,6 +587,9 @@ jobs:
       - name: Free up disk space
         if: ${{ inputs.free-disk-space == 'true' }}
         uses: smartcontractkit/.github/actions/free-disk-space@free-disk-space/v1
+
+      - name: Enable S3 Cache for Self-Hosted Runners
+        uses: runs-on/action@4e5f72399b6b17f2e79c511c1b38a315a64d22dc # v2.2.0
 
       - uses: actions/checkout@v6
         id: checkout
@@ -708,6 +726,8 @@ jobs:
           docker-build-args: ${{ inputs.docker-build-args }}
           docker-restore-cache: ${{ needs.init.outputs.docker-restore-cache }}
           docker-save-cache: ${{ needs.init.outputs.docker-save-cache }}
+          docker-build-cache-to: ${{ needs.init.outputs.docker-build-cache-to }}
+          docker-build-cache-from: ${{ needs.init.outputs.docker-build-cache-from }}
           context: ${{ inputs.docker-build-context }}
           docker-build-contexts: ${{ inputs.docker-build-contexts }}
           docker-push: ${{ inputs.docker-push }}


### PR DESCRIPTION
### Changes

* Adds default `cache-to` and `cache-from` values
* Compute a relevant cache scope based on dockerfile path, custom tag suffixes, and runner os/arch
* Adds S3 cache setup (this no-ops for GH-hosted runners)

### Testing

* https://github.com/smartcontractkit/chainlink/pull/23144
* Got as fast as 5m19s in the best case scenario: https://github.com/smartcontractkit/chainlink/actions/runs/29467579485

---

DX-4666