### PR TITLE
[DX-4553] Compile + Run Fan Out

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -912,7 +912,6 @@ jobs:
           go_mod_path: ./integration-tests/go.mod
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
-          should_tidy: "false"
           go_coverage_src_dir: /var/tmp/go-coverage
           go_coverage_dest_dir: ${{ github.workspace }}/.covdata
           main-dns-zone: ${{ secrets.MAIN_DNS_ZONE_PUBLIC_SDLC }}
@@ -1373,7 +1372,6 @@ jobs:
           go_mod_path: ./integration-tests/go.mod
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
-          should_tidy: "false"
           go_coverage_src_dir: /var/tmp/go-coverage
           go_coverage_dest_dir: ${{ github.workspace }}/.covdata
           main-dns-zone: ${{ secrets.MAIN_DNS_ZONE_PUBLIC_SDLC }}

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -188,6 +188,11 @@ on:
         required: false
         type: number
         default: 60
+      cache_builds:
+        description: "Cache go builds (GOCACHE). Set to 'true' to enable go build cache sharing."
+        required: false
+        type: string
+        default: "false"
     outputs:
       test_results:
         description: "Test results from all executed tests"
@@ -903,6 +908,7 @@ jobs:
           publish_check_name: ${{ env.TEST_ID }}
           token: ${{ secrets.GH_TOKEN }}
           cache_key_id: e2e-tests
+          cache_builds: ${{ inputs.cache_builds }}
           go_mod_path: ./integration-tests/go.mod
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -1220,6 +1226,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
           should_cleanup: false
           cache_key_id: e2e-tests
+          cache_builds: ${{ inputs.cache_builds }}
           go_mod_path: ./integration-tests/go.mod
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -912,6 +912,7 @@ jobs:
           go_mod_path: ./integration-tests/go.mod
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
+          should_tidy: "false"
           go_coverage_src_dir: /var/tmp/go-coverage
           go_coverage_dest_dir: ${{ github.workspace }}/.covdata
           main-dns-zone: ${{ secrets.MAIN_DNS_ZONE_PUBLIC_SDLC }}
@@ -1372,6 +1373,7 @@ jobs:
           go_mod_path: ./integration-tests/go.mod
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
+          should_tidy: "false"
           go_coverage_src_dir: /var/tmp/go-coverage
           go_coverage_dest_dir: ${{ github.workspace }}/.covdata
           main-dns-zone: ${{ secrets.MAIN_DNS_ZONE_PUBLIC_SDLC }}

--- a/actions/ctf-build-tests/action.yml
+++ b/actions/ctf-build-tests/action.yml
@@ -27,6 +27,16 @@ inputs:
   go_tags:
     required: false
     description: Go tags to use when building
+  cache_restore_only:
+    required: false
+    description:
+      Only restore the cache, set to true if you want to restore and save on
+      cache hit miss
+    default: "false"
+  cache_key_id:
+    required: false
+    description: Cache go vendors unique id
+    default: go
   dep_chainlink_integration_tests:
     required: false
     description: chainlink/integration-tests commit or branch
@@ -38,19 +48,17 @@ inputs:
 runs:
   using: composite
   steps:
-    # Setup Tools and libraries (replaces ctf-setup-go with actions/setup-go@v7)
+    # Setup Tools and libraries
     - name: Setup Go
-      uses: actions/setup-go@v7
+      uses: smartcontractkit/.github/actions/ctf-setup-go@b0d756c57fcdbcff187e74166562a029fdd5d1b9 # ctf-setup-go@0.0.0
       with:
-        go-version-file: ${{ inputs.go_mod_path }}
-        go-version: ${{ inputs.go_version }}
-        check-latest: true
-        cache: true
-
-    - name: Run go mod download
-      if: inputs.test_download_vendor_packages_command
-      shell: bash
-      run: ${{ inputs.test_download_vendor_packages_command }}
+        test_download_vendor_packages_command:
+          ${{ inputs.test_download_vendor_packages_command }}
+        go_version: ${{ inputs.go_version }}
+        go_mod_path: ${{ inputs.go_mod_path }}
+        cache_restore_only: ${{ inputs.cache_restore_only }}
+        cache_key_id: ${{ inputs.cache_key_id }}
+        should_tidy: "true"
 
     - name: Replace chainlink/integration-tests deps
       if: ${{ inputs.dep_chainlink_integration_tests }}

--- a/actions/ctf-build-tests/action.yml
+++ b/actions/ctf-build-tests/action.yml
@@ -27,16 +27,6 @@ inputs:
   go_tags:
     required: false
     description: Go tags to use when building
-  cache_restore_only:
-    required: false
-    description:
-      Only restore the cache, set to true if you want to restore and save on
-      cache hit miss
-    default: "false"
-  cache_key_id:
-    required: false
-    description: Cache go vendors unique id
-    default: go
   dep_chainlink_integration_tests:
     required: false
     description: chainlink/integration-tests commit or branch
@@ -48,17 +38,19 @@ inputs:
 runs:
   using: composite
   steps:
-    # Setup Tools and libraries
+    # Setup Tools and libraries (replaces ctf-setup-go with actions/setup-go@v7)
     - name: Setup Go
-      uses: smartcontractkit/.github/actions/ctf-setup-go@b0d756c57fcdbcff187e74166562a029fdd5d1b9 # ctf-setup-go@0.0.0
+      uses: actions/setup-go@v7
       with:
-        test_download_vendor_packages_command:
-          ${{ inputs.test_download_vendor_packages_command }}
-        go_version: ${{ inputs.go_version }}
-        go_mod_path: ${{ inputs.go_mod_path }}
-        cache_restore_only: ${{ inputs.cache_restore_only }}
-        cache_key_id: ${{ inputs.cache_key_id }}
-        should_tidy: "true"
+        go-version-file: ${{ inputs.go_mod_path }}
+        go-version: ${{ inputs.go_version }}
+        check-latest: true
+        cache: true
+
+    - name: Run go mod download
+      if: inputs.test_download_vendor_packages_command
+      shell: bash
+      run: ${{ inputs.test_download_vendor_packages_command }}
 
     - name: Replace chainlink/integration-tests deps
       if: ${{ inputs.dep_chainlink_integration_tests }}

--- a/actions/ctf-run-tests/action.yml
+++ b/actions/ctf-run-tests/action.yml
@@ -159,10 +159,6 @@ inputs:
       Whether to run the cleanup at the end, soak tests and such would not want
       to automatically cleanup
     default: "false"
-  should_tidy:
-    required: false
-    description: Should we check go mod tidy
-    default: "true"
   no_cache:
     required: false
     description: Do not use a go cache
@@ -247,7 +243,6 @@ runs:
         dockerhub_password: ${{ inputs.dockerhub_password }}
         QA_AWS_REGION: ${{ inputs.QA_AWS_REGION }}
         QA_AWS_ROLE_TO_ASSUME: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}
-        should_tidy: ${{ inputs.should_tidy }}
         no_cache: ${{ inputs.no_cache }}
         prod_aws_role_to_assume: ${{ inputs.prod_aws_role_to_assume }}
         prod_aws_region: ${{ inputs.prod_aws_region }}

--- a/actions/ctf-run-tests/action.yml
+++ b/actions/ctf-run-tests/action.yml
@@ -113,6 +113,10 @@ inputs:
       Only restore the cache, set to true if you want to restore and save on
       cache hit miss
     default: "false"
+  cache_builds:
+    required: false
+    description: Cache go builds (GOCACHE). Defaults to false.
+    default: "false"
   cache_key_id:
     required: false
     description: Cache go vendors unique id
@@ -236,6 +240,7 @@ runs:
         go_mod_path: ${{ inputs.go_mod_path }}
         cache_restore_only: ${{ inputs.cache_restore_only }}
         cache_key_id: ${{ inputs.cache_key_id }}
+        cache_builds: ${{ inputs.cache_builds }}
         aws_registries: ${{ inputs.aws_registries }}
         aws_role_duration_seconds: ${{ inputs.aws_role_duration_seconds }}
         dockerhub_username: ${{ inputs.dockerhub_username }}

--- a/actions/ctf-run-tests/action.yml
+++ b/actions/ctf-run-tests/action.yml
@@ -159,6 +159,10 @@ inputs:
       Whether to run the cleanup at the end, soak tests and such would not want
       to automatically cleanup
     default: "false"
+  should_tidy:
+    required: false
+    description: Should we check go mod tidy
+    default: "true"
   no_cache:
     required: false
     description: Do not use a go cache
@@ -243,6 +247,7 @@ runs:
         dockerhub_password: ${{ inputs.dockerhub_password }}
         QA_AWS_REGION: ${{ inputs.QA_AWS_REGION }}
         QA_AWS_ROLE_TO_ASSUME: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}
+        should_tidy: ${{ inputs.should_tidy }}
         no_cache: ${{ inputs.no_cache }}
         prod_aws_role_to_assume: ${{ inputs.prod_aws_role_to_assume }}
         prod_aws_region: ${{ inputs.prod_aws_region }}

--- a/actions/ctf-setup-go/action.yml
+++ b/actions/ctf-setup-go/action.yml
@@ -72,7 +72,7 @@ runs:
         fi
 
     - name: Setup Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@v7
       with:
         go-version: ${{ steps.export-go-version.outputs.go_version }}
         check-latest: true
@@ -94,7 +94,7 @@ runs:
 
     - name: Cache Go Modules
       if: inputs.cache_restore_only == 'false' && inputs.no_cache == 'false'
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       id: cache-packages
       with:
         path: ${{ steps.go-cache-dir.outputs.gomodcache }}
@@ -104,7 +104,7 @@ runs:
         restore-keys: |
           ${{ runner.os }}-${{ inputs.cache_key_id }}-gomod-
 
-    - uses: actions/cache@v5
+    - uses: actions/cache@v6
       if: inputs.cache_restore_only == 'false' && inputs.cache_builds == 'true'
       name: Cache Go Builds
       with:
@@ -118,7 +118,7 @@ runs:
 
     - name: Restore Go Modules
       if: inputs.cache_restore_only != 'false' && inputs.no_cache == 'false'
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@v6
       id: restore-cache-packages
       with:
         path: |

--- a/actions/ctf-setup-run-tests-environment/action.yml
+++ b/actions/ctf-setup-run-tests-environment/action.yml
@@ -54,6 +54,10 @@ inputs:
   QA_AWS_ROLE_TO_ASSUME:
     required: true
     description: The AWS role to assume
+  should_tidy:
+    required: false
+    description: Should we check go mod tidy
+    default: "true"
   no_cache:
     required: false
     description: Do not use a go cache
@@ -135,63 +139,21 @@ runs:
           exit 1
         fi
 
-    # Go setup and caching (replaces ctf-setup-go with actions/setup-go@v7)
+    # Go setup and caching
     - name: Setup Go
       if: inputs.go_necessary == 'true'
-      uses: actions/setup-go@v7
+      uses: smartcontractkit/.github/actions/ctf-setup-go@c83a1867f404a79db873b55f1a5fd30b42569bbb # ctf-setup-go@0.2.0
       with:
-        go-version-file: ${{ inputs.go_mod_path }}
-        go-version: ${{ inputs.go_version }}
-        check-latest: true
-        cache: ${{ inputs.no_cache == 'false' }}
-
-    - name: Setup Go with private repo access
-      if: inputs.go_necessary == 'true' && inputs.gati_token != ''
-      shell: bash
-      run: |
-        git config --global url."https://x-access-token:${{ inputs.gati_token }}@github.com/".insteadOf "https://github.com/"
-        go env -w GOPRIVATE=github.com/smartcontractkit/*
-
-    - name: Set go cache dir
-      if:
-        inputs.go_necessary == 'true' && inputs.cache_builds == 'true' &&
-        inputs.no_cache == 'false'
-      shell: bash
-      id: go-cache-dir
-      run: echo "gobuildcache=$(go env GOCACHE)" >> $GITHUB_OUTPUT
-
-    - name: Cache Go Builds
-      if:
-        inputs.go_necessary == 'true' && inputs.cache_builds == 'true' &&
-        inputs.cache_restore_only == 'false' && inputs.no_cache == 'false'
-      uses: actions/cache@v6
-      with:
-        path: ${{ steps.go-cache-dir.outputs.gobuildcache }}
-        key:
-          ${{ runner.os }}-${{ inputs.cache_key_id }}-gobuild-${{
-          hashFiles(inputs.go_mod_path) }}
-        restore-keys: |
-          ${{ runner.os }}-${{ inputs.cache_key_id }}-gobuild-
-
-    - name: Restore Go Builds
-      if:
-        inputs.go_necessary == 'true' && inputs.cache_builds == 'true' &&
-        inputs.cache_restore_only != 'false' && inputs.no_cache == 'false'
-      uses: actions/cache/restore@v6
-      with:
-        path: ${{ steps.go-cache-dir.outputs.gobuildcache }}
-        key:
-          ${{ runner.os }}-${{ inputs.cache_key_id }}-gobuild-${{
-          hashFiles(inputs.go_mod_path) }}
-        restore-keys: |
-          ${{ runner.os }}-${{ inputs.cache_key_id }}-gobuild-
-
-    - name: Run go mod download
-      if:
-        inputs.go_necessary == 'true' &&
-        inputs.test_download_vendor_packages_command
-      shell: bash
-      run: ${{ inputs.test_download_vendor_packages_command }}
+        go_version: ${{ inputs.go_version }}
+        go_mod_path: ${{ inputs.go_mod_path }}
+        cache_restore_only: ${{ inputs.cache_restore_only }}
+        cache_key_id: ${{ inputs.cache_key_id }}
+        cache_builds: ${{ inputs.cache_builds }}
+        should_tidy: ${{ inputs.should_tidy }}
+        no_cache: ${{ inputs.no_cache }}
+        test_download_vendor_packages_command:
+          ${{ inputs.test_download_vendor_packages_command }}
+        gati_token: ${{ inputs.gati_token }}
 
     - name: Setup postgres container
       id: setup-pg

--- a/actions/ctf-setup-run-tests-environment/action.yml
+++ b/actions/ctf-setup-run-tests-environment/action.yml
@@ -54,10 +54,6 @@ inputs:
   QA_AWS_ROLE_TO_ASSUME:
     required: true
     description: The AWS role to assume
-  should_tidy:
-    required: false
-    description: Should we check go mod tidy
-    default: "true"
   no_cache:
     required: false
     description: Do not use a go cache
@@ -139,21 +135,63 @@ runs:
           exit 1
         fi
 
-    # Go setup and caching
+    # Go setup and caching (replaces ctf-setup-go with actions/setup-go@v7)
     - name: Setup Go
       if: inputs.go_necessary == 'true'
-      uses: smartcontractkit/.github/actions/ctf-setup-go@c83a1867f404a79db873b55f1a5fd30b42569bbb # ctf-setup-go@0.2.0
+      uses: actions/setup-go@v7
       with:
-        go_version: ${{ inputs.go_version }}
-        go_mod_path: ${{ inputs.go_mod_path }}
-        cache_restore_only: ${{ inputs.cache_restore_only }}
-        cache_key_id: ${{ inputs.cache_key_id }}
-        cache_builds: ${{ inputs.cache_builds }}
-        should_tidy: ${{ inputs.should_tidy }}
-        no_cache: ${{ inputs.no_cache }}
-        test_download_vendor_packages_command:
-          ${{ inputs.test_download_vendor_packages_command }}
-        gati_token: ${{ inputs.gati_token }}
+        go-version-file: ${{ inputs.go_mod_path }}
+        go-version: ${{ inputs.go_version }}
+        check-latest: true
+        cache: ${{ inputs.no_cache == 'false' }}
+
+    - name: Setup Go with private repo access
+      if: inputs.go_necessary == 'true' && inputs.gati_token != ''
+      shell: bash
+      run: |
+        git config --global url."https://x-access-token:${{ inputs.gati_token }}@github.com/".insteadOf "https://github.com/"
+        go env -w GOPRIVATE=github.com/smartcontractkit/*
+
+    - name: Set go cache dir
+      if:
+        inputs.go_necessary == 'true' && inputs.cache_builds == 'true' &&
+        inputs.no_cache == 'false'
+      shell: bash
+      id: go-cache-dir
+      run: echo "gobuildcache=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+
+    - name: Cache Go Builds
+      if:
+        inputs.go_necessary == 'true' && inputs.cache_builds == 'true' &&
+        inputs.cache_restore_only == 'false' && inputs.no_cache == 'false'
+      uses: actions/cache@v6
+      with:
+        path: ${{ steps.go-cache-dir.outputs.gobuildcache }}
+        key:
+          ${{ runner.os }}-${{ inputs.cache_key_id }}-gobuild-${{
+          hashFiles(inputs.go_mod_path) }}
+        restore-keys: |
+          ${{ runner.os }}-${{ inputs.cache_key_id }}-gobuild-
+
+    - name: Restore Go Builds
+      if:
+        inputs.go_necessary == 'true' && inputs.cache_builds == 'true' &&
+        inputs.cache_restore_only != 'false' && inputs.no_cache == 'false'
+      uses: actions/cache/restore@v6
+      with:
+        path: ${{ steps.go-cache-dir.outputs.gobuildcache }}
+        key:
+          ${{ runner.os }}-${{ inputs.cache_key_id }}-gobuild-${{
+          hashFiles(inputs.go_mod_path) }}
+        restore-keys: |
+          ${{ runner.os }}-${{ inputs.cache_key_id }}-gobuild-
+
+    - name: Run go mod download
+      if:
+        inputs.go_necessary == 'true' &&
+        inputs.test_download_vendor_packages_command
+      shell: bash
+      run: ${{ inputs.test_download_vendor_packages_command }}
 
     - name: Setup postgres container
       id: setup-pg

--- a/actions/ctf-setup-run-tests-environment/action.yml
+++ b/actions/ctf-setup-run-tests-environment/action.yml
@@ -25,6 +25,10 @@ inputs:
       Only restore the cache, set to true if you want to restore and save on
       cache hit miss
     default: "false"
+  cache_builds:
+    required: false
+    description: Cache go builds (GOCACHE). Defaults to false.
+    default: "false"
   cache_key_id:
     required: false
     description: Cache go vendors unique id
@@ -144,6 +148,7 @@ runs:
         go_mod_path: ${{ inputs.go_mod_path }}
         cache_restore_only: ${{ inputs.cache_restore_only }}
         cache_key_id: ${{ inputs.cache_key_id }}
+        cache_builds: ${{ inputs.cache_builds }}
         should_tidy: ${{ inputs.should_tidy }}
         no_cache: ${{ inputs.no_cache }}
         test_download_vendor_packages_command:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,10 +9,12 @@ pre-commit:
   parallel: true
   commands:
     prettier:
-      description: "Check for prettier formatting"
+      description: "Fix prettier formatting"
       glob: "*.{json,md,scss,yaml,yml}"
-      run: pnpm hook:check {staged_files}
+      run: pnpm hook:fix {staged_files}
+      stage_fixed: true
     reusable-workflows:
-      description: "Check reusable workflows are synced"
+      description: "Fix reusable workflows sync"
       glob: "{workflows/*/*,.github/workflows/*}.{yml,yaml}"
-      run: pnpm workflows:check {staged_files}
+      run: pnpm workflows:fix {staged_files}
+      stage_fixed: true

--- a/tools/scripts/sync-reusable-workflows.sh
+++ b/tools/scripts/sync-reusable-workflows.sh
@@ -155,12 +155,6 @@ done
 # Post-processing
 # ------------------------------------------------------------
 
-if [[ "$MODE" == "fix" && $changed_count -gt 0 ]]; then
-  err "regenerated $changed_count file(s) under $DST_ROOT — please stage them:"
-  err "  git add $DST_ROOT"
-  exit 1
-fi
-
 if [[ $strict_fail -eq 1 ]]; then
   if [[ "$MODE" == "check" ]]; then
     err "impacted reusable workflows are out of sync."

--- a/workflows/run-e2e-tests/run-e2e-tests.yml
+++ b/workflows/run-e2e-tests/run-e2e-tests.yml
@@ -184,6 +184,11 @@ on:
         required: false
         type: number
         default: 60
+      cache_builds:
+        description: "Cache go builds (GOCACHE). Set to 'true' to enable go build cache sharing."
+        required: false
+        type: string
+        default: "false"
     outputs:
       test_results:
         description: "Test results from all executed tests"
@@ -899,6 +904,7 @@ jobs:
           publish_check_name: ${{ env.TEST_ID }}
           token: ${{ secrets.GH_TOKEN }}
           cache_key_id: e2e-tests
+          cache_builds: ${{ inputs.cache_builds }}
           go_mod_path: ./integration-tests/go.mod
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -1216,6 +1222,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
           should_cleanup: false
           cache_key_id: e2e-tests
+          cache_builds: ${{ inputs.cache_builds }}
           go_mod_path: ./integration-tests/go.mod
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}

--- a/workflows/run-e2e-tests/run-e2e-tests.yml
+++ b/workflows/run-e2e-tests/run-e2e-tests.yml
@@ -908,7 +908,6 @@ jobs:
           go_mod_path: ./integration-tests/go.mod
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
-          should_tidy: "false"
           go_coverage_src_dir: /var/tmp/go-coverage
           go_coverage_dest_dir: ${{ github.workspace }}/.covdata
           main-dns-zone: ${{ secrets.MAIN_DNS_ZONE_PUBLIC_SDLC }}
@@ -1369,7 +1368,6 @@ jobs:
           go_mod_path: ./integration-tests/go.mod
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
-          should_tidy: "false"
           go_coverage_src_dir: /var/tmp/go-coverage
           go_coverage_dest_dir: ${{ github.workspace }}/.covdata
           main-dns-zone: ${{ secrets.MAIN_DNS_ZONE_PUBLIC_SDLC }}

--- a/workflows/run-e2e-tests/run-e2e-tests.yml
+++ b/workflows/run-e2e-tests/run-e2e-tests.yml
@@ -908,6 +908,7 @@ jobs:
           go_mod_path: ./integration-tests/go.mod
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
+          should_tidy: "false"
           go_coverage_src_dir: /var/tmp/go-coverage
           go_coverage_dest_dir: ${{ github.workspace }}/.covdata
           main-dns-zone: ${{ secrets.MAIN_DNS_ZONE_PUBLIC_SDLC }}
@@ -1368,6 +1369,7 @@ jobs:
           go_mod_path: ./integration-tests/go.mod
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
+          should_tidy: "false"
           go_coverage_src_dir: /var/tmp/go-coverage
           go_coverage_dest_dir: ${{ github.workspace }}/.covdata
           main-dns-zone: ${{ secrets.MAIN_DNS_ZONE_PUBLIC_SDLC }}


### PR DESCRIPTION
* Preps for passing Go caches around to different jobs so we can compile test code and build Docker containers at the same time for `Integration Tests`
* Fixes lefthook to stage fix changes instead of just telling me to run the fix script again.

