### PR TITLE
chore: gha dependency bumps

### DIFF
--- a/.changeset/dull-pumas-doubt.md
+++ b/.changeset/dull-pumas-doubt.md
@@ -1,0 +1,40 @@
+---
+"cicd-build-publish-artifacts-go": patch
+"cicd-build-publish-artifacts-ts": patch
+"beholder-pulumi-deploy-schema": patch
+"guard-from-missing-changesets": patch
+"parse-and-mask-test-secrets": patch
+"cicd-build-publish-charts": patch
+"llm-action-error-reporter": patch
+"chip-schema-registration": patch
+"crib-deploy-environment": patch
+"validate-protos-version": patch
+"ci-beholder-validator": patch
+"guard-tag-from-branch": patch
+"cleanup-old-branches": patch
+"ctf-build-test-image": patch
+"slack-notify-git-ref": patch
+"devenv-k8s-setup-ns": patch
+"md-confluence-sync": patch
+"pr-quality-check": patch
+"bump-mcms-tools": patch
+"ci-benchmarking": patch
+"ci-sonarqube-go": patch
+"ci-sonarqube-ts": patch
+"ctf-build-image": patch
+"ci-kubeconform": patch
+"ci-lint-charts": patch
+"setup-renovate": patch
+"update-actions": patch
+"llm-pr-writer": patch
+"ci-lint-misc": patch
+"setup-golang": patch
+"ci-prettier": patch
+"ci-test-sol": patch
+"ci-lint-go": patch
+"ci-lint-ts": patch
+"ci-test-go": patch
+"ci-test-ts": patch
+---
+
+chore: gha dependency bumps

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Check if deny licenses are in sync
         id: check-sync

--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -32,7 +32,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -49,7 +49,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # Commit back any changes based on the commit that triggered this action
           # rather than merge commit of main into the PR branch
@@ -101,7 +101,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -119,7 +119,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -136,7 +136,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -163,7 +163,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: ci-lint
         uses: ./actions/ci-lint-ts
@@ -29,7 +29,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -46,7 +46,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -68,7 +68,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -87,7 +87,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/reusable-apidiff-go-analysis.yml
+++ b/.github/workflows/reusable-apidiff-go-analysis.yml
@@ -74,7 +74,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@v6
         with:
           go-version-file: ${{ matrix.module }}/go.mod
           cache: false

--- a/.github/workflows/reusable-apidiff-go-analysis.yml
+++ b/.github/workflows/reusable-apidiff-go-analysis.yml
@@ -74,7 +74,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version-file: ${{ matrix.module }}/go.mod
           cache: false

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -436,7 +436,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: "1.24.0"
           check-latest: true

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -436,7 +436,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@v6
         with:
           go-version: "1.24.0"
           check-latest: true

--- a/.github/workflows/schedule-renovate.yml
+++ b/.github/workflows/schedule-renovate.yml
@@ -17,7 +17,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repo (needed to reference local action)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/setup-postgres-validate.yml
+++ b/.github/workflows/setup-postgres-validate.yml
@@ -31,7 +31,7 @@ jobs:
             want_shared_buffers: "128MB"
             want_fsync: "off"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/solidity-review-artifacts.yml
+++ b/.github/workflows/solidity-review-artifacts.yml
@@ -340,7 +340,7 @@ jobs:
 
       - name: Set up Python
         if: ${{ inputs.generate_slither_reports == true }}
-        uses: actions/setup-python@v5.6.0
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.8"
 

--- a/.github/workflows/solidity-review-artifacts.yml
+++ b/.github/workflows/solidity-review-artifacts.yml
@@ -141,7 +141,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout the caller repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -207,7 +207,7 @@ jobs:
     needs: [gather-basic-info]
     steps:
       - name: Checkout the caller repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           ref: ${{ env.head_ref }}
           persist-credentials: false
@@ -308,14 +308,14 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout caller repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
           ref: ${{ env.head_ref }}
           persist-credentials: false
 
       - name: Checkout .github repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           repository: smartcontractkit/.github
           ref: 65249c7eae628aad6e70a0c0850d981cd0074bf9
@@ -472,14 +472,14 @@ jobs:
 
       - name: Checkout caller repository
         if: ${{ inputs.link_with_jira == true }}
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           ref: ${{ env.head_ref }}
           persist-credentials: false
 
       - name: Checkout chainlink-github-actions repository
         if: ${{ inputs.link_with_jira == true }}
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           repository: smartcontractkit/.github
           ref: 65249c7eae628aad6e70a0c0850d981cd0074bf9

--- a/actions/beholder-pulumi-deploy-schema/action.yml
+++ b/actions/beholder-pulumi-deploy-schema/action.yml
@@ -24,7 +24,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Docker login to ECR
       shell: bash

--- a/actions/bump-mcms-tools/action.yml
+++ b/actions/bump-mcms-tools/action.yml
@@ -36,7 +36,7 @@ runs:
   using: "composite"
   steps:
     - name: Check out
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Resolve latest tag
       id: latest

--- a/actions/chip-schema-registration/action.yml
+++ b/actions/chip-schema-registration/action.yml
@@ -44,7 +44,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Login to ECR
       uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2

--- a/actions/ci-beholder-validator/action.yml
+++ b/actions/ci-beholder-validator/action.yml
@@ -31,7 +31,7 @@ runs:
   using: composite
   steps:
     - name: Checkout repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/ci-benchmarking/action.yml
+++ b/actions/ci-benchmarking/action.yml
@@ -53,7 +53,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout Code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Setup Go Environment
       uses: actions/setup-go@v6

--- a/actions/ci-benchmarking/action.yml
+++ b/actions/ci-benchmarking/action.yml
@@ -56,7 +56,7 @@ runs:
       uses: actions/checkout@v7
 
     - name: Setup Go Environment
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@v7
       with:
         go-version: "stable"
 

--- a/actions/ci-kubeconform/action.yml
+++ b/actions/ci-kubeconform/action.yml
@@ -50,7 +50,7 @@ runs:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@v7
       with:
         go-version-file: ${{ inputs.go-version-file }}
 

--- a/actions/ci-kubeconform/action.yml
+++ b/actions/ci-kubeconform/action.yml
@@ -45,7 +45,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/ci-lint-charts/action.yml
+++ b/actions/ci-lint-charts/action.yml
@@ -30,7 +30,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/ci-lint-go/action.yml
+++ b/actions/ci-lint-go/action.yml
@@ -103,7 +103,7 @@ runs:
         envFile: ${{ inputs.env-files }}
 
     - name: Setup go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@v7
       with:
         go-version-file: ${{ inputs.go-version-file }}
         cache: ${{ inputs.use-go-cache }}

--- a/actions/ci-lint-go/action.yml
+++ b/actions/ci-lint-go/action.yml
@@ -81,7 +81,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/ci-lint-misc/action.yml
+++ b/actions/ci-lint-misc/action.yml
@@ -21,7 +21,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/ci-lint-ts/action.yml
+++ b/actions/ci-lint-ts/action.yml
@@ -34,7 +34,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/ci-prettier/action.yml
+++ b/actions/ci-prettier/action.yml
@@ -36,7 +36,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/ci-sonarqube-go/action.yml
+++ b/actions/ci-sonarqube-go/action.yml
@@ -46,7 +46,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/ci-sonarqube-ts/action.yml
+++ b/actions/ci-sonarqube-ts/action.yml
@@ -54,7 +54,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/ci-test-go/action.yml
+++ b/actions/ci-test-go/action.yml
@@ -102,7 +102,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/ci-test-sol/action.yml
+++ b/actions/ci-test-sol/action.yml
@@ -55,7 +55,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/ci-test-ts/action.yml
+++ b/actions/ci-test-ts/action.yml
@@ -34,7 +34,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/cicd-build-publish-artifacts-go/action.yml
+++ b/actions/cicd-build-publish-artifacts-go/action.yml
@@ -110,7 +110,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
         ref: ${{ inputs.checkout-ref }}

--- a/actions/cicd-build-publish-artifacts-go/action.yml
+++ b/actions/cicd-build-publish-artifacts-go/action.yml
@@ -127,7 +127,7 @@ runs:
         set-git-config: "true"
 
     - name: Setup go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@v7
       with:
         go-version-file: ${{ inputs.go-version-file }}
         cache: ${{ inputs.use-go-cache }}

--- a/actions/cicd-build-publish-artifacts-ts/action.yml
+++ b/actions/cicd-build-publish-artifacts-ts/action.yml
@@ -70,7 +70,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/cicd-build-publish-charts/action.yml
+++ b/actions/cicd-build-publish-charts/action.yml
@@ -48,7 +48,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/cleanup-old-branches/action.yml
+++ b/actions/cleanup-old-branches/action.yml
@@ -42,7 +42,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -214,7 +214,7 @@ runs:
         websockets-services: ${{ env.WEBSOCKETS_SERVICES }}
 
     - name: Checkout crib repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         repository: "smartcontractkit/crib"
         ref: ${{ inputs.crib-repo-ref }}

--- a/actions/crib-deploy-environment/action.yml
+++ b/actions/crib-deploy-environment/action.yml
@@ -238,7 +238,7 @@ runs:
       with:
         registries: ${{ inputs.aws-ecr-private-registry }}
 
-    - uses: actions/setup-go@v6
+    - uses: actions/setup-go@v7
       with:
         go-version-file: "${{ github.workspace }}/crib/cli/go.mod"
         cache-dependency-path: "${{ github.workspace }}/crib/**/*.sum"

--- a/actions/ctf-build-image/action.yml
+++ b/actions/ctf-build-image/action.yml
@@ -156,7 +156,7 @@ runs:
 
     - name: Setup Go for dependency overrides
       if: inputs.go-get-overrides != ''
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@v7
       with:
         go-version-file: go.mod
         cache: false

--- a/actions/ctf-build-test-image/action.yml
+++ b/actions/ctf-build-test-image/action.yml
@@ -70,7 +70,7 @@ runs:
         echo "short_sha=${short_sha}" >> "$GITHUB_OUTPUT"
     - name: Checkout chainlink-testing-framework
       if: steps.version.outputs.is_semantic == 'false'
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         repository: smartcontractkit/chainlink-testing-framework
         ref: main

--- a/actions/devenv-k8s-setup-ns/action.yml
+++ b/actions/devenv-k8s-setup-ns/action.yml
@@ -109,7 +109,7 @@ runs:
         echo "workflow-run-number=${WORKFLOW_RUN_NUMBER}" | tee -a "$GITHUB_OUTPUT"
 
     - name: Checkout devenv repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         repository: "smartcontractkit/devenv"
         ref: ${{ inputs.devenv-repo-ref }}

--- a/actions/guard-from-missing-changesets/action.yml
+++ b/actions/guard-from-missing-changesets/action.yml
@@ -21,7 +21,7 @@ runs:
   steps:
     - name: Checkout full repo
       if: inputs.checkout == 'true'
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     - name: Install changesets
       shell: bash
       run: ${{ github.action_path }}/scripts/install-changesets.sh

--- a/actions/guard-tag-from-branch/action.yml
+++ b/actions/guard-tag-from-branch/action.yml
@@ -30,7 +30,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/llm-action-error-reporter/action.yml
+++ b/actions/llm-action-error-reporter/action.yml
@@ -43,7 +43,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout calling repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Check if this run is invoked from a pull request event
       shell: bash
@@ -68,7 +68,7 @@ runs:
 
     - name: Checkout action repo
       if: ${{ env.SKIP_ACTION == 'false' }}
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         repository: smartcontractkit/.github
         ref: ${{ inputs.workflow-ref }}

--- a/actions/llm-pr-writer/action.yml
+++ b/actions/llm-pr-writer/action.yml
@@ -47,7 +47,7 @@ runs:
 
     - name: Checkout calling repo
       if: ${{ env.SKIP_ACTION == 'false' }}
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/md-confluence-sync/action.yml
+++ b/actions/md-confluence-sync/action.yml
@@ -50,7 +50,7 @@ runs:
         prettier-command: pnpm prettier --check ${{ inputs.files }}
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@v7
 
     - name: Setup tools
       shell: bash

--- a/actions/md-confluence-sync/action.yml
+++ b/actions/md-confluence-sync/action.yml
@@ -39,7 +39,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/parse-and-mask-test-secrets/action.yml
+++ b/actions/parse-and-mask-test-secrets/action.yml
@@ -11,7 +11,7 @@ runs:
   using: composite
   steps:
     - name: Setup Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@v7
       with:
         go-version: 1.21.3
 

--- a/actions/pr-quality-check/action.yml
+++ b/actions/pr-quality-check/action.yml
@@ -102,7 +102,7 @@ runs:
 
     - name: Setup Python
       if: env.SHOULD_RUN == 'true' && github.event.action != 'closed'
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
 

--- a/actions/setup-golang/action.yml
+++ b/actions/setup-golang/action.yml
@@ -49,7 +49,7 @@ runs:
         echo "version=$version" >> "$GITHUB_OUTPUT"
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@v7
       with:
         go-version: ${{ steps.go-version.outputs.version }}
         cache: ${{ inputs.use-go-cache }}

--- a/actions/setup-renovate/action.yml
+++ b/actions/setup-renovate/action.yml
@@ -48,7 +48,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/slack-notify-git-ref/action.yml
+++ b/actions/slack-notify-git-ref/action.yml
@@ -63,7 +63,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
     - name: Validate inputs

--- a/actions/update-actions/action.yml
+++ b/actions/update-actions/action.yml
@@ -37,7 +37,7 @@ runs:
   steps:
     - name: Checkout repo
       if: inputs.checkout-repo == 'true'
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: ${{ inputs.checkout-repo-fetch-depth }}
 

--- a/actions/validate-protos-version/action.yml
+++ b/actions/validate-protos-version/action.yml
@@ -8,7 +8,7 @@ runs:
   using: composite
   steps:
     - name: Checkout chainlink-protos
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         repository: smartcontractkit/chainlink-protos
         ref: capabilities-development


### PR DESCRIPTION
Consolidates renovate bumps from #1578, #1584, #1598.

* actions/checkout to v7
* actions/setup-go  to v7
* actions/setup-python to v6
