### PR TITLE
fix: get-refs-from-pr-body disable github gpg key

### DIFF
--- a/.changeset/nine-seahorses-wink.md
+++ b/.changeset/nine-seahorses-wink.md
@@ -1,0 +1,6 @@
+---
+"get-refs-from-pr-body": minor
+---
+
+fix: set disable_gpg to true for sigscanner to ensure commit signatures are
+hardware backed

--- a/actions/get-refs-from-pr-body/dist/index.js
+++ b/actions/get-refs-from-pr-body/dist/index.js
@@ -44351,7 +44351,8 @@ var core3 = __toESM(require_core());
 async function verifyCommit(opts) {
   const params = new URLSearchParams({
     commit: opts.sha,
-    repository: opts.repository
+    repository: opts.repository,
+    disable_gpg: "true"
   });
   const target = `${opts.url}?${params.toString()}`;
   core3.debug(

--- a/actions/get-refs-from-pr-body/src/sigscanner.ts
+++ b/actions/get-refs-from-pr-body/src/sigscanner.ts
@@ -20,6 +20,7 @@ export async function verifyCommit(
   const params = new URLSearchParams({
     commit: opts.sha,
     repository: opts.repository,
+    disable_gpg: "true",
   });
   const target = `${opts.url}?${params.toString()}`;
 


### PR DESCRIPTION
This passes `disable_gpg=true` to sigscanner, which disables Githubs GPG signatures during the commit verification process. This ensures that the referenced commit is hardware backed.

---

DX-4670