### PR TITLE
reusable-dependabump: set GOTOOLCHAIN=auto everywhere

### DIFF
--- a/.changeset/gentle-oranges-lick.md
+++ b/.changeset/gentle-oranges-lick.md
@@ -1,0 +1,5 @@
+---
+"reusable-dependabump": patch
+---
+
+fix post-bump-command by using GOTOOLCHAIN=auto

--- a/.github/workflows/dependabump.yml
+++ b/.github/workflows/dependabump.yml
@@ -33,6 +33,7 @@ jobs:
       vulnerability-alerts: read
     env:
       GH_TOKEN: ${{ github.token }}
+      GOTOOLCHAIN: auto
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -42,8 +43,6 @@ jobs:
 
       - name: Install tools
         id: install
-        env:
-          GOTOOLCHAIN: auto
         run: |
           go install github.com/jmank88/gomods@ec230e90e89d4310b21fdeeba0d1290a3821a901 && \
           go install github.com/smartcontractkit/chainlink-common/script/cmd/dependabot@70b55abaf6e19d887c219b497046838d6113f22c
@@ -52,7 +51,6 @@ jobs:
       - name: Bump Dependencies
         id: bump
         env:
-          GOTOOLCHAIN: auto
           SEVERITY: ${{ inputs.severity }}
         if: steps.install.outcome == 'success'
         run: |

--- a/.github/workflows/reusable-dependabump.yml
+++ b/.github/workflows/reusable-dependabump.yml
@@ -33,6 +33,7 @@ jobs:
       vulnerability-alerts: read
     env:
       GH_TOKEN: ${{ github.token }}
+      GOTOOLCHAIN: auto
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -42,8 +43,6 @@ jobs:
 
       - name: Install tools
         id: install
-        env:
-          GOTOOLCHAIN: auto
         run: |
           go install github.com/jmank88/gomods@ec230e90e89d4310b21fdeeba0d1290a3821a901 && \
           go install github.com/smartcontractkit/chainlink-common/script/cmd/dependabot@70b55abaf6e19d887c219b497046838d6113f22c
@@ -52,7 +51,6 @@ jobs:
       - name: Bump Dependencies
         id: bump
         env:
-          GOTOOLCHAIN: auto
           SEVERITY: ${{ inputs.severity }}
         if: steps.install.outcome == 'success'
         run: |

--- a/workflows/reusable-dependabump/reusable-dependabump.yml
+++ b/workflows/reusable-dependabump/reusable-dependabump.yml
@@ -29,6 +29,7 @@ jobs:
       vulnerability-alerts: read
     env:
       GH_TOKEN: ${{ github.token }}
+      GOTOOLCHAIN: auto
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -38,8 +39,6 @@ jobs:
 
       - name: Install tools
         id: install
-        env:
-          GOTOOLCHAIN: auto
         run: |
           go install github.com/jmank88/gomods@ec230e90e89d4310b21fdeeba0d1290a3821a901 && \
           go install github.com/smartcontractkit/chainlink-common/script/cmd/dependabot@70b55abaf6e19d887c219b497046838d6113f22c
@@ -48,7 +47,6 @@ jobs:
       - name: Bump Dependencies
         id: bump
         env:
-          GOTOOLCHAIN: auto
           SEVERITY: ${{ inputs.severity }}
         if: steps.install.outcome == 'success'
         run: |


### PR DESCRIPTION
https://github.com/smartcontractkit/chainlink-common/actions/runs/30866779824/job/91860282096
```
go: go.mod requires go >= 1.26.2 (running go 1.24.13; GOTOOLCHAIN=local)
```