### PR TITLE
[DX-4969] Handle merge_group events

### DIFF
--- a/.changeset/sweet-horns-bite.md
+++ b/.changeset/sweet-horns-bite.md
@@ -1,0 +1,5 @@
+---
+"advanced-triggers": patch
+---
+
+better handle merge_group events

--- a/actions/advanced-triggers/dist/index.js
+++ b/actions/advanced-triggers/dist/index.js
@@ -68385,11 +68385,16 @@ async function gitFetchMissingRefs(base, head, directory, token) {
     return;
   }
   core4.info(`Fetching missing refs from origin: ${refs.join(", ")}`);
-  const args = ["fetch", "origin", "--depth=1", ...refs];
+  const args = ["fetch", "origin", "--depth=1", "--", ...refs];
   const options = { cwd: directory };
   if (token) {
     const auth2 = Buffer.from(`x-access-token:${token}`).toString("base64");
-    args.unshift("-c", `http.extraheader=AUTHORIZATION: basic ${auth2}`);
+    options.env = {
+      ...process.env,
+      GIT_CONFIG_COUNT: "1",
+      GIT_CONFIG_KEY_0: "http.extraheader",
+      GIT_CONFIG_VALUE_0: `AUTHORIZATION: basic ${auth2}`
+    };
   }
   try {
     await execFileAsync("git", args, options);

--- a/actions/advanced-triggers/dist/index.js
+++ b/actions/advanced-triggers/dist/index.js
@@ -68346,17 +68346,18 @@ var core4 = __toESM(require_core());
 var import_child_process = require("child_process");
 var import_util3 = require("util");
 var execFileAsync = (0, import_util3.promisify)(import_child_process.execFile);
-async function getChangedFilesGit(base, head, directory = process.cwd()) {
+async function getChangedFilesGit(base, head, directory = process.cwd(), token) {
   core4.info(
     `Getting changed files between ${base} and ${head} in ${directory}`
   );
   let resolvedHead = await resolveCommitish(head, directory);
   let resolvedBase = await resolveCommitish(base, directory);
   if (!resolvedHead || !resolvedBase) {
+    const missing = [resolvedBase ? null : base, resolvedHead ? null : head].filter((ref) => Boolean(ref)).join(", ");
     core4.warning(
-      `Head ("${head}") or Base ("${base}") could not be resolved. Attempting to pull latest changes and retry...`
+      `Head ("${head}") or Base ("${base}") could not be resolved. Attempting shallow fetch of missing refs (${missing}) from origin...`
     );
-    await gitPull(directory);
+    await gitFetchMissingRefs(base, head, directory, token);
     resolvedHead = resolvedHead || await resolveCommitish(head, directory);
     resolvedBase = resolvedBase || await resolveCommitish(base, directory);
   }
@@ -68376,6 +68377,28 @@ async function getChangedFilesGit(base, head, directory = process.cwd()) {
   );
   return changedFiles.split("\n").filter(Boolean);
 }
+async function gitFetchMissingRefs(base, head, directory, token) {
+  const refs = [];
+  if (!await resolveCommitish(base, directory)) refs.push(base);
+  if (!await resolveCommitish(head, directory)) refs.push(head);
+  if (refs.length === 0) {
+    return;
+  }
+  core4.info(`Fetching missing refs from origin: ${refs.join(", ")}`);
+  const args = ["fetch", "origin", "--depth=1", ...refs];
+  const options = { cwd: directory };
+  if (token) {
+    const auth2 = Buffer.from(`x-access-token:${token}`).toString("base64");
+    args.unshift("-c", `http.extraheader=AUTHORIZATION: basic ${auth2}`);
+  }
+  try {
+    await execFileAsync("git", args, options);
+    core4.info(`Successfully fetched missing refs from origin`);
+  } catch (err) {
+    core4.error(`Failed to fetch missing refs from origin: ${err}`);
+    throw new Error(`Failed to fetch missing refs from origin: ${err}`);
+  }
+}
 async function resolveCommitish(ref, directory) {
   if (!ref || /\s/.test(ref) || ref.includes("..")) return null;
   try {
@@ -68387,16 +68410,6 @@ async function resolveCommitish(ref, directory) {
     return stdout.trim();
   } catch {
     return null;
-  }
-}
-async function gitPull(directory) {
-  core4.info(`Attempting to pull latest changes in ${directory}...`);
-  try {
-    await execFileAsync("git", ["pull"], { cwd: directory });
-    core4.info(`Successfully pulled latest changes in ${directory}`);
-  } catch (err) {
-    core4.error(`Failed to pull latest changes in ${directory}: ${err}`);
-    throw new Error(`Failed to pull latest changes: ${err}`);
   }
 }
 
@@ -68411,6 +68424,23 @@ async function getChangedFilesForPR(octokit, owner, repo, prNumber) {
     per_page: 100
   });
   return prFiles;
+}
+async function getChangedFilesForMergeGroup(octokit, owner, repo, base, head) {
+  core5.debug(
+    `Fetching changed files for ${owner}/${repo} merge group ${base}...${head}`
+  );
+  const files = await octokit.paginate(
+    octokit.rest.repos.compareCommits,
+    {
+      owner,
+      repo,
+      base,
+      head,
+      per_page: 100
+    },
+    (response) => response.data.files?.map((f) => f.filename) ?? []
+  );
+  return files;
 }
 
 // actions/advanced-triggers/src/run.ts
@@ -68478,7 +68508,8 @@ async function run() {
         octokit,
         { owner: context3.owner, repo: context3.repo },
         context3.event,
-        inputs.repositoryRoot
+        inputs.repositoryRoot,
+        context3.token
       );
       core6.info(`Changed files count: ${changedFiles.length}`);
       if (core6.isDebug()) {
@@ -68530,7 +68561,7 @@ async function run() {
   }
 }
 var PR_FILES_API_LIMIT = 3e3;
-async function getChangedFiles(octokit, { owner, repo }, event, repositoryRoot) {
+async function getChangedFiles(octokit, { owner, repo }, event, repositoryRoot, token) {
   switch (event.eventName) {
     case "pull_request": {
       return getChangedFilesForPRWithFallback(
@@ -68540,23 +68571,31 @@ async function getChangedFiles(octokit, { owner, repo }, event, repositoryRoot) 
         event.prNumber,
         event.base,
         event.head,
-        repositoryRoot
+        repositoryRoot,
+        token
       );
     }
     case "push": {
       core6.info("Fetching changed files via git diff (push).");
-      return getChangedFilesGit(event.base, event.head, repositoryRoot);
+      return getChangedFilesGit(event.base, event.head, repositoryRoot, token);
     }
     case "merge_group": {
-      core6.info("Fetching changed files via git diff (merge_group).");
-      return getChangedFilesGit(event.base, event.head, repositoryRoot);
+      return getChangedFilesForMergeGroupWithFallback(
+        octokit,
+        owner,
+        repo,
+        event.base,
+        event.head,
+        repositoryRoot,
+        token
+      );
     }
     default:
       event;
       throw new Error(`Unhandled event: ${JSON.stringify(event)}`);
   }
 }
-async function getChangedFilesForPRWithFallback(octokit, owner, repo, prNumber, base, head, repositoryRoot) {
+async function getChangedFilesForPRWithFallback(octokit, owner, repo, prNumber, base, head, repositoryRoot, token) {
   core6.info("Fetching changed files via GitHub API (pull_request).");
   let apiFiles;
   try {
@@ -68566,13 +68605,33 @@ async function getChangedFilesForPRWithFallback(octokit, owner, repo, prNumber, 
     core6.warning(
       `GitHub API request for PR files failed: ${err}. Falling back to git diff (base: ${base}, head: ${head}).`
     );
-    return getChangedFilesGit(base, head, repositoryRoot);
+    return getChangedFilesGit(base, head, repositoryRoot, token);
   }
   if (apiFiles.length >= PR_FILES_API_LIMIT) {
     core6.warning(
       `GitHub API returned ${apiFiles.length} files, which meets or exceeds the known API limit of ${PR_FILES_API_LIMIT}. The list may be truncated. Falling back to git diff (base: ${base}, head: ${head}).`
     );
-    return getChangedFilesGit(base, head, repositoryRoot);
+    return getChangedFilesGit(base, head, repositoryRoot, token);
+  }
+  core6.info(`GitHub API returned ${apiFiles.length} changed file(s).`);
+  return apiFiles;
+}
+async function getChangedFilesForMergeGroupWithFallback(octokit, owner, repo, base, head, repositoryRoot, token) {
+  core6.info("Fetching changed files via GitHub API (merge_group).");
+  let apiFiles;
+  try {
+    apiFiles = await getChangedFilesForMergeGroup(
+      octokit,
+      owner,
+      repo,
+      base,
+      head
+    );
+  } catch (err) {
+    core6.warning(
+      `GitHub API request for merge group files failed: ${err}. Falling back to git diff (base: ${base}, head: ${head}).`
+    );
+    return getChangedFilesGit(base, head, repositoryRoot, token);
   }
   core6.info(`GitHub API returned ${apiFiles.length} changed file(s).`);
   return apiFiles;

--- a/actions/advanced-triggers/dist/index.js
+++ b/actions/advanced-triggers/dist/index.js
@@ -19649,10 +19649,10 @@ var require_oidc_utils = __commonJS({
           var _a2;
           const httpclient = _OidcClient.createHttpClient();
           const res = yield httpclient.getJson(id_token_url).catch((error49) => {
-            throw new Error(`Failed to get ID Token. 
- 
+            throw new Error(`Failed to get ID Token.
+
         Error Code : ${error49.statusCode}
- 
+
         Error Message: ${error49.message}`);
           });
           const id_token = (_a2 = res.result) === null || _a2 === void 0 ? void 0 : _a2.value;
@@ -57399,7 +57399,7 @@ var $ZodObjectJIT = /* @__PURE__ */ $constructor("$ZodObjectJIT", (inst, def) =>
             })));
           }
         }
-        
+
         if (${id}.value === undefined) {
           if (${k} in input) {
             newResult[${k}] = undefined;
@@ -57407,7 +57407,7 @@ var $ZodObjectJIT = /* @__PURE__ */ $constructor("$ZodObjectJIT", (inst, def) =>
         } else {
           newResult[${k}] = ${id}.value;
         }
-        
+
       `);
       } else {
         doc.write(`
@@ -57417,7 +57417,7 @@ var $ZodObjectJIT = /* @__PURE__ */ $constructor("$ZodObjectJIT", (inst, def) =>
             path: iss.path ? [${k}, ...iss.path] : [${k}]
           })));
         }
-        
+
         if (${id}.value === undefined) {
           if (${k} in input) {
             newResult[${k}] = undefined;
@@ -57425,7 +57425,7 @@ var $ZodObjectJIT = /* @__PURE__ */ $constructor("$ZodObjectJIT", (inst, def) =>
         } else {
           newResult[${k}] = ${id}.value;
         }
-        
+
       `);
       }
     }
@@ -68434,18 +68434,24 @@ async function getChangedFilesForMergeGroup(octokit, owner, repo, base, head) {
   core5.debug(
     `Fetching changed files for ${owner}/${repo} merge group ${base}...${head}`
   );
-  const files = await octokit.paginate(
-    octokit.rest.repos.compareCommits,
-    {
-      owner,
-      repo,
-      base,
-      head,
-      per_page: 100
-    },
-    (response) => response.data.files?.map((f) => f.filename) ?? []
-  );
-  return files;
+  const res = await octokit.rest.repos.compareCommits({
+    owner,
+    repo,
+    base,
+    head,
+    per_page: 100
+  });
+  if (!res.data.files) {
+    throw new Error(
+      `GitHub compareCommits API did not return a files list for ${base}...${head}`
+    );
+  }
+  if (res.data.files.length >= 300) {
+    throw new Error(
+      `GitHub compareCommits returned ${res.data.files.length} files (hit 300 limit).`
+    );
+  }
+  return res.data.files.map((f) => f.filename);
 }
 
 // actions/advanced-triggers/src/run.ts

--- a/actions/advanced-triggers/dist/index.js
+++ b/actions/advanced-triggers/dist/index.js
@@ -19649,10 +19649,10 @@ var require_oidc_utils = __commonJS({
           var _a2;
           const httpclient = _OidcClient.createHttpClient();
           const res = yield httpclient.getJson(id_token_url).catch((error49) => {
-            throw new Error(`Failed to get ID Token.
-
+            throw new Error(`Failed to get ID Token. 
+ 
         Error Code : ${error49.statusCode}
-
+ 
         Error Message: ${error49.message}`);
           });
           const id_token = (_a2 = res.result) === null || _a2 === void 0 ? void 0 : _a2.value;
@@ -57399,7 +57399,7 @@ var $ZodObjectJIT = /* @__PURE__ */ $constructor("$ZodObjectJIT", (inst, def) =>
             })));
           }
         }
-
+        
         if (${id}.value === undefined) {
           if (${k} in input) {
             newResult[${k}] = undefined;
@@ -57407,7 +57407,7 @@ var $ZodObjectJIT = /* @__PURE__ */ $constructor("$ZodObjectJIT", (inst, def) =>
         } else {
           newResult[${k}] = ${id}.value;
         }
-
+        
       `);
       } else {
         doc.write(`
@@ -57417,7 +57417,7 @@ var $ZodObjectJIT = /* @__PURE__ */ $constructor("$ZodObjectJIT", (inst, def) =>
             path: iss.path ? [${k}, ...iss.path] : [${k}]
           })));
         }
-
+        
         if (${id}.value === undefined) {
           if (${k} in input) {
             newResult[${k}] = undefined;
@@ -57425,7 +57425,7 @@ var $ZodObjectJIT = /* @__PURE__ */ $constructor("$ZodObjectJIT", (inst, def) =>
         } else {
           newResult[${k}] = ${id}.value;
         }
-
+        
       `);
       }
     }

--- a/actions/advanced-triggers/src/__tests__/git.test.ts
+++ b/actions/advanced-triggers/src/__tests__/git.test.ts
@@ -1,4 +1,5 @@
 import { vi, describe, test, expect } from "vitest";
+import { execFile } from "child_process";
 
 vi.mock("@actions/core", () => ({
   info: vi.fn(),
@@ -16,6 +17,7 @@ let execFileSequence: {
   stderr?: string;
   exitCode?: number;
 }[] = [];
+let execFileCalls: { cmd: string; args: string[]; options: any }[] = [];
 
 vi.mock("child_process", () => ({
   execFile: vi.fn(
@@ -28,21 +30,14 @@ vi.mock("child_process", () => ({
         result?: { stdout: string; stderr: string },
       ) => void,
     ) => {
+      execFileCalls.push({ cmd, args, options });
       const fullCommand = `${cmd} ${args.join(" ")}`;
 
-      const match = execFileResponses[fullCommand];
-      if (match) {
-        callback(null, {
-          stdout: match.stdout ?? "",
-          stderr: match.stderr ?? "",
-        });
-        return {} as any;
-      }
-
-      const seqMatch = execFileSequence.find(
+      const seqIndex = execFileSequence.findIndex(
         (s) => s.command === cmd && s.args.join(" ") === args.join(" "),
       );
-      if (seqMatch) {
+      if (seqIndex !== -1) {
+        const [seqMatch] = execFileSequence.splice(seqIndex, 1);
         if (seqMatch.exitCode !== undefined && seqMatch.exitCode !== 0) {
           const err = new Error(
             seqMatch.stderr ?? "exit code " + seqMatch.exitCode,
@@ -55,6 +50,15 @@ vi.mock("child_process", () => ({
             stderr: seqMatch.stderr ?? "",
           });
         }
+        return {} as any;
+      }
+
+      const match = execFileResponses[fullCommand];
+      if (match) {
+        callback(null, {
+          stdout: match.stdout ?? "",
+          stderr: match.stderr ?? "",
+        });
         return {} as any;
       }
 
@@ -76,9 +80,19 @@ function setExecFileResponse(
   execFileResponses[fullCommand] = { stdout };
 }
 
+function pushExecFileSequence(
+  command: string,
+  args: string[],
+  stdout: string,
+  exitCode: number = 0,
+) {
+  execFileSequence.push({ command, args, stdout, exitCode });
+}
+
 function clearExecFileResponses() {
   execFileResponses = {};
   execFileSequence = [];
+  execFileCalls = [];
 }
 
 // ---------------------------------------------------------------------------
@@ -112,12 +126,23 @@ describe("getChangedFilesGit", () => {
   test("fetches missing refs when token provided", async () => {
     clearExecFileResponses();
     // First resolution attempt fails for both refs.
-    setExecFileResponse(
+    pushExecFileSequence(
+      "git",
+      ["rev-parse", "-q", "--verify", "head-sha^{commit}"],
+      "",
+    );
+    pushExecFileSequence(
       "git",
       ["rev-parse", "-q", "--verify", "base-sha^{commit}"],
       "",
     );
-    setExecFileResponse(
+    // gitFetchMissingRefs checks
+    pushExecFileSequence(
+      "git",
+      ["rev-parse", "-q", "--verify", "base-sha^{commit}"],
+      "",
+    );
+    pushExecFileSequence(
       "git",
       ["rev-parse", "-q", "--verify", "head-sha^{commit}"],
       "",
@@ -125,15 +150,7 @@ describe("getChangedFilesGit", () => {
     // Fetch succeeds.
     setExecFileResponse(
       "git",
-      [
-        "-c",
-        "http.extraheader=AUTHORIZATION: basic eC1hY2Nlc3MtdG9rZW46dG9rZW4=",
-        "fetch",
-        "origin",
-        "--depth=1",
-        "base-sha",
-        "head-sha",
-      ],
+      ["fetch", "origin", "--depth=1", "--", "base-sha", "head-sha"],
       "",
     );
     // Resolution succeeds after fetch.
@@ -161,6 +178,13 @@ describe("getChangedFilesGit", () => {
     );
 
     expect(files).toEqual(["src/foo.ts"]);
+    const fetchCall = execFileCalls.find((c) => c.args[0] === "fetch");
+    expect(fetchCall).toBeDefined();
+    expect(fetchCall?.options?.env?.GIT_CONFIG_COUNT).toBe("1");
+    expect(fetchCall?.options?.env?.GIT_CONFIG_KEY_0).toBe("http.extraheader");
+    expect(fetchCall?.options?.env?.GIT_CONFIG_VALUE_0).toBe(
+      "AUTHORIZATION: basic eC1hY2Nlc3MtdG9rZW46dG9rZW4=",
+    );
   });
 
   test("throws when refs remain unresolved after fetch", async () => {
@@ -177,15 +201,7 @@ describe("getChangedFilesGit", () => {
     );
     setExecFileResponse(
       "git",
-      [
-        "-c",
-        "http.extraheader=AUTHORIZATION: basic eC1hY2Nlc3MtdG9rZW46dG9rZW4=",
-        "fetch",
-        "origin",
-        "--depth=1",
-        "base-sha",
-        "head-sha",
-      ],
+      ["fetch", "origin", "--depth=1", "--", "base-sha", "head-sha"],
       "",
     );
     setExecFileResponse(

--- a/actions/advanced-triggers/src/__tests__/git.test.ts
+++ b/actions/advanced-triggers/src/__tests__/git.test.ts
@@ -1,0 +1,206 @@
+import { vi, describe, test, expect } from "vitest";
+
+vi.mock("@actions/core", () => ({
+  info: vi.fn(),
+  debug: vi.fn(),
+  warning: vi.fn(),
+  error: vi.fn(),
+}));
+
+let execFileResponses: Record<string, { stdout?: string; stderr?: string }> =
+  {};
+let execFileSequence: {
+  command: string;
+  args: string[];
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+}[] = [];
+
+vi.mock("child_process", () => ({
+  execFile: vi.fn(
+    (
+      cmd: string,
+      args: string[],
+      options: unknown,
+      callback: (
+        err: Error | null,
+        result?: { stdout: string; stderr: string },
+      ) => void,
+    ) => {
+      const fullCommand = `${cmd} ${args.join(" ")}`;
+
+      const match = execFileResponses[fullCommand];
+      if (match) {
+        callback(null, {
+          stdout: match.stdout ?? "",
+          stderr: match.stderr ?? "",
+        });
+        return {} as any;
+      }
+
+      const seqMatch = execFileSequence.find(
+        (s) => s.command === cmd && s.args.join(" ") === args.join(" "),
+      );
+      if (seqMatch) {
+        if (seqMatch.exitCode !== undefined && seqMatch.exitCode !== 0) {
+          const err = new Error(
+            seqMatch.stderr ?? "exit code " + seqMatch.exitCode,
+          );
+          (err as any).code = seqMatch.exitCode;
+          callback(err);
+        } else {
+          callback(null, {
+            stdout: seqMatch.stdout ?? "",
+            stderr: seqMatch.stderr ?? "",
+          });
+        }
+        return {} as any;
+      }
+
+      callback(new Error(`Unexpected execFile call: ${fullCommand}`));
+      return {} as any;
+    },
+  ),
+}));
+
+import { getChangedFilesGit } from "../git";
+
+function setExecFileResponse(
+  command: string,
+  args: string[],
+  stdout: string,
+  exitCode: number = 0,
+) {
+  const fullCommand = `${command} ${args.join(" ")}`;
+  execFileResponses[fullCommand] = { stdout };
+}
+
+function clearExecFileResponses() {
+  execFileResponses = {};
+  execFileSequence = [];
+}
+
+// ---------------------------------------------------------------------------
+// getChangedFilesGit
+// ---------------------------------------------------------------------------
+
+describe("getChangedFilesGit", () => {
+  test("returns changed files when both refs resolve", async () => {
+    clearExecFileResponses();
+    setExecFileResponse(
+      "git",
+      ["rev-parse", "-q", "--verify", "base-sha^{commit}"],
+      "base-sha\n",
+    );
+    setExecFileResponse(
+      "git",
+      ["rev-parse", "-q", "--verify", "head-sha^{commit}"],
+      "head-sha\n",
+    );
+    setExecFileResponse(
+      "git",
+      ["diff", "--name-only", "base-sha", "head-sha"],
+      "src/foo.ts\nsrc/bar.ts\n",
+    );
+
+    const files = await getChangedFilesGit("base-sha", "head-sha", "/repo");
+
+    expect(files).toEqual(["src/foo.ts", "src/bar.ts"]);
+  });
+
+  test("fetches missing refs when token provided", async () => {
+    clearExecFileResponses();
+    // First resolution attempt fails for both refs.
+    setExecFileResponse(
+      "git",
+      ["rev-parse", "-q", "--verify", "base-sha^{commit}"],
+      "",
+    );
+    setExecFileResponse(
+      "git",
+      ["rev-parse", "-q", "--verify", "head-sha^{commit}"],
+      "",
+    );
+    // Fetch succeeds.
+    setExecFileResponse(
+      "git",
+      [
+        "-c",
+        "http.extraheader=AUTHORIZATION: basic eC1hY2Nlc3MtdG9rZW46dG9rZW4=",
+        "fetch",
+        "origin",
+        "--depth=1",
+        "base-sha",
+        "head-sha",
+      ],
+      "",
+    );
+    // Resolution succeeds after fetch.
+    setExecFileResponse(
+      "git",
+      ["rev-parse", "-q", "--verify", "base-sha^{commit}"],
+      "base-sha\n",
+    );
+    setExecFileResponse(
+      "git",
+      ["rev-parse", "-q", "--verify", "head-sha^{commit}"],
+      "head-sha\n",
+    );
+    setExecFileResponse(
+      "git",
+      ["diff", "--name-only", "base-sha", "head-sha"],
+      "src/foo.ts\n",
+    );
+
+    const files = await getChangedFilesGit(
+      "base-sha",
+      "head-sha",
+      "/repo",
+      "token",
+    );
+
+    expect(files).toEqual(["src/foo.ts"]);
+  });
+
+  test("throws when refs remain unresolved after fetch", async () => {
+    clearExecFileResponses();
+    setExecFileResponse(
+      "git",
+      ["rev-parse", "-q", "--verify", "base-sha^{commit}"],
+      "",
+    );
+    setExecFileResponse(
+      "git",
+      ["rev-parse", "-q", "--verify", "head-sha^{commit}"],
+      "",
+    );
+    setExecFileResponse(
+      "git",
+      [
+        "-c",
+        "http.extraheader=AUTHORIZATION: basic eC1hY2Nlc3MtdG9rZW46dG9rZW4=",
+        "fetch",
+        "origin",
+        "--depth=1",
+        "base-sha",
+        "head-sha",
+      ],
+      "",
+    );
+    setExecFileResponse(
+      "git",
+      ["rev-parse", "-q", "--verify", "base-sha^{commit}"],
+      "",
+    );
+    setExecFileResponse(
+      "git",
+      ["rev-parse", "-q", "--verify", "head-sha^{commit}"],
+      "",
+    );
+
+    await expect(
+      getChangedFilesGit("base-sha", "head-sha", "/repo", "token"),
+    ).rejects.toThrow("One or both git references could not be resolved");
+  });
+});

--- a/actions/advanced-triggers/src/__tests__/github.test.ts
+++ b/actions/advanced-triggers/src/__tests__/github.test.ts
@@ -13,9 +13,7 @@ import { getChangedFilesForMergeGroup, type OctokitType } from "../github";
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeOctokit(
-  compareCommitsImpl = vi.fn(),
-): OctokitType {
+function makeOctokit(compareCommitsImpl = vi.fn()): OctokitType {
   return {
     paginate: vi.fn(),
     rest: {

--- a/actions/advanced-triggers/src/__tests__/github.test.ts
+++ b/actions/advanced-triggers/src/__tests__/github.test.ts
@@ -1,0 +1,122 @@
+import { vi, describe, test, expect } from "vitest";
+
+vi.mock("@actions/core", () => ({
+  info: vi.fn(),
+  debug: vi.fn(),
+  warning: vi.fn(),
+  error: vi.fn(),
+}));
+
+import { getChangedFilesForMergeGroup, type OctokitType } from "../github";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeOctokit(
+  paginateImpl: OctokitType["paginate"] = vi.fn(),
+): OctokitType {
+  return {
+    paginate: paginateImpl,
+    rest: {
+      repos: {
+        compareCommits: vi.fn(),
+      },
+    },
+  } as unknown as OctokitType;
+}
+
+// ---------------------------------------------------------------------------
+// getChangedFilesForMergeGroup
+// ---------------------------------------------------------------------------
+
+describe("getChangedFilesForMergeGroup", () => {
+  test("returns filenames from compareCommits", async () => {
+    const octokit = makeOctokit(
+      vi.fn().mockResolvedValue(["src/foo.ts", "src/bar.ts"]),
+    );
+
+    const files = await getChangedFilesForMergeGroup(
+      octokit,
+      "smartcontractkit",
+      ".github",
+      "base-sha",
+      "head-sha",
+    );
+
+    expect(octokit.paginate).toHaveBeenCalledWith(
+      octokit.rest.repos.compareCommits,
+      {
+        owner: "smartcontractkit",
+        repo: ".github",
+        base: "base-sha",
+        head: "head-sha",
+        per_page: 100,
+      },
+      expect.any(Function),
+    );
+    expect(files).toEqual(["src/foo.ts", "src/bar.ts"]);
+  });
+
+  test("paginates across multiple pages", async () => {
+    const octokit = makeOctokit(
+      vi
+        .fn()
+        .mockResolvedValue([
+          "src/foo.ts",
+          "src/bar.ts",
+          "src/baz.ts",
+          "src/qux.ts",
+        ]),
+    );
+
+    const files = await getChangedFilesForMergeGroup(
+      octokit,
+      "smartcontractkit",
+      ".github",
+      "base-sha",
+      "head-sha",
+    );
+
+    expect(files).toEqual([
+      "src/foo.ts",
+      "src/bar.ts",
+      "src/baz.ts",
+      "src/qux.ts",
+    ]);
+  });
+
+  test("returns empty array when no files changed", async () => {
+    const octokit = makeOctokit(vi.fn().mockResolvedValue([]));
+
+    const files = await getChangedFilesForMergeGroup(
+      octokit,
+      "smartcontractkit",
+      ".github",
+      "base-sha",
+      "head-sha",
+    );
+
+    expect(files).toEqual([]);
+  });
+
+  test("extracts filenames from response data", async () => {
+    const paginate = vi.fn().mockImplementation((endpoint, params, mapFn) => {
+      const mapped = mapFn({
+        data: { files: [{ filename: "mapped/file.ts" }] },
+      });
+      return Promise.resolve(mapped);
+    });
+    const octokit = makeOctokit(paginate);
+
+    const files = await getChangedFilesForMergeGroup(
+      octokit,
+      "smartcontractkit",
+      ".github",
+      "base-sha",
+      "head-sha",
+    );
+
+    expect(files).toEqual(["mapped/file.ts"]);
+  });
+});

--- a/actions/advanced-triggers/src/__tests__/github.test.ts
+++ b/actions/advanced-triggers/src/__tests__/github.test.ts
@@ -58,7 +58,7 @@ describe("getChangedFilesForMergeGroup", () => {
     expect(files).toEqual(["src/foo.ts", "src/bar.ts"]);
   });
 
-  test("paginates across multiple pages", async () => {
+  test("returns all files from octokit.paginate", async () => {
     const octokit = makeOctokit(
       vi
         .fn()

--- a/actions/advanced-triggers/src/__tests__/github.test.ts
+++ b/actions/advanced-triggers/src/__tests__/github.test.ts
@@ -14,13 +14,13 @@ import { getChangedFilesForMergeGroup, type OctokitType } from "../github";
 // ---------------------------------------------------------------------------
 
 function makeOctokit(
-  paginateImpl: OctokitType["paginate"] = vi.fn(),
+  compareCommitsImpl = vi.fn(),
 ): OctokitType {
   return {
-    paginate: paginateImpl,
+    paginate: vi.fn(),
     rest: {
       repos: {
-        compareCommits: vi.fn(),
+        compareCommits: compareCommitsImpl,
       },
     },
   } as unknown as OctokitType;
@@ -33,7 +33,11 @@ function makeOctokit(
 describe("getChangedFilesForMergeGroup", () => {
   test("returns filenames from compareCommits", async () => {
     const octokit = makeOctokit(
-      vi.fn().mockResolvedValue(["src/foo.ts", "src/bar.ts"]),
+      vi.fn().mockResolvedValue({
+        data: {
+          files: [{ filename: "src/foo.ts" }, { filename: "src/bar.ts" }],
+        },
+      }),
     );
 
     const files = await getChangedFilesForMergeGroup(
@@ -44,79 +48,56 @@ describe("getChangedFilesForMergeGroup", () => {
       "head-sha",
     );
 
-    expect(octokit.paginate).toHaveBeenCalledWith(
-      octokit.rest.repos.compareCommits,
-      {
-        owner: "smartcontractkit",
-        repo: ".github",
-        base: "base-sha",
-        head: "head-sha",
-        per_page: 100,
-      },
-      expect.any(Function),
-    );
+    expect(octokit.rest.repos.compareCommits).toHaveBeenCalledWith({
+      owner: "smartcontractkit",
+      repo: ".github",
+      base: "base-sha",
+      head: "head-sha",
+      per_page: 100,
+    });
     expect(files).toEqual(["src/foo.ts", "src/bar.ts"]);
   });
 
-  test("returns all files from octokit.paginate", async () => {
+  test("throws when files property is undefined", async () => {
     const octokit = makeOctokit(
-      vi
-        .fn()
-        .mockResolvedValue([
-          "src/foo.ts",
-          "src/bar.ts",
-          "src/baz.ts",
-          "src/qux.ts",
-        ]),
+      vi.fn().mockResolvedValue({
+        data: {},
+      }),
     );
 
-    const files = await getChangedFilesForMergeGroup(
-      octokit,
-      "smartcontractkit",
-      ".github",
-      "base-sha",
-      "head-sha",
+    await expect(
+      getChangedFilesForMergeGroup(
+        octokit,
+        "smartcontractkit",
+        ".github",
+        "base-sha",
+        "head-sha",
+      ),
+    ).rejects.toThrow(
+      "GitHub compareCommits API did not return a files list for base-sha...head-sha",
     );
-
-    expect(files).toEqual([
-      "src/foo.ts",
-      "src/bar.ts",
-      "src/baz.ts",
-      "src/qux.ts",
-    ]);
   });
 
-  test("returns empty array when no files changed", async () => {
-    const octokit = makeOctokit(vi.fn().mockResolvedValue([]));
-
-    const files = await getChangedFilesForMergeGroup(
-      octokit,
-      "smartcontractkit",
-      ".github",
-      "base-sha",
-      "head-sha",
+  test("throws when files count reaches or exceeds 300 limit", async () => {
+    const fakeFiles = Array.from({ length: 300 }, (_, i) => ({
+      filename: `file_${i}.ts`,
+    }));
+    const octokit = makeOctokit(
+      vi.fn().mockResolvedValue({
+        data: { files: fakeFiles },
+      }),
     );
 
-    expect(files).toEqual([]);
-  });
-
-  test("extracts filenames from response data", async () => {
-    const paginate = vi.fn().mockImplementation((endpoint, params, mapFn) => {
-      const mapped = mapFn({
-        data: { files: [{ filename: "mapped/file.ts" }] },
-      });
-      return Promise.resolve(mapped);
-    });
-    const octokit = makeOctokit(paginate);
-
-    const files = await getChangedFilesForMergeGroup(
-      octokit,
-      "smartcontractkit",
-      ".github",
-      "base-sha",
-      "head-sha",
+    await expect(
+      getChangedFilesForMergeGroup(
+        octokit,
+        "smartcontractkit",
+        ".github",
+        "base-sha",
+        "head-sha",
+      ),
+    ).rejects.toThrow(
+      "GitHub compareCommits returned 300 files (hit 300 limit)",
     );
-
-    expect(files).toEqual(["mapped/file.ts"]);
   });
 });

--- a/actions/advanced-triggers/src/__tests__/run.test.ts
+++ b/actions/advanced-triggers/src/__tests__/run.test.ts
@@ -20,9 +20,7 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-function makeOctokit(
-  compareCommitsImpl = vi.fn(),
-): OctokitType {
+function makeOctokit(compareCommitsImpl = vi.fn()): OctokitType {
   return {
     paginate: vi.fn(),
     rest: {

--- a/actions/advanced-triggers/src/__tests__/run.test.ts
+++ b/actions/advanced-triggers/src/__tests__/run.test.ts
@@ -1,0 +1,134 @@
+import { vi, describe, test, expect, beforeEach } from "vitest";
+
+vi.mock("@actions/core", () => ({
+  info: vi.fn(),
+  debug: vi.fn(),
+  warning: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("../git", () => ({
+  getChangedFilesGit: vi.fn(),
+}));
+
+import { getChangedFilesGit } from "../git";
+import { getChangedFiles } from "../run";
+import type { OctokitType } from "../github";
+import type { MergeGroupEventData, PushEventData } from "../event";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function makeOctokit(
+  paginateImpl: OctokitType["paginate"] = vi.fn(),
+): OctokitType {
+  return {
+    paginate: paginateImpl,
+    rest: {
+      repos: {
+        compareCommits: vi.fn(),
+      },
+      pulls: {
+        listFiles: vi.fn(),
+      },
+    },
+  } as unknown as OctokitType;
+}
+
+// ---------------------------------------------------------------------------
+// getChangedFiles routing
+// ---------------------------------------------------------------------------
+
+describe("getChangedFiles routing", () => {
+  test("merge_group uses compareCommits API and returns filenames", async () => {
+    const octokit = makeOctokit(vi.fn().mockResolvedValue(["src/foo.ts"]));
+
+    const event: MergeGroupEventData = {
+      kind: "file-change",
+      eventName: "merge_group",
+      base: "base-sha",
+      head: "head-sha",
+    };
+
+    const files = await getChangedFiles(
+      octokit,
+      { owner: "smartcontractkit", repo: ".github" },
+      event,
+      "/repo",
+      "token",
+    );
+
+    expect(octokit.paginate).toHaveBeenCalledWith(
+      octokit.rest.repos.compareCommits,
+      {
+        owner: "smartcontractkit",
+        repo: ".github",
+        base: "base-sha",
+        head: "head-sha",
+        per_page: 100,
+      },
+      expect.any(Function),
+    );
+    expect(files).toEqual(["src/foo.ts"]);
+    expect(getChangedFilesGit).not.toHaveBeenCalled();
+  });
+
+  test("merge_group falls back to git when API fails", async () => {
+    const octokit = makeOctokit(
+      vi.fn().mockRejectedValue(new Error("API error")),
+    );
+    vi.mocked(getChangedFilesGit).mockResolvedValue(["src/fallback.ts"]);
+
+    const event: MergeGroupEventData = {
+      kind: "file-change",
+      eventName: "merge_group",
+      base: "base-sha",
+      head: "head-sha",
+    };
+
+    const files = await getChangedFiles(
+      octokit,
+      { owner: "smartcontractkit", repo: ".github" },
+      event,
+      "/repo",
+      "token",
+    );
+
+    expect(getChangedFilesGit).toHaveBeenCalledWith(
+      "base-sha",
+      "head-sha",
+      "/repo",
+      "token",
+    );
+    expect(files).toEqual(["src/fallback.ts"]);
+  });
+
+  test("push still uses git diff", async () => {
+    const octokit = makeOctokit();
+    vi.mocked(getChangedFilesGit).mockResolvedValue(["src/push.ts"]);
+
+    const event: PushEventData = {
+      kind: "file-change",
+      eventName: "push",
+      base: "before-sha",
+      head: "after-sha",
+    };
+
+    const files = await getChangedFiles(
+      octokit,
+      { owner: "smartcontractkit", repo: ".github" },
+      event,
+      "/repo",
+      "token",
+    );
+
+    expect(getChangedFilesGit).toHaveBeenCalledWith(
+      "before-sha",
+      "after-sha",
+      "/repo",
+      "token",
+    );
+    expect(files).toEqual(["src/push.ts"]);
+  });
+});

--- a/actions/advanced-triggers/src/__tests__/run.test.ts
+++ b/actions/advanced-triggers/src/__tests__/run.test.ts
@@ -21,13 +21,13 @@ beforeEach(() => {
 });
 
 function makeOctokit(
-  paginateImpl: OctokitType["paginate"] = vi.fn(),
+  compareCommitsImpl = vi.fn(),
 ): OctokitType {
   return {
-    paginate: paginateImpl,
+    paginate: vi.fn(),
     rest: {
       repos: {
-        compareCommits: vi.fn(),
+        compareCommits: compareCommitsImpl,
       },
       pulls: {
         listFiles: vi.fn(),
@@ -42,7 +42,13 @@ function makeOctokit(
 
 describe("getChangedFiles routing", () => {
   test("merge_group uses compareCommits API and returns filenames", async () => {
-    const octokit = makeOctokit(vi.fn().mockResolvedValue(["src/foo.ts"]));
+    const octokit = makeOctokit(
+      vi.fn().mockResolvedValue({
+        data: {
+          files: [{ filename: "src/foo.ts" }],
+        },
+      }),
+    );
 
     const event: MergeGroupEventData = {
       kind: "file-change",
@@ -59,17 +65,13 @@ describe("getChangedFiles routing", () => {
       "token",
     );
 
-    expect(octokit.paginate).toHaveBeenCalledWith(
-      octokit.rest.repos.compareCommits,
-      {
-        owner: "smartcontractkit",
-        repo: ".github",
-        base: "base-sha",
-        head: "head-sha",
-        per_page: 100,
-      },
-      expect.any(Function),
-    );
+    expect(octokit.rest.repos.compareCommits).toHaveBeenCalledWith({
+      owner: "smartcontractkit",
+      repo: ".github",
+      base: "base-sha",
+      head: "head-sha",
+      per_page: 100,
+    });
     expect(files).toEqual(["src/foo.ts"]);
     expect(getChangedFilesGit).not.toHaveBeenCalled();
   });

--- a/actions/advanced-triggers/src/git.ts
+++ b/actions/advanced-triggers/src/git.ts
@@ -76,12 +76,17 @@ async function gitFetchMissingRefs(
 
   core.info(`Fetching missing refs from origin: ${refs.join(", ")}`);
 
-  const args = ["fetch", "origin", "--depth=1", ...refs];
+  const args = ["fetch", "origin", "--depth=1", "--", ...refs];
   const options: { cwd: string; env?: NodeJS.ProcessEnv } = { cwd: directory };
 
   if (token) {
     const auth = Buffer.from(`x-access-token:${token}`).toString("base64");
-    args.unshift("-c", `http.extraheader=AUTHORIZATION: basic ${auth}`);
+    options.env = {
+      ...process.env,
+      GIT_CONFIG_COUNT: "1",
+      GIT_CONFIG_KEY_0: "http.extraheader",
+      GIT_CONFIG_VALUE_0: `AUTHORIZATION: basic ${auth}`,
+    };
   }
 
   try {

--- a/actions/advanced-triggers/src/git.ts
+++ b/actions/advanced-triggers/src/git.ts
@@ -6,14 +6,15 @@ const execFileAsync = promisify(execFile);
 
 /**
  * Returns changed files between two git refs using `git diff --name-only`.
- * If either ref cannot be resolved, a `git pull` is attempted and resolution
- * is retried once. If either ref still cannot be resolved after the retry,
- * an error is thrown.
+ * If either ref cannot be resolved, a shallow `git fetch` of the missing
+ * commit(s) from `origin` is attempted and resolution is retried once. If
+ * either ref still cannot be resolved after the retry, an error is thrown.
  */
 export async function getChangedFilesGit(
   base: string,
   head: string,
   directory: string = process.cwd(),
+  token?: string,
 ): Promise<string[]> {
   core.info(
     `Getting changed files between ${base} and ${head} in ${directory}`,
@@ -23,10 +24,13 @@ export async function getChangedFilesGit(
   let resolvedBase = await resolveCommitish(base, directory);
 
   if (!resolvedHead || !resolvedBase) {
+    const missing = [resolvedBase ? null : base, resolvedHead ? null : head]
+      .filter((ref): ref is string => Boolean(ref))
+      .join(", ");
     core.warning(
-      `Head ("${head}") or Base ("${base}") could not be resolved. Attempting to pull latest changes and retry...`,
+      `Head ("${head}") or Base ("${base}") could not be resolved. Attempting shallow fetch of missing refs (${missing}) from origin...`,
     );
-    await gitPull(directory);
+    await gitFetchMissingRefs(base, head, directory, token);
     resolvedHead = resolvedHead || (await resolveCommitish(head, directory));
     resolvedBase = resolvedBase || (await resolveCommitish(base, directory));
   }
@@ -52,6 +56,44 @@ export async function getChangedFilesGit(
 }
 
 /**
+ * Fetches only the missing refs from origin with a shallow depth. If a token
+ * is provided it is supplied via a transient `http.extraheader` git config so
+ * the fetch can authenticate against private repositories.
+ */
+async function gitFetchMissingRefs(
+  base: string,
+  head: string,
+  directory: string,
+  token?: string,
+): Promise<void> {
+  const refs: string[] = [];
+  if (!(await resolveCommitish(base, directory))) refs.push(base);
+  if (!(await resolveCommitish(head, directory))) refs.push(head);
+
+  if (refs.length === 0) {
+    return;
+  }
+
+  core.info(`Fetching missing refs from origin: ${refs.join(", ")}`);
+
+  const args = ["fetch", "origin", "--depth=1", ...refs];
+  const options: { cwd: string; env?: NodeJS.ProcessEnv } = { cwd: directory };
+
+  if (token) {
+    const auth = Buffer.from(`x-access-token:${token}`).toString("base64");
+    args.unshift("-c", `http.extraheader=AUTHORIZATION: basic ${auth}`);
+  }
+
+  try {
+    await execFileAsync("git", args, options);
+    core.info(`Successfully fetched missing refs from origin`);
+  } catch (err) {
+    core.error(`Failed to fetch missing refs from origin: ${err}`);
+    throw new Error(`Failed to fetch missing refs from origin: ${err}`);
+  }
+}
+
+/**
  * Resolves a git ref (branch, tag, or SHA) to a full commit SHA, or null if it cannot be resolved.
  */
 async function resolveCommitish(
@@ -69,16 +111,5 @@ async function resolveCommitish(
     return stdout.trim();
   } catch {
     return null;
-  }
-}
-
-async function gitPull(directory: string): Promise<void> {
-  core.info(`Attempting to pull latest changes in ${directory}...`);
-  try {
-    await execFileAsync("git", ["pull"], { cwd: directory });
-    core.info(`Successfully pulled latest changes in ${directory}`);
-  } catch (err) {
-    core.error(`Failed to pull latest changes in ${directory}: ${err}`);
-    throw new Error(`Failed to pull latest changes: ${err}`);
   }
 }

--- a/actions/advanced-triggers/src/github.ts
+++ b/actions/advanced-triggers/src/github.ts
@@ -42,18 +42,25 @@ export async function getChangedFilesForMergeGroup(
     `Fetching changed files for ${owner}/${repo} merge group ${base}...${head}`,
   );
 
-  const files = await octokit.paginate(
-    octokit.rest.repos.compareCommits,
-    {
-      owner,
-      repo,
-      base,
-      head,
-      per_page: 100,
-    },
-    (response: CompareResponse) =>
-      response.data.files?.map((f: CompareFiles[number]) => f.filename) ?? [],
-  );
+  const res = await octokit.rest.repos.compareCommits({
+    owner,
+    repo,
+    base,
+    head,
+    per_page: 100,
+  });
 
-  return files;
+  if (!res.data.files) {
+    throw new Error(
+      `GitHub compareCommits API did not return a files list for ${base}...${head}`,
+    );
+  }
+
+  if (res.data.files.length >= 300) {
+    throw new Error(
+      `GitHub compareCommits returned ${res.data.files.length} files (hit 300 limit).`,
+    );
+  }
+
+  return res.data.files.map((f) => f.filename);
 }

--- a/actions/advanced-triggers/src/github.ts
+++ b/actions/advanced-triggers/src/github.ts
@@ -62,5 +62,5 @@ export async function getChangedFilesForMergeGroup(
     );
   }
 
-  return res.data.files.map((f: { filename: any; }) => f.filename);
+  return res.data.files.map((f: { filename: any }) => f.filename);
 }

--- a/actions/advanced-triggers/src/github.ts
+++ b/actions/advanced-triggers/src/github.ts
@@ -8,6 +8,11 @@ type ListFilesResponse = GetResponseTypeFromEndpointMethod<
 >;
 export type PRFiles = ListFilesResponse["data"];
 
+type CompareResponse = GetResponseTypeFromEndpointMethod<
+  OctokitType["rest"]["repos"]["compareCommits"]
+>;
+export type CompareFiles = CompareResponse["data"]["files"];
+
 export async function getChangedFilesForPR(
   octokit: OctokitType,
   owner: string,
@@ -24,4 +29,31 @@ export async function getChangedFilesForPR(
   });
 
   return prFiles;
+}
+
+export async function getChangedFilesForMergeGroup(
+  octokit: OctokitType,
+  owner: string,
+  repo: string,
+  base: string,
+  head: string,
+): Promise<string[]> {
+  core.debug(
+    `Fetching changed files for ${owner}/${repo} merge group ${base}...${head}`,
+  );
+
+  const files = await octokit.paginate(
+    octokit.rest.repos.compareCommits,
+    {
+      owner,
+      repo,
+      base,
+      head,
+      per_page: 100,
+    },
+    (response: CompareResponse) =>
+      response.data.files?.map((f: CompareFiles[number]) => f.filename) ?? [],
+  );
+
+  return files;
 }

--- a/actions/advanced-triggers/src/github.ts
+++ b/actions/advanced-triggers/src/github.ts
@@ -62,5 +62,5 @@ export async function getChangedFilesForMergeGroup(
     );
   }
 
-  return res.data.files.map((f) => f.filename);
+  return res.data.files.map((f: { filename: any; }) => f.filename);
 }

--- a/actions/advanced-triggers/src/github.ts
+++ b/actions/advanced-triggers/src/github.ts
@@ -11,7 +11,7 @@ export type PRFiles = ListFilesResponse["data"];
 type CompareResponse = GetResponseTypeFromEndpointMethod<
   OctokitType["rest"]["repos"]["compareCommits"]
 >;
-export type CompareFiles = CompareResponse["data"]["files"];
+type CompareFiles = CompareResponse["data"]["files"];
 
 export async function getChangedFilesForPR(
   octokit: OctokitType,

--- a/actions/advanced-triggers/src/run.ts
+++ b/actions/advanced-triggers/src/run.ts
@@ -5,7 +5,7 @@ import { getInvokeContext, getInputs } from "./run-inputs";
 import { parseFileSets, parseTriggers } from "./schema";
 import { applyTrigger, TriggerResult } from "./filters";
 import { getChangedFilesGit } from "./git";
-import { getChangedFilesForPR } from "./github";
+import { getChangedFilesForMergeGroup, getChangedFilesForPR } from "./github";
 import type { OctokitType } from "./github";
 import type { FileChangeEventData } from "./event";
 
@@ -99,6 +99,7 @@ export async function run(): Promise<void> {
         { owner: context.owner, repo: context.repo },
         context.event,
         inputs.repositoryRoot,
+        context.token,
       );
       core.info(`Changed files count: ${changedFiles.length}`);
       if (core.isDebug()) {
@@ -174,11 +175,12 @@ const PR_FILES_API_LIMIT = 3000;
  *
  * The git fallback requires the repository to be checked out at repositoryRoot.
  */
-async function getChangedFiles(
+export async function getChangedFiles(
   octokit: OctokitType,
   { owner, repo }: { owner: string; repo: string },
   event: FileChangeEventData,
   repositoryRoot: string,
+  token: string,
 ): Promise<string[]> {
   switch (event.eventName) {
     case "pull_request": {
@@ -190,17 +192,25 @@ async function getChangedFiles(
         event.base,
         event.head,
         repositoryRoot,
+        token,
       );
     }
 
     case "push": {
       core.info("Fetching changed files via git diff (push).");
-      return getChangedFilesGit(event.base, event.head, repositoryRoot);
+      return getChangedFilesGit(event.base, event.head, repositoryRoot, token);
     }
 
     case "merge_group": {
-      core.info("Fetching changed files via git diff (merge_group).");
-      return getChangedFilesGit(event.base, event.head, repositoryRoot);
+      return getChangedFilesForMergeGroupWithFallback(
+        octokit,
+        owner,
+        repo,
+        event.base,
+        event.head,
+        repositoryRoot,
+        token,
+      );
     }
 
     default:
@@ -217,6 +227,7 @@ async function getChangedFilesForPRWithFallback(
   base: string,
   head: string,
   repositoryRoot: string,
+  token: string,
 ): Promise<string[]> {
   core.info("Fetching changed files via GitHub API (pull_request).");
 
@@ -229,7 +240,7 @@ async function getChangedFilesForPRWithFallback(
       `GitHub API request for PR files failed: ${err}. ` +
         `Falling back to git diff (base: ${base}, head: ${head}).`,
     );
-    return getChangedFilesGit(base, head, repositoryRoot);
+    return getChangedFilesGit(base, head, repositoryRoot, token);
   }
 
   if (apiFiles.length >= PR_FILES_API_LIMIT) {
@@ -238,7 +249,39 @@ async function getChangedFilesForPRWithFallback(
         `known API limit of ${PR_FILES_API_LIMIT}. The list may be truncated. ` +
         `Falling back to git diff (base: ${base}, head: ${head}).`,
     );
-    return getChangedFilesGit(base, head, repositoryRoot);
+    return getChangedFilesGit(base, head, repositoryRoot, token);
+  }
+
+  core.info(`GitHub API returned ${apiFiles.length} changed file(s).`);
+  return apiFiles;
+}
+
+async function getChangedFilesForMergeGroupWithFallback(
+  octokit: OctokitType,
+  owner: string,
+  repo: string,
+  base: string,
+  head: string,
+  repositoryRoot: string,
+  token: string,
+): Promise<string[]> {
+  core.info("Fetching changed files via GitHub API (merge_group).");
+
+  let apiFiles: string[];
+  try {
+    apiFiles = await getChangedFilesForMergeGroup(
+      octokit,
+      owner,
+      repo,
+      base,
+      head,
+    );
+  } catch (err) {
+    core.warning(
+      `GitHub API request for merge group files failed: ${err}. ` +
+        `Falling back to git diff (base: ${base}, head: ${head}).`,
+    );
+    return getChangedFilesGit(base, head, repositoryRoot, token);
   }
 
   core.info(`GitHub API returned ${apiFiles.length} changed file(s).`);

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -25,6 +25,7 @@ pre-commit:
       glob: "*.sh"
       run: shellcheck {staged_files}
     build-artifacts:
-      description: "Build artifacts"
-      glob: "package.json"
-      run: pnpm build:artifacts
+      description: "Build artifacts for affected projects"
+      glob: "*.{js,ts,json}"
+      run: pnpm build:affected
+      stage_fixed: true

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,7 +9,7 @@ pre-commit:
     prettier:
       description: "Fix prettier formatting"
       glob: "*.{json,md,scss,yaml,yml}"
-      run: pnpm hook:fix {staged_files}
+      run: pnpm prettier:write {staged_files}
       stage_fixed: true
     reusable-workflows:
       description: "Fix reusable workflows sync"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -24,3 +24,7 @@ pre-commit:
       description: "Run shellcheck"
       glob: "*.sh"
       run: shellcheck {staged_files}
+    build-artifacts:
+      description: "Build artifacts"
+      glob: "package.json"
+      run: pnpm build:artifacts

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "lint:affected": "pnpm nx affected --target=lint --verbose",
     "build": "pnpm nx run-many --target=build --verbose",
     "build:affected": "pnpm nx affected --target=build --verbose",
+    "build:artifacts": "pnpm build",
+    "build:artifacts:affected": "pnpm build:affected",
     "test": "pnpm nx run-many --target=test --verbose",
     "test:affected": "pnpm nx affected --target=test --verbose",
     "package": "pnpm nx run-many --target=package --verbose",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -999,6 +999,8 @@ importers:
 
   workflows/reusable-codeowners-review-analysis: {}
 
+  workflows/reusable-dependabump: {}
+
   workflows/reusable-dependency-review: {}
 
   workflows/reusable-docker-build-publish: {}


### PR DESCRIPTION
`merge_group` events had issues with git history, as we didn't fetch the proper git history. The `git pull` fallback [didn't work properly either](https://github.com/smartcontractkit/chainlink/actions/runs/31510996276/job/93844475256#step:3:140). Now we fetch proper history with the API.

Tested on https://github.com/smartcontractkit/chainlink/pull/23386
