### PR TITLE
IP-3478]: Remove Bitnami Chart Refs

### DIFF
--- a/.changeset/ctf-setup-remove-bitnami-repo.md
+++ b/.changeset/ctf-setup-remove-bitnami-repo.md
@@ -1,0 +1,5 @@
+---
+"ctf-setup-run-tests-environment": minor
+---
+
+Remove the Bitnami Helm chart repo from test env setup. The action no longer runs `helm repo add bitnami`; CTF charts are provided through the `chainlink-qa` repository. Tests that still require a Bitnami chart must add their own non-Bitnami source.

--- a/actions/ctf-setup-run-tests-environment/action.yml
+++ b/actions/ctf-setup-run-tests-environment/action.yml
@@ -246,7 +246,6 @@ runs:
     - name: Add required helm charts including chainlink-qa
       shell: bash
       run: |
-        helm repo add bitnami https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
         helm repo add chainlink-qa https://raw.githubusercontent.com/smartcontractkit/qa-charts/gh-pages/
 
     # Display tool versions


### PR DESCRIPTION
## What

Remove the Bitnami Helm chart repo from the shared `ctf-setup-run-tests-environment` action 

## Why

No chart dependency in scope requires the Bitnami repo — the action never installs a
chart itself, and the `chainlink-cluster` chart (from `chainlink-qa`) has no Bitnami
dependency. This aligns with the org-wide Bitnami removal effort and is the ticket's
preferred approach (remove when unused).

## Changes

- **actions/ctf-setup-run-tests-environment/action.yml** — drop the `helm repo add
  bitnami` line; `chainlink-qa` repo add unchanged.
- **.changeset/ctf-setup-remove-bitnami-repo.md** — add `minor` changeset.
