### PR TITLE
fix(docker): input cache map

### DIFF
--- a/.changeset/build-push-docker-cache-map-docs.md
+++ b/.changeset/build-push-docker-cache-map-docs.md
@@ -1,0 +1,8 @@
+---
+"build-push-docker": patch
+---
+
+Fix cache-map input description: recommend the object form with an explicit id
+matching the Dockerfile cache mount id. The simple string form omits id, so
+BuildKit keys the cache on the target path and never matches mounts that
+define an explicit id.

--- a/.changeset/docker-cache-map-input.md
+++ b/.changeset/docker-cache-map-input.md
@@ -1,0 +1,9 @@
+---
+"reusable-docker-build-publish": minor
+---
+
+Add `docker-cache-map` input, passed through to build-push-docker's `cache-map`.
+Set it to restrict buildkit-cache-dance to specific cache mounts (e.g.
+`'{"cache-mount/go-build-cache": {"id": "go-build-cache", "target": "/var/cache-target"}}'`)
+instead of auto-discovering all cache mounts in the Dockerfile. Omit to keep
+auto-discovery.

--- a/.github/workflows/reusable-docker-build-publish.yml
+++ b/.github/workflows/reusable-docker-build-publish.yml
@@ -150,6 +150,17 @@ on:
         required: false
         type: string
         default: "write-on-trunk"
+      docker-cache-map:
+        description: |
+          JSON string mapping cache mount paths/names for buildkit-cache-dance, passed
+          through to build-push-docker's cache-map. Use the object form with an explicit
+          id matching the Dockerfile's cache mount id, e.g.
+          '{"cache-mount/go-build-cache": {"id": "go-build-cache", "target": "/var/cache-target"}}'.
+          Restricts cache-dance to only the listed mounts; if omitted, all cache mounts
+          are discovered from the Dockerfile.
+        required: false
+        type: string
+        default: ""
       docker-build-context:
         description: "Path to Docker build context."
         required: true
@@ -437,7 +448,7 @@ jobs:
       docker-build-cache-from: ${{ steps.should-cache.outputs.docker-build-cache-from }}
       docker-cache-suffix: ${{ steps.should-cache.outputs.docker-cache-suffix }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           fetch-depth: 1
@@ -616,9 +627,9 @@ jobs:
         uses: smartcontractkit/.github/actions/free-disk-space@free-disk-space/v1
 
       - name: Enable S3 Cache for Self-Hosted Runners
-        uses: runs-on/action@4e5f72399b6b17f2e79c511c1b38a315a64d22dc # v2.2.0
+        uses: runs-on/action@efac073ea2507ec18797de3a81704201ade11d9d # v2.3.1
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         id: checkout
         with:
           persist-credentials: false
@@ -780,6 +791,7 @@ jobs:
           docker-save-cache: ${{ needs.init.outputs.docker-save-cache }}
           docker-build-cache-to: ${{ needs.init.outputs.docker-build-cache-to }},scope=${{ steps.compute-cache-scope.outputs.scope }}
           docker-build-cache-from: ${{ needs.init.outputs.docker-build-cache-from }},scope=${{ steps.compute-cache-scope.outputs.scope }}
+          cache-map: ${{ inputs.docker-cache-map }}
           context: ${{ inputs.docker-build-context }}
           docker-build-contexts: ${{ inputs.docker-build-contexts }}
           docker-push: ${{ inputs.docker-push }}

--- a/actions/build-push-docker/action.yml
+++ b/actions/build-push-docker/action.yml
@@ -125,7 +125,11 @@ inputs:
     default: "auto"
   cache-map:
     description: |
-      JSON string mapping cache mount paths/names for buildkit-cache-dance (e.g. '{"go-mod-cache": "/go/pkg/mod"}').
+      JSON string mapping cache mount paths/names for buildkit-cache-dance.
+      Use the object form with an explicit id matching the Dockerfile's cache mount id
+      (e.g. '{"cache-mount/go-build-cache": {"id": "go-build-cache", "target": "/var/cache-target"}}').
+      The simple string form omits id; BuildKit then keys the cache on the target path,
+      which will not match mounts that define an explicit id.
       If omitted, buildkit-cache-dance automatically discovers mounts from the Dockerfile.
       See: https://github.com/reproducible-containers/buildkit-cache-dance
       See: https://docs.docker.com/build/ci/github-actions/cache/#cache-mounts
@@ -223,7 +227,7 @@ runs:
       if:
         ${{ steps.dockerfile-ecr-parse.outputs.needs-ecr-login == 'true' ||
         inputs.docker-push == 'true' }}
-      uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+      uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}
         role-duration-seconds: 900
@@ -232,14 +236,14 @@ runs:
 
     - name: Login to private ECR registries for base images
       if: ${{ steps.dockerfile-ecr-parse.outputs.needs-ecr-login == 'true' }}
-      uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
+      uses: aws-actions/amazon-ecr-login@03f1aad4c6c7ffd436567f42f9384779290529bd # v2.1.7
       with:
         registries: ${{ steps.dockerfile-ecr-parse.outputs.ecr-registries }}
 
     - name: Login to ECR for publishing
       if: ${{ inputs.docker-push == 'true' }}
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
+      uses: aws-actions/amazon-ecr-login@03f1aad4c6c7ffd436567f42f9384779290529bd # v2.1.7
       with:
         registry-type: >-
           ${{
@@ -251,7 +255,7 @@ runs:
 
     - name: Set up Docker Buildx
       id: setup-buildx
-      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
       with:
         # https://github.com/docker/buildx/tags
         version: v0.35.0

--- a/workflows/reusable-docker-build-publish/reusable-docker-build-publish.yml
+++ b/workflows/reusable-docker-build-publish/reusable-docker-build-publish.yml
@@ -146,6 +146,17 @@ on:
         required: false
         type: string
         default: "write-on-trunk"
+      docker-cache-map:
+        description: |
+          JSON string mapping cache mount paths/names for buildkit-cache-dance, passed
+          through to build-push-docker's cache-map. Use the object form with an explicit
+          id matching the Dockerfile's cache mount id, e.g.
+          '{"cache-mount/go-build-cache": {"id": "go-build-cache", "target": "/var/cache-target"}}'.
+          Restricts cache-dance to only the listed mounts; if omitted, all cache mounts
+          are discovered from the Dockerfile.
+        required: false
+        type: string
+        default: ""
       docker-build-context:
         description: "Path to Docker build context."
         required: true
@@ -433,7 +444,7 @@ jobs:
       docker-build-cache-from: ${{ steps.should-cache.outputs.docker-build-cache-from }}
       docker-cache-suffix: ${{ steps.should-cache.outputs.docker-cache-suffix }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           fetch-depth: 1
@@ -612,9 +623,9 @@ jobs:
         uses: smartcontractkit/.github/actions/free-disk-space@free-disk-space/v1
 
       - name: Enable S3 Cache for Self-Hosted Runners
-        uses: runs-on/action@4e5f72399b6b17f2e79c511c1b38a315a64d22dc # v2.2.0
+        uses: runs-on/action@efac073ea2507ec18797de3a81704201ade11d9d # v2.3.1
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         id: checkout
         with:
           persist-credentials: false
@@ -776,6 +787,7 @@ jobs:
           docker-save-cache: ${{ needs.init.outputs.docker-save-cache }}
           docker-build-cache-to: ${{ needs.init.outputs.docker-build-cache-to }},scope=${{ steps.compute-cache-scope.outputs.scope }}
           docker-build-cache-from: ${{ needs.init.outputs.docker-build-cache-from }},scope=${{ steps.compute-cache-scope.outputs.scope }}
+          cache-map: ${{ inputs.docker-cache-map }}
           context: ${{ inputs.docker-build-context }}
           docker-build-contexts: ${{ inputs.docker-build-contexts }}
           docker-push: ${{ inputs.docker-push }}


### PR DESCRIPTION
* Adds `docker-cache-map` inputs for docker builds
* Updates some action versions